### PR TITLE
fix(ui): 修复 ModelPicker 在 models 为空数组时崩溃的问题

### DIFF
--- a/ui/src/components/ui/v0-ai-chat.tsx
+++ b/ui/src/components/ui/v0-ai-chat.tsx
@@ -411,8 +411,8 @@ function ModelPicker({
   const [open, setOpen] = useState(false);
   const current = models.find((model) => model.name === selected) ?? models[0];
   const currentLabel =
-    current.display_name ||
-    current.name ||
+    current?.display_name ||
+    current?.name ||
     (isLoading ? "加载模型..." : loadError ? "模型加载失败" : "未配置模型");
   const isDisabled = isLoading || (!loadError && models.length <= 1);
 


### PR DESCRIPTION
## 问题描述

点击对话按钮进入页面时出现白屏，控制台报错：



## 根本原因

在  组件中（第 412 行）：



当  数组为空时， 为 ，导致  为 。随后在第 414-415 行访问  和  时抛出错误。

## 修复方案

使用可选链操作符 (?.) 安全地访问属性：



## 测试

- [x] 修复后当 models 为空时显示未配置模型而非白屏

Fixes #33