### PR TITLE
feat(ui): 落地设计系统字体与语义色彩变量

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,300..700;1,6..72,300..700&family=Geist:wght@300..700&family=Geist+Mono:wght@300..700&display=swap" rel="stylesheet">
     <title>SwarmMind · Supervisor</title>
   </head>
   <body>

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -27,25 +27,30 @@
     --neutral-800: #3A3832;
     --neutral-900: #1E1E1C;
 
-    /* Semantic Colors (Desaturated) */
-    --status-running: #5A7A96;
-    --status-running-bg: #EEF1F4;
-    --status-running-border: #D5DCE3;
-    --status-approval: #B8956F;
-    --status-approval-bg: #F5F0EA;
-    --status-approval-border: #E5DDD3;
-    --status-blocked: #A67C6B;
-    --status-blocked-bg: #F3EEEB;
-    --status-blocked-border: #E3D9D3;
-    --status-done: #7A9A7E;
-    --status-done-bg: #EDF2EE;
-    --status-done-border: #D5E0D7;
-    --status-chat: #8A8298;
-    --status-chat-bg: #F0EEF3;
-    --status-chat-border: #E0DCE6;
-    --status-draft: #9A9894;
-    --status-draft-bg: #F2F2F0;
-    --status-draft-border: #E5E5E3;
+    /* Semantic Colors (oklch) */
+    --status-running: oklch(0.72 0.17 140);
+    --status-running-bg: oklch(0.96 0.04 140);
+    --status-running-border: oklch(0.88 0.08 140);
+
+    --status-approval: oklch(0.72 0.17 55);
+    --status-approval-bg: oklch(0.97 0.04 55);
+    --status-approval-border: oklch(0.90 0.08 55);
+
+    --status-blocked: oklch(0.65 0.20 25);
+    --status-blocked-bg: oklch(0.97 0.04 25);
+    --status-blocked-border: oklch(0.90 0.08 25);
+
+    --status-done: oklch(0.55 0.15 250);
+    --status-done-bg: oklch(0.96 0.04 250);
+    --status-done-border: oklch(0.88 0.08 250);
+
+    --status-draft: oklch(0.55 0.05 270);
+    --status-draft-bg: oklch(0.97 0.02 270);
+    --status-draft-border: oklch(0.90 0.04 270);
+
+    --status-chat: oklch(0.55 0.12 270);
+    --status-chat-bg: oklch(0.96 0.04 270);
+    --status-chat-border: oklch(0.88 0.08 270);
 
     /* ShadCN Theme Mapping */
     --background: 45 8% 97%;        /* warm-paper #F7F7F5 */
@@ -91,8 +96,9 @@
     --user-bubble-border: 34 14% 85%;
 
     /* Typography */
-    --font-sans: "Geist", "Inter", "SF Pro Text", "SF Pro Display", "PingFang SC", "Hiragino Sans GB", "Noto Sans SC", "Microsoft YaHei", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-    --font-mono: "Geist Mono", "SFMono-Regular", "IBM Plex Mono", ui-monospace, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+    --font-display: "Newsreader", "Noto Serif SC", Georgia, serif;
+    --font-sans: "Geist", "PingFang SC", system-ui, sans-serif;
+    --font-mono: "Geist Mono", "Cascadia Code", monospace;
     --font-heading: "Geist", "SF Pro Display", "PingFang SC", "Hiragino Sans GB", "Noto Sans SC", sans-serif;
     --font-body: "Geist", "PingFang SC", "Noto Sans SC", "Microsoft YaHei", ui-sans-serif, system-ui, sans-serif;
   }

--- a/ui/tailwind.config.js
+++ b/ui/tailwind.config.js
@@ -12,11 +12,18 @@ export default {
     },
     extend: {
       fontFamily: {
+        display: ["var(--font-display)"],
         sans: ["var(--font-sans)"],
         mono: ["var(--font-mono)"],
         heading: ["var(--font-heading)"],
       },
       colors: {
+        "status-running": "var(--status-running)",
+        "status-approval": "var(--status-approval)",
+        "status-blocked": "var(--status-blocked)",
+        "status-done": "var(--status-done)",
+        "status-draft": "var(--status-draft)",
+        "status-chat": "var(--status-chat)",
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",
         ring: "hsl(var(--ring))",


### PR DESCRIPTION
## Summary

- **字体系统** — `index.html` 加载 Newsreader、Geist、Geist Mono（Google Fonts），覆盖展示标题/UI正文/代码三个层次
- **CSS 语义色变量** — `index.css` 将原 hex 色值全量替换为 oklch 色彩空间，补全 `--status-running/approval/blocked/done/draft/chat` 及其 `-bg`/`-border` 共 18 个变量，新增 `--font-display`
- **Tailwind 注册** — `tailwind.config.js` 在 `theme.extend` 中注册 `fontFamily.display` 和 `colors.status-*`，Tailwind 可直接使用 `text-status-running`、`font-display` 等类名

## Files changed

| 文件 | 变更 |
|------|------|
| `ui/index.html` | 添加 Google Fonts preconnect + 字体 link |
| `ui/src/index.css` | oklch 色彩变量 + 字体变量 |
| `ui/tailwind.config.js` | fontFamily + status colors 注册 |

## Test plan

- [ ] 页面标题区字体显示为 Newsreader serif 风格
- [ ] 正文显示为 Geist 无衬线字体
- [ ] 代码块显示为 Geist Mono
- [ ] status badge 颜色（运行中绿、审批黄、阻塞红、完成蓝）与 DESIGN.md 一致
- [ ] `text-status-running` 等 Tailwind 类名可正常编译

🤖 Generated with [Claude Code](https://claude.com/claude-code)