### PR TITLE
refactor: pay down phase-a technical debt hotspots

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,7 +14,20 @@ ANTHROPIC_BASE_URL=https://coding.dashscope.aliyuncs.com/apps/anthropic
 # LLM_BASE_URL=https://api.openai.com/v1
 
 # Database
-SWARMMIND_DB_PATH=swarmmind.db
+# Preferred: full SQLAlchemy URL, so switching SQLite / PostgreSQL / MySQL only needs config changes.
+# Examples:
+# SWARMMIND_DATABASE_URL=sqlite:///swarmmind.db
+# SWARMMIND_DATABASE_URL=postgresql+psycopg://user:pass@localhost:5432/swarmmind
+# SWARMMIND_DATABASE_URL=mysql+pymysql://user:pass@localhost:3306/swarmmind
+SWARMMIND_DATABASE_URL=sqlite:///swarmmind.db
+
+# Schema initialization mode:
+# - migrate: apply Alembic migrations to head (recommended for real deployments)
+# - create_all: direct SQLModel metadata bootstrap (useful for isolated tests/dev only)
+SWARMMIND_DB_INIT_MODE=migrate
+
+# Legacy SQLite-only fallback. Only used when SWARMMIND_DATABASE_URL is unset.
+# SWARMMIND_DB_PATH=swarmmind.db
 
 # Supervisor API
 SWARMMIND_API_HOST=127.0.0.1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,7 @@ SwarmMind 文档按性质分为两类，阅读和使用时请区分：
 - **Phase**: Phase A (ChatSession + Project + DeerFlow Gateway foundation)
 - **Frontend**: shadcn/ui (React 18 + Tailwind CSS + Vite)
 - **Backend**: Python (FastAPI)
-- **Storage**: SQLite (Phase 1)
+- **Storage**: SQLModel ORM + Alembic, dialect-aware via `SWARMMIND_DATABASE_URL` (SQLite default for local/dev)
 - **Python env**: uv
 
 ## Workspace Layout
@@ -133,7 +133,7 @@ SwarmMindProject/              ← 本地工作区根目录（无git管理）
 swarmmind/                         ← Python package root
 ├── __init__.py
 ├── config.py                      ✅ load_dotenv + LLM configuration
-├── db.py                          ✅ SQLite connection + ORM engine + session scope
+├── db.py                          ✅ dialect-aware engine + Alembic-backed schema init + session scope
 ├── db_models.py                   ✅ SQLModel ORM table definitions
 ├── models.py                      ✅ Pydantic models (API/service layer)
 ├── context_broker.py              ✅ dispatch() + keyword routing + strategy table
@@ -186,7 +186,7 @@ tests/
 
 本阶段描述的是**当前代码已实现**的工程状态。如需了解 Phase B/C/D 的设计目标，参见 `docs/architecture.md` §9。
 
-- [x] SQLite schema + health check + seeding
+- [x] ORM schema + health check + seeding
 - [x] SQLModel + Alembic + Repository layer migrated from raw sqlite3
 - [x] Pydantic models for all database tables
 - [x] SharedMemory (KV store + conflict resolution)
@@ -247,6 +247,21 @@ uv run python -m swarmmind.api.supervisor   # run API
 
 Secrets → `.env` (gitignored). Copy `.env.example` to `.env` and fill in keys.
 
+Database config in `.env`:
+
+```bash
+# Preferred: full SQLAlchemy URL, so switching SQLite / PostgreSQL / MySQL only needs config changes
+SWARMMIND_DATABASE_URL=sqlite:///swarmmind.db
+
+# Schema init strategy
+# - migrate: Alembic upgrade to head (default, recommended)
+# - create_all: SQLModel metadata bootstrap (tests / isolated dev only)
+SWARMMIND_DB_INIT_MODE=migrate
+
+# Legacy SQLite-only fallback; only used when SWARMMIND_DATABASE_URL is unset
+# SWARMMIND_DB_PATH=swarmmind.db
+```
+
 ## Running
 
 All dev/build commands via `make`:
@@ -284,6 +299,8 @@ make frontend      # start frontend only (first time)
 
 `.env` (gitignored):
 ```bash
+SWARMMIND_DATABASE_URL=sqlite:///swarmmind.db
+SWARMMIND_DB_INIT_MODE=migrate
 LLM_PROVIDER=openai
 LLM_MODEL=qwen3.5-plus
 ANTHROPIC_API_KEY=sk-sp-...

--- a/README.md
+++ b/README.md
@@ -285,7 +285,8 @@ uv sync
 # Set your LLM API key (copy .env.example → .env and fill in)
 cp .env.example .env
 
-# Start the supervisor API (auto-inits DB on first run)
+# Start the supervisor API
+# DB is configured by SWARMMIND_DATABASE_URL and schema init mode by SWARMMIND_DB_INIT_MODE
 uv run python -m swarmmind.api.supervisor
 # API runs at http://localhost:8000
 
@@ -305,7 +306,7 @@ cd ui && npm install && npm run dev
 | **Human Interface** | Supervisor UI (shadcn/ui) + LLM Status Renderer | Submit goals, approve/reject, view status |
 | **Orchestration** | Context Broker | Routes goals to agents via strategy table |
 | **Agent Layer** | Finance Agent, Code Review Agent | Specialized domain actors with LLM inference |
-| **Memory Layer** | Shared Context (SQLite KV) | Persistent shared memory, conflict-resolved |
+| **Memory Layer** | Shared Context (ORM + Alembic, config-switched dialect) | Persistent shared memory, conflict-resolved |
 | **Supervisor API** | FastAPI REST API | Human oversight and approval endpoints |
 
 ---
@@ -318,7 +319,7 @@ cd ui && npm install && npm run dev
 - [x] Project concept & design
 - [x] Context Broker implementation
 - [x] Finance + Code Review agents
-- [x] Shared context layer (SQLite KV)
+- [x] Shared context layer (ORM-backed, SQLite local/dev default, config-switched for PostgreSQL/MySQL)
 - [x] Supervisor REST API (6 endpoints + pagination)
 - [x] Supervisor UI (React + shadcn/ui, 3 tabs)
 - [x] LLM Status Renderer

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -4,7 +4,7 @@ from sqlalchemy import pool
 from sqlalchemy.engine import engine_from_config
 
 from alembic import context
-from swarmmind.db import _get_db_url
+from swarmmind.db import _get_database_url
 import swarmmind.db_models  # noqa: F401
 from sqlmodel import SQLModel
 
@@ -22,7 +22,7 @@ if config.config_file_name is not None:
 target_metadata = SQLModel.metadata
 
 # Override DB URL from app configuration
-config.set_main_option("sqlalchemy.url", _get_db_url())
+config.set_main_option("sqlalchemy.url", _get_database_url())
 
 
 def run_migrations_offline() -> None:

--- a/alembic/versions/8c4f96c8f27a_add_tool_fields_to_messages.py
+++ b/alembic/versions/8c4f96c8f27a_add_tool_fields_to_messages.py
@@ -1,0 +1,42 @@
+"""add tool_call_id and name to messages
+
+Revision ID: 8c4f96c8f27a
+Revises: 1a3eb1e28e8d
+Create Date: 2026-04-14 20:05:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "8c4f96c8f27a"
+down_revision: Union[str, Sequence[str], None] = "1a3eb1e28e8d"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _get_message_columns() -> set[str]:
+    inspector = sa.inspect(op.get_bind())
+    return {column["name"] for column in inspector.get_columns("messages")}
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    columns = _get_message_columns()
+    if "tool_call_id" not in columns:
+        op.add_column("messages", sa.Column("tool_call_id", sa.String(), nullable=True))
+    if "name" not in columns:
+        op.add_column("messages", sa.Column("name", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    columns = _get_message_columns()
+    if "name" in columns:
+        op.drop_column("messages", "name")
+    if "tool_call_id" in columns:
+        op.drop_column("messages", "tool_call_id")

--- a/swarmmind/agents/general_agent.py
+++ b/swarmmind/agents/general_agent.py
@@ -520,9 +520,9 @@ class DeerFlowRuntimeAdapter(BaseAgent):
         Uses async stream mode internally to properly handle async tools like task_tool.
         This bridges the async _astream_events with the sync generator interface.
 
-        IMPORTANT: Runs async code in the main thread's event loop to prevent httpx
-        client binding issues. Subagents create their own event loops in threads,
-        which can cause conflicts if the main client is bound to a different loop.
+        IMPORTANT: Runs async DeerFlow execution inside a dedicated worker thread
+        with its own event loop. This isolates the runtime from any existing loop
+        in the caller while preserving the synchronous generator API.
         """
         import queue
         import threading

--- a/swarmmind/agents/middlewares/clarification_middleware.py
+++ b/swarmmind/agents/middlewares/clarification_middleware.py
@@ -1,5 +1,6 @@
 """Middleware for intercepting clarification requests and presenting them to the user."""
 
+import logging
 from collections.abc import Callable
 from typing import override
 
@@ -9,6 +10,8 @@ from langchain_core.messages import ToolMessage
 from langgraph.graph import END
 from langgraph.prebuilt.tool_node import ToolCallRequest
 from langgraph.types import Command
+
+logger = logging.getLogger(__name__)
 
 
 class ClarificationMiddlewareState(AgentState):
@@ -100,15 +103,22 @@ class ClarificationMiddleware(AgentMiddleware[ClarificationMiddlewareState]):
         # Extract clarification arguments
         args = request.tool_call.get("args", {})
         question = args.get("question", "")
+        tool_call_id = request.tool_call.get("id", "")
+        clarification_type = args.get("clarification_type", "missing_info")
+        context = args.get("context")
+        options = args.get("options", [])
 
-        print("[ClarificationMiddleware] Intercepted clarification request")
-        print(f"[ClarificationMiddleware] Question: {question}")
+        logger.info(
+            "Intercepted clarification request: tool_call_id=%s clarification_type=%s has_context=%s options_count=%d question=%r",
+            tool_call_id,
+            clarification_type,
+            bool(context),
+            len(options) if isinstance(options, list) else 0,
+            question,
+        )
 
         # Format the clarification message
         formatted_message = self._format_clarification_message(args)
-
-        # Get the tool call ID
-        tool_call_id = request.tool_call.get("id", "")
 
         # Create a ToolMessage with the formatted question
         # This will be added to the message history

--- a/swarmmind/api/supervisor.py
+++ b/swarmmind/api/supervisor.py
@@ -1,11 +1,9 @@
 """Supervisor REST API — FastAPI server for human oversight."""
 
-import json
 import logging
-import threading
-import time
 import uuid
-from datetime import datetime
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime
 
 from fastapi import FastAPI, HTTPException, Query
 from fastapi.middleware.cors import CORSMiddleware
@@ -18,11 +16,10 @@ from swarmmind.context_broker import (
     dispatch,
     record_supervisor_decision,
 )
-from swarmmind.db import health_check, init_db, seed_default_agents
+from swarmmind.db import init_db, seed_default_agents
 from swarmmind.models import (
     Conversation,
     ConversationListResponse,
-    ConversationMode,
     ConversationRuntimeOptions,
     GoalRequest,
     MemoryContext,
@@ -47,121 +44,62 @@ from swarmmind.repositories.conversation import ConversationRepository
 from swarmmind.repositories.memory import MemoryRepository
 from swarmmind.repositories.message import MessageRepository
 from swarmmind.repositories.strategy import StrategyRepository
+from swarmmind.services.conversation_support import (
+    ConversationSupportService,
+    generate_title_with_deerflow,
+)
+from swarmmind.services.lifecycle import run_cleanup_scanner, startup_lifecycle
+from swarmmind.services.runtime_support import RuntimeSupportService
+from swarmmind.services.stream_events import (
+    general_agent_status_labels as service_general_agent_status_labels,
+)
+from swarmmind.services.stream_events import (
+    serialize_stream_event as service_serialize_stream_event,
+)
+from swarmmind.services.stream_events import (
+    task_card_title as service_task_card_title,
+)
+from swarmmind.services.stream_events import (
+    task_status_from_result as service_task_status_from_result,
+)
+from swarmmind.services.stream_events import (
+    tool_activity_label as service_tool_activity_label,
+)
+from swarmmind.services.stream_events import (
+    translate_general_agent_event as service_translate_general_agent_event,
+)
 
 conversation_repo = ConversationRepository()
 message_repo = MessageRepository()
 action_proposal_repo = ActionProposalRepository()
 strategy_repo = StrategyRepository()
 memory_repo = MemoryRepository()
+conversation_support = ConversationSupportService(
+    conversation_repo=conversation_repo,
+    message_repo=message_repo,
+    title_generator=generate_title_with_deerflow,
+)
+runtime_support = RuntimeSupportService(conversation_repo=conversation_repo)
 
 
-# Deferred import for deer-flow title generation (avoid circular imports)
 def _generate_title_with_deerflow(user_msg: str, assistant_msg: str) -> tuple[str, str]:
-    """Generate title in isolated session using deer-flow's capabilities.
-
-    This replicates TitleMiddleware's logic but executes in a separate thread/session,
-    preventing title generation from appearing in the main conversation stream.
-    """
-    try:
-        from deerflow.config.title_config import get_title_config
-        from deerflow.models import create_chat_model
-    except ImportError:
-        # Fallback to simple truncation if deerflow not available
-        title = user_msg[:50] if len(user_msg) <= 50 else user_msg[:47] + "..."
-        return title or "New Conversation", "fallback"
-
-    config = get_title_config()
-
-    # Normalize content (same as TitleMiddleware._normalize_content)
-    def _normalize(content: object) -> str:
-        if isinstance(content, str):
-            return content
-        if isinstance(content, list):
-            parts = [_normalize(item) for item in content]
-            return "\n".join(part for part in parts if part)
-        if isinstance(content, dict):
-            text_value = content.get("text")
-            if isinstance(text_value, str):
-                return text_value
-            nested = content.get("content")
-            if nested is not None:
-                return _normalize(nested)
-        return ""
-
-    user_normalized = _normalize(user_msg)[:500]
-    assistant_normalized = _normalize(assistant_msg)[:500]
-
-    # Build prompt using deer-flow's template
-    prompt = config.prompt_template.format(
-        max_words=config.max_words,
-        user_msg=user_normalized,
-        assistant_msg=assistant_normalized,
-    )
-
-    # Create model with thinking disabled (title doesn't need reasoning)
-    model = create_chat_model(name=config.model_name, thinking_enabled=False)
-
-    try:
-        # Execute in isolated session (no thread state pollution)
-        response = model.invoke(prompt)
-
-        # Parse title (same as TitleMiddleware._parse_title)
-        title_content = _normalize(response.content).strip().strip('"').strip("'")
-        title = title_content[: config.max_chars] if len(title_content) > config.max_chars else title_content
-
-        if title:
-            return title, "llm"
-    except Exception:
-        logger.exception("Title generation failed, using fallback")
-
-    # Fallback to truncated user message
-    fallback_chars = min(config.max_chars, 50)
-    if len(user_normalized) > fallback_chars:
-        return user_normalized[:fallback_chars].rstrip() + "...", "fallback"
-    return user_normalized or "New Conversation", "fallback"
+    return generate_title_with_deerflow(user_msg, assistant_msg)
 
 
 from swarmmind.agents.general_agent import DeerFlowRuntimeAdapter
 from swarmmind.runtime import (
-    RuntimeConfigError,
-    RuntimeExecutionError,
-    RuntimeUnavailableError,
     ensure_default_runtime_instance,
 )
 from swarmmind.runtime.catalog import (
     ANONYMOUS_SUBJECT_ID,
     ANONYMOUS_SUBJECT_TYPE,
     list_models_for_subject,
-    resolve_model_for_subject,
     sync_env_runtime_model,
 )
 
 logger = logging.getLogger(__name__)
 
 NEW_CONVERSATION_TITLE = "New Conversation"
-
-MODE_RUNTIME_MAP: dict[ConversationMode, dict[str, bool]] = {
-    ConversationMode.FLASH: {
-        "thinking_enabled": False,
-        "plan_mode": False,
-        "subagent_enabled": False,
-    },
-    ConversationMode.THINKING: {
-        "thinking_enabled": True,
-        "plan_mode": False,
-        "subagent_enabled": False,
-    },
-    ConversationMode.PRO: {
-        "thinking_enabled": True,
-        "plan_mode": True,
-        "subagent_enabled": False,
-    },
-    ConversationMode.ULTRA: {
-        "thinking_enabled": True,
-        "plan_mode": True,
-        "subagent_enabled": True,
-    },
-}
 
 # ---- Pydantic models ----
 
@@ -181,10 +119,27 @@ class StrategyChangeApproveRequest(BaseModel):
 
 # ---- FastAPI app ----
 
+
+@asynccontextmanager
+async def lifespan(_app: FastAPI):
+    """Bootstrap API dependencies and launch background cleanup workers."""
+    startup_lifecycle(
+        init_db=init_db,
+        seed_default_agents=seed_default_agents,
+        sync_env_runtime_model=sync_env_runtime_model,
+        ensure_default_runtime_instance=ensure_default_runtime_instance,
+        cleanup_scanner=_cleanup_scanner,
+        api_host=API_HOST,
+        api_port=API_PORT,
+    )
+    yield
+
+
 app = FastAPI(
     title="SwarmMind Supervisor API",
     version="0.1.0",
     description="Human oversight interface for AI agent teams.",
+    lifespan=lifespan,
 )
 
 app.add_middleware(
@@ -195,44 +150,19 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-
-@app.on_event("startup")
-def startup() -> None:
-    """Initialize DB on startup."""
-    init_db()
-    seed_default_agents()
-    sync_env_runtime_model()
-    ensure_default_runtime_instance()
-    logger.info("SwarmMind API started on %s:%s", API_HOST, API_PORT)
-    # Start cleanup scanner (proposals + expired memory) in background
-    threading.Thread(target=_cleanup_scanner, daemon=True).start()
-
-
 # ---- Timeout scanner ----
 
 
 def _cleanup_scanner():
     """Background thread: clean up stale proposals and expired memory entries."""
-    while True:
-        time.sleep(30)
-        try:
-            # 1. Auto-reject proposals pending beyond ACTION_TIMEOUT_SECONDS
-            stale = action_proposal_repo.list_stale(ACTION_TIMEOUT_SECONDS)
-            for proposal in stale:
-                logger.info(
-                    "Auto-rejecting stale proposal: id=%s (created=%s)",
-                    proposal.id,
-                    proposal.created_at,
-                )
-                action_proposal_repo.reject_proposal(proposal.id)
-                record_supervisor_decision(proposal.id, SupervisorDecision.TIMEOUT)
-
-            # 2. Delete expired memory entries (TTL elapsed)
-            deleted_memory = memory_repo.delete_expired()
-            if deleted_memory > 0:
-                logger.info("Cleaned up %d expired memory entries.", deleted_memory)
-        except Exception as e:
-            logger.error("Cleanup scanner error: %s", e)
+    run_cleanup_scanner(
+        action_proposal_repo=action_proposal_repo,
+        memory_repo=memory_repo,
+        action_timeout_seconds=ACTION_TIMEOUT_SECONDS,
+        record_supervisor_decision=record_supervisor_decision,
+        supervisor_timeout_decision=SupervisorDecision.TIMEOUT,
+        lifecycle_logger=logger,
+    )
 
 
 # ---- Supervisor endpoints ----
@@ -313,7 +243,7 @@ def post_dispatch(body: GoalRequest):
 @app.get("/health")
 def health() -> dict[str, str]:
     """Health check endpoint."""
-    return {"status": "ok", "timestamp": datetime.utcnow().isoformat()}
+    return {"status": "ok", "timestamp": datetime.now(UTC).isoformat()}
 
 
 @app.get("/ready")
@@ -358,412 +288,74 @@ def list_runtime_models() -> RuntimeModelCatalogResponse:
 
 
 def _db_to_conversation(conv) -> Conversation:
-    return Conversation(
-        id=conv.id,
-        title=conv.title,
-        title_status=conv.title_status,
-        title_source=conv.title_source,
-        title_generated_at=(str(conv.title_generated_at) if conv.title_generated_at is not None else None),
-        runtime_profile_id=(str(conv.runtime_profile_id) if conv.runtime_profile_id is not None else None),
-        runtime_instance_id=(str(conv.runtime_instance_id) if conv.runtime_instance_id is not None else None),
-        thread_id=str(conv.thread_id) if conv.thread_id is not None else None,
-        created_at=str(conv.created_at) if conv.created_at is not None else "",
-        updated_at=str(conv.updated_at) if conv.updated_at is not None else "",
-    )
+    return conversation_support.db_to_conversation(conv)
 
 
 def _db_to_message(msg) -> Message:
-    return Message(
-        id=msg.id,
-        conversation_id=msg.conversation_id,
-        role=msg.role,
-        content=msg.content,
-        created_at=str(msg.created_at) if msg.created_at is not None else "",
-    )
+    return conversation_support.db_to_message(msg)
 
 
 def _serialize_stream_event(event_type: str, **payload) -> str:
-    return json.dumps({"type": event_type, **payload}, ensure_ascii=False) + "\n"
+    return service_serialize_stream_event(event_type, **payload)
 
 
 def _tool_activity_label(tool_name: str, args: dict | None = None) -> str:
-    args = args or {}
-
-    if tool_name == "search":
-        query = args.get("query")
-        if isinstance(query, str) and query.strip():
-            return f"检索资料：{query.strip()[:60]}"
-        return "检索外部资料"
-    if tool_name == "crawl":
-        return "抓取网页内容"
-    if tool_name == "fetch":
-        return "获取远端内容"
-    if tool_name == "view_image":
-        return "查看图像资料"
-    if tool_name == "read_file":
-        return "读取文件"
-    if tool_name == "write_file":
-        return "写入文件"
-    if tool_name == "edit_file":
-        return "编辑文件"
-    if tool_name == "bash":
-        return "执行命令"
-    if tool_name == "present_files":
-        return "整理输出产物"
-    if tool_name == "ask_clarification":
-        return "请求补充信息"
-    if tool_name == "tool_search":
-        return "搜索可用工具"
-
-    return f"执行工具：{tool_name}"
+    return service_tool_activity_label(tool_name, args)
 
 
 def _task_card_title(tool_args: dict | None) -> str:
-    if not isinstance(tool_args, dict):
-        return "新的协作分工"
-
-    description = tool_args.get("description")
-    if isinstance(description, str) and description.strip():
-        return description.strip()
-
-    prompt = tool_args.get("prompt")
-    if isinstance(prompt, str) and prompt.strip():
-        return prompt.strip().splitlines()[0][:80]
-
-    return "新的协作分工"
+    return service_task_card_title(tool_args)
 
 
 def _task_status_from_result(content: str) -> tuple[str, str | None]:
-    normalized = content.strip()
-    if normalized.startswith("Task Succeeded. Result:"):
-        return "completed", normalized.split("Task Succeeded. Result:", 1)[1].strip() or None
-    if normalized.startswith("Task failed."):
-        return "failed", normalized.split("Task failed.", 1)[1].strip() or None
-    if normalized.startswith("Task timed out"):
-        return "failed", normalized
-    return "running", normalized or None
+    return service_task_status_from_result(content)
 
 
 def _persist_user_message(conversation_id: str, content: str) -> Message:
-    conversation_repo.get_by_id(conversation_id)
-    msg = message_repo.create(conversation_id, "user", content)
-    conversation_repo.touch(conversation_id)
-    return _db_to_message(msg)
+    return conversation_support.persist_user_message(conversation_id, content)
 
 
 def _persist_assistant_message(conversation_id: str, content: str) -> Message:
-    msg = message_repo.create(conversation_id, "assistant", content)
-    conversation_repo.touch(conversation_id)
-    return _db_to_message(msg)
+    return conversation_support.persist_assistant_message(conversation_id, content)
 
 
 def _normalize_model_name(model_name: str | None) -> str | None:
-    if model_name is None:
-        return None
-
-    value = model_name.strip()
-    return value or None
+    return runtime_support.normalize_model_name(model_name)
 
 
 def _resolve_model_name_for_request(model_name: str | None) -> str:
-    normalized_model_name = _normalize_model_name(model_name)
-    try:
-        selected_model = resolve_model_for_subject(
-            requested_model_name=normalized_model_name,
-            subject_type=ANONYMOUS_SUBJECT_TYPE,
-            subject_id=ANONYMOUS_SUBJECT_ID,
-        )
-    except RuntimeConfigError as exc:
-        raise HTTPException(
-            status_code=400 if normalized_model_name else 503,
-            detail=str(exc),
-        ) from exc
-    return selected_model.name
+    return runtime_support.resolve_model_name_for_request(model_name)
 
 
 def _conversation_thread_id(conversation_id: str) -> str:
-    return conversation_id
+    return runtime_support.conversation_thread_id(conversation_id)
 
 
 def _bind_conversation_runtime(conversation_id: str) -> tuple[object, str]:
-    runtime_instance = ensure_default_runtime_instance()
-    thread_id = _conversation_thread_id(conversation_id)
-
-    conversation_repo.update_runtime(
-        conversation_id,
-        runtime_instance.runtime_profile_id,
-        runtime_instance.runtime_instance_id,
-        thread_id,
-    )
-
-    return runtime_instance, thread_id
+    return runtime_support.bind_conversation_runtime(conversation_id)
 
 
 def _format_runtime_error(exc: Exception) -> str:
-    if isinstance(exc, (RuntimeConfigError, RuntimeUnavailableError, RuntimeExecutionError)):
-        return f"DeerFlow Runtime error: {exc}"
-    return f"Unexpected DeerFlow execution error: {exc}"
+    return runtime_support.format_runtime_error(exc)
 
 
 def _resolve_runtime_options(body: SendMessageRequest) -> ConversationRuntimeOptions:
-    effective_mode = body.mode
-    logger.info(
-        "[DEBUG] _resolve_runtime_options: body.mode=%s, effective_mode=%s",
-        body.mode,
-        effective_mode,
-    )
-    if effective_mode is None:
-        effective_mode = ConversationMode.THINKING if body.reasoning else ConversationMode.FLASH
-
-    runtime_flags = MODE_RUNTIME_MAP[effective_mode]
-    logger.info("[DEBUG] _resolve_runtime_options: runtime_flags=%s", runtime_flags)
-    options = ConversationRuntimeOptions(
-        mode=effective_mode,
-        model_name=_resolve_model_name_for_request(body.model_name),
-        thinking_enabled=runtime_flags["thinking_enabled"],
-        plan_mode=runtime_flags["plan_mode"],
-        subagent_enabled=runtime_flags["subagent_enabled"],
-    )
-    logger.info(
-        "[DEBUG] _resolve_runtime_options: returning options with subagent_enabled=%s",
-        options.subagent_enabled,
-    )
-    return options
+    return runtime_support.resolve_runtime_options(body)
 
 
 def _general_agent_status_labels(runtime_options: ConversationRuntimeOptions) -> tuple[str, str]:
-    if runtime_options.mode == ConversationMode.ULTRA:
-        return (
-            "Agent Team 正在判断这轮探索需要怎样的协作方式",
-            "Agent Team 正在协作处理你的问题",
-        )
-    if runtime_options.mode == ConversationMode.PRO:
-        return (
-            "正在规划这轮任务的执行方式",
-            "正在按规划生成结果",
-        )
-    if runtime_options.mode == ConversationMode.THINKING:
-        return (
-            "正在分析你的问题",
-            "正在整理深入回复",
-        )
-    return (
-        "正在准备快速回复",
-        "正在快速生成结果",
-    )
+    return service_general_agent_status_labels(runtime_options)
 
 
 def _translate_general_agent_event(
     event: dict,
     runtime_options: ConversationRuntimeOptions,
 ) -> list[str]:
-    event_type = event.get("type")
-
-    if event_type == "assistant_reasoning":
-        if not runtime_options.thinking_enabled:
-            return []
-        content = event.get("content")
-        if isinstance(content, str) and content.strip():
-            return [
-                _serialize_stream_event(
-                    "thinking",
-                    message_id=event.get("message_id"),
-                    content=content,
-                ),
-            ]
-        return []
-
-    if event_type == "assistant_message":
-        content = event.get("content")
-        if isinstance(content, str) and content:
-            return [
-                _serialize_stream_event(
-                    "assistant_message",
-                    message_id=event.get("message_id"),
-                    content=content,
-                ),
-            ]
-        return []
-
-    if event_type == "assistant_tool_calls":
-        if not runtime_options.subagent_enabled:
-            return []
-        tool_calls = event.get("tool_calls")
-        if not isinstance(tool_calls, list):
-            return []
-
-        lines: list[str] = []
-        for tool_call in tool_calls:
-            if not isinstance(tool_call, dict):
-                continue
-
-            tool_name = tool_call.get("name")
-            tool_args = tool_call.get("args", {})
-            tool_call_id = tool_call.get("id")
-
-            if tool_name == "task":
-                lines.append(
-                    _serialize_stream_event(
-                        "team_task",
-                        task={
-                            "id": tool_call_id,
-                            "title": _task_card_title(tool_args if isinstance(tool_args, dict) else {}),
-                            "status": "running",
-                            "detail": "Agent Team 正在协同处理这个子任务。",
-                        },
-                    ),
-                )
-                continue
-
-            lines.append(
-                _serialize_stream_event(
-                    "team_activity",
-                    activity={
-                        "id": tool_call_id or str(uuid.uuid4()),
-                        "tool_name": tool_name,
-                        "label": _tool_activity_label(
-                            str(tool_name),
-                            tool_args if isinstance(tool_args, dict) else {},
-                        ),
-                        "status": "running",
-                    },
-                ),
-            )
-        return lines
-
-    if event_type == "tool_result":
-        tool_name = str(event.get("tool_name") or "unknown")
-        tool_call_id = event.get("tool_call_id")
-        content = str(event.get("content") or "").strip()
-
-        # Handle ask_clarification tool (available in all modes, not just subagent mode)
-        if tool_name == "ask_clarification":
-            return [
-                _serialize_stream_event(
-                    "clarification_request",
-                    clarification={
-                        "id": tool_call_id,
-                        "content": content,
-                    },
-                ),
-            ]
-
-        if not runtime_options.subagent_enabled:
-            return []
-
-        if tool_name == "task":
-            status, detail = _task_status_from_result(content)
-            return [
-                _serialize_stream_event(
-                    "team_task",
-                    task={
-                        "id": tool_call_id,
-                        "status": status,
-                        "detail": detail,
-                    },
-                ),
-            ]
-
-        return [
-            _serialize_stream_event(
-                "team_activity",
-                activity={
-                    "id": tool_call_id or str(uuid.uuid4()),
-                    "tool_name": tool_name,
-                    "label": _tool_activity_label(tool_name),
-                    "status": "completed",
-                    "detail": content[:240] if content else None,
-                },
-            ),
-        ]
-
-    # Handle custom events from task_tool (task_started, task_running, task_completed, task_failed)
-    if event_type == "custom_event":
-        if not runtime_options.subagent_enabled:
-            return []
-
-        custom_event_type = event.get("event_type")
-        task_id = event.get("task_id")
-
-        if custom_event_type == "task_started":
-            return [
-                _serialize_stream_event(
-                    "task_started",
-                    task={
-                        "id": task_id,
-                        "description": event.get("description"),
-                        "status": "in_progress",
-                    },
-                ),
-            ]
-
-        if custom_event_type == "task_running":
-            return [
-                _serialize_stream_event(
-                    "task_running",
-                    task={
-                        "id": task_id,
-                        "message": event.get("message"),
-                    },
-                ),
-            ]
-
-        if custom_event_type == "task_completed":
-            return [
-                _serialize_stream_event(
-                    "task_completed",
-                    task={
-                        "id": task_id,
-                        "result": event.get("result"),
-                        "status": "completed",
-                    },
-                ),
-            ]
-
-        if custom_event_type == "task_failed":
-            return [
-                _serialize_stream_event(
-                    "task_failed",
-                    task={
-                        "id": task_id,
-                        "error": event.get("error"),
-                        "status": "failed",
-                    },
-                ),
-            ]
-
-    return []
+    return service_translate_general_agent_event(event, runtime_options)
 
 
 def _maybe_generate_conversation_title(conversation_id: str) -> None:
-    """Generate a conversation title after the first complete exchange.
-
-    Uses deer-flow's title generation capabilities in an isolated session,
-    preventing title LLM calls from polluting the main conversation stream.
-    """
-    conversation = conversation_repo.get_by_id(conversation_id)
-    if conversation.title_status != "pending":
-        return
-
-    messages = message_repo.list_by_conversation(conversation_id)
-    user_messages = [msg.content for msg in messages if msg.role == "user"]
-    assistant_messages = [msg.content for msg in messages if msg.role == "assistant"]
-
-    if len(user_messages) != 1 or len(assistant_messages) < 1:
-        return
-
-    # Generate title in isolated session using deer-flow capabilities
-    title, source = _generate_title_with_deerflow(
-        user_messages[0],
-        assistant_messages[0],
-    )
-
-    conversation_repo.update_title(
-        conversation_id,
-        title or NEW_CONVERSATION_TITLE,
-        "generated" if source == "llm" else "fallback",
-        source,
-    )
+    conversation_support.maybe_generate_conversation_title(conversation_id, _generate_title_with_deerflow)
 
 
 @app.get("/conversations")
@@ -1062,7 +654,7 @@ class ClarificationResponseRequest(BaseModel):
 
 
 @app.post("/conversations/{conversation_id}/clarification")
-def respond_to_clarification(conversation_id: str, body: ClarificationResponseRequest) -> dict:
+def respond_to_clarification(conversation_id: str, body: ClarificationResponseRequest) -> Message:
     """Respond to a clarification request from the AI.
 
     This endpoint is called when the user responds to an ask_clarification tool call.
@@ -1073,40 +665,21 @@ def respond_to_clarification(conversation_id: str, body: ClarificationResponseRe
     conversation_repo.get_by_id(conversation_id)
 
     # Persist the clarification response as a user message with tool_call_id
-    result = message_repo.create_clarification_response(
+    result = message_repo.create(
         conversation_id=conversation_id,
         role="tool",
         content=body.response,
         tool_call_id=body.tool_call_id,
         name="ask_clarification_response",
     )
-    return {
-        "id": result["id"],
-        "role": result["role"],
-        "content": result["content"],
-        "tool_call_id": result["tool_call_id"],
-        "created_at": result["created_at"],
-    }
+    conversation_repo.touch(conversation_id)
+    return _db_to_message(result)
 
 
 # ---- Run ----
 
 if __name__ == "__main__":
     import uvicorn
-
-    # Initialize database on startup
-    logger.info("Initializing SwarmMind database...")
-    init_db()
-    health = health_check()
-    if health["status"] == "healed":
-        logger.info("Database healed and initialized with new schema.")
-    else:
-        logger.info("Database health check passed.")
-
-    # Seed default agents if needed
-    logger.info("Seeding default agents if needed...")
-    seed_default_agents()
-    logger.info("Default agents ready.")
 
     logging.basicConfig(level=logging.INFO)
     uvicorn.run(app, host=API_HOST, port=API_PORT)

--- a/swarmmind/config.py
+++ b/swarmmind/config.py
@@ -13,7 +13,11 @@ from dotenv import load_dotenv
 load_dotenv(override=True)
 
 # Database
+# Preferred: a full SQLAlchemy URL so deployments can switch dialects by config only.
+# Legacy fallback: SWARMMIND_DB_PATH keeps local SQLite workflows working.
+DATABASE_URL = os.environ.get("SWARMMIND_DATABASE_URL")
 DB_PATH = os.environ.get("SWARMMIND_DB_PATH", "swarmmind.db")
+DB_INIT_MODE = os.environ.get("SWARMMIND_DB_INIT_MODE", "migrate")
 
 # LLM Provider
 LLM_PROVIDER = os.environ.get("LLM_PROVIDER", "openai")  # "openai" or "anthropic"

--- a/swarmmind/db.py
+++ b/swarmmind/db.py
@@ -1,23 +1,51 @@
-"""SQLite database setup, schema, and health check."""
+"""Database setup, schema, and health check."""
 
 import logging
 import os
+import threading
+from collections.abc import Generator
+from contextlib import contextmanager
+from pathlib import Path
+from urllib.parse import urlparse
 
-from swarmmind.config import DB_PATH
+from alembic.config import Config
+from sqlalchemy import create_engine, event
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import Session, SQLModel
+
+from alembic import command
+from swarmmind.config import DATABASE_URL, DB_INIT_MODE, DB_PATH
 from swarmmind.prompting import SWARMMIND_PRODUCT_IDENTITY_PROMPT
 
 logger = logging.getLogger(__name__)
 
 
 def _get_db_path() -> str:
-    """Read DB path dynamically so tests and runtime env overrides take effect."""
+    """Read legacy DB path dynamically so tests and runtime env overrides take effect."""
     return os.environ.get("SWARMMIND_DB_PATH", DB_PATH)
 
 
+def _get_database_url() -> str:
+    """Return the configured SQLAlchemy URL, falling back to local SQLite path."""
+    configured_url = os.environ.get("SWARMMIND_DATABASE_URL", DATABASE_URL)
+    if configured_url:
+        return configured_url
+
+    path = _get_db_path()
+    if not os.path.isabs(path):
+        path = os.path.abspath(path)
+    return f"sqlite:///{path}"
+
+
+def _is_sqlite_url(database_url: str) -> bool:
+    return urlparse(database_url).scheme == "sqlite"
+
+
 def init_db() -> None:
-    """Initialize database: create all tables and indexes."""
-    init_orm_db()
-    logger.info("Database initialized at %s", _get_db_path())
+    """Initialize database schema using the configured initialization mode."""
+    apply_schema()
+    logger.info("Database initialized at %s", _get_database_url())
 
 
 def health_check() -> dict:
@@ -49,7 +77,7 @@ def health_check() -> dict:
     missing = [t for t in required_tables if t not in existing]
     if missing:
         logger.warning("Missing tables detected: %s. Auto-creating schema.", missing)
-        init_orm_db()
+        apply_schema()
         return {"status": "healed", "missing_tables": missing}
 
     return {"status": "ok", "missing_tables": []}
@@ -96,26 +124,15 @@ def seed_default_agents() -> None:
     logger.info("Default agents seeded.")
 
 
-# ---------------------------------------------------------------------------
-# ORM layer (SQLModel / SQLAlchemy 2.0)
-# ---------------------------------------------------------------------------
-
-from collections.abc import Generator
-from contextlib import contextmanager
-
-from sqlalchemy import create_engine, event
-from sqlalchemy.engine import Engine
-from sqlalchemy.orm import sessionmaker
-from sqlmodel import Session, SQLModel
+_engine_lock = threading.Lock()
+_engine_cache: dict[str, Engine] = {}
 
 
-def _get_db_url() -> str:
-    """Return SQLAlchemy-compatible SQLite URL."""
-    path = _get_db_path()
-    # Use absolute path to avoid cwd issues in alembic
-    if not os.path.isabs(path):
-        path = os.path.abspath(path)
-    return f"sqlite:///{path}"
+def _dispose_engine(engine: object) -> None:
+    """Dispose an engine-like object when supported."""
+    dispose = getattr(engine, "dispose", None)
+    if callable(dispose):
+        dispose()
 
 
 def _set_sqlite_pragma(dbapi_conn, _connection_record):
@@ -127,19 +144,44 @@ def _set_sqlite_pragma(dbapi_conn, _connection_record):
 
 
 def get_engine() -> Engine:
-    """Return a SQLAlchemy engine bound to the current DB path.
+    """Return a SQLAlchemy engine bound to the current database URL.
 
-    NOTE: A new engine is created on every call so that tests which
-    override SWARMMIND_DB_PATH get the correct database without stale
-    singleton state.
+    Engines are cached per database URL. If the configured URL changes,
+    stale cached engines are disposed before a new engine is created.
     """
-    engine = create_engine(
-        _get_db_url(),
-        connect_args={"check_same_thread": False},
-        pool_pre_ping=True,
-    )
-    event.listen(engine, "connect", _set_sqlite_pragma)
-    return engine
+    database_url = _get_database_url()
+    with _engine_lock:
+        cached_engine = _engine_cache.get(database_url)
+        if cached_engine is not None:
+            return cached_engine
+
+        for cached_url, cached in list(_engine_cache.items()):
+            if cached_url != database_url:
+                _dispose_engine(cached)
+                del _engine_cache[cached_url]
+
+        engine_kwargs: dict = {
+            "pool_pre_ping": True,
+        }
+        if _is_sqlite_url(database_url):
+            engine_kwargs["connect_args"] = {"check_same_thread": False}
+
+        engine = create_engine(
+            database_url,
+            **engine_kwargs,
+        )
+        if _is_sqlite_url(database_url):
+            event.listen(engine, "connect", _set_sqlite_pragma)
+        _engine_cache[database_url] = engine
+        return engine
+
+
+def dispose_engines() -> None:
+    """Dispose all cached engines. Useful for tests and shutdown hygiene."""
+    with _engine_lock:
+        for engine in _engine_cache.values():
+            _dispose_engine(engine)
+        _engine_cache.clear()
 
 
 def get_session() -> Session:
@@ -159,6 +201,41 @@ def session_scope() -> Generator[Session, None, None]:
         raise
     finally:
         session.close()
+
+
+def _project_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def _build_alembic_config() -> Config:
+    project_root = _project_root()
+    alembic_ini_path = project_root / "alembic.ini"
+    config = Config(str(alembic_ini_path))
+    config.set_main_option("script_location", str(project_root / "alembic"))
+    config.set_main_option("sqlalchemy.url", _get_database_url())
+    return config
+
+
+def run_migrations_to_head() -> None:
+    """Apply Alembic migrations to the configured database."""
+    command.upgrade(_build_alembic_config(), "head")
+
+
+def apply_schema() -> None:
+    """Apply schema using the configured initialization mode.
+
+    Modes:
+    - ``migrate``: migration-first, suitable for real deployments.
+    - ``create_all``: test/dev fallback that creates metadata directly.
+    """
+    mode = os.environ.get("SWARMMIND_DB_INIT_MODE", DB_INIT_MODE).strip().lower()
+    if mode == "create_all":
+        init_orm_db()
+        return
+    if mode == "migrate":
+        run_migrations_to_head()
+        return
+    raise ValueError(f"Unsupported SWARMMIND_DB_INIT_MODE: {mode}")
 
 
 def init_orm_db() -> None:
@@ -181,4 +258,4 @@ def init_orm_db() -> None:
     )
 
     SQLModel.metadata.create_all(bind=get_engine())
-    logger.info("ORM tables ensured at %s", _get_db_path())
+    logger.info("ORM tables ensured at %s", _get_database_url())

--- a/swarmmind/db_models.py
+++ b/swarmmind/db_models.py
@@ -8,6 +8,8 @@ from typing import Any
 from sqlalchemy import JSON, Column, Index, UniqueConstraint
 from sqlmodel import Field, SQLModel
 
+from swarmmind.time_utils import utc_now
+
 
 class AgentDB(SQLModel, table=True):
     """Core agent registry."""
@@ -17,7 +19,7 @@ class AgentDB(SQLModel, table=True):
     agent_id: str = Field(primary_key=True)
     domain: str
     system_prompt: str
-    created_at: datetime | None = Field(default_factory=datetime.utcnow)
+    created_at: datetime | None = Field(default_factory=utc_now)
 
 
 class WorkingMemoryDB(SQLModel, table=True):
@@ -29,7 +31,7 @@ class WorkingMemoryDB(SQLModel, table=True):
     value: str
     domain_tags: str | None = None
     last_writer_agent_id: str | None = None
-    updated_at: datetime | None = Field(default_factory=datetime.utcnow)
+    updated_at: datetime | None = Field(default_factory=utc_now)
 
     __table_args__ = (Index("idx_working_memory_tags", "domain_tags"),)
 
@@ -51,7 +53,7 @@ class EventLogDB(SQLModel, table=True):
     __tablename__ = "event_log"
 
     id: int | None = Field(default=None, primary_key=True)
-    timestamp: datetime | None = Field(default_factory=datetime.utcnow)
+    timestamp: datetime | None = Field(default_factory=utc_now)
     goal: str
     situation_tag: str | None = None
     dispatched_agent_id: str | None = None
@@ -76,7 +78,7 @@ class ActionProposalDB(SQLModel, table=True):
     postconditions: dict[str, Any] | None = Field(default=None, sa_column=Column(JSON))
     confidence: float = Field(default=0.5)
     status: str = Field(default="pending")  # 'pending' | 'approved' | 'rejected' | 'executed'
-    created_at: datetime | None = Field(default_factory=datetime.utcnow)
+    created_at: datetime | None = Field(default_factory=utc_now)
 
     __table_args__ = (Index("idx_action_proposals_status", "status"),)
 
@@ -91,7 +93,7 @@ class StrategyChangeProposalDB(SQLModel, table=True):
     proposed_agent_id: str = Field(foreign_key="agents.agent_id")
     reason: str | None = None
     status: str = Field(default="pending")  # 'pending' | 'approved' | 'rejected'
-    proposed_at: datetime | None = Field(default_factory=datetime.utcnow)
+    proposed_at: datetime | None = Field(default_factory=utc_now)
 
 
 class ConversationDB(SQLModel, table=True):
@@ -107,8 +109,8 @@ class ConversationDB(SQLModel, table=True):
     runtime_profile_id: str | None = None
     runtime_instance_id: str | None = None
     thread_id: str | None = None
-    created_at: datetime | None = Field(default_factory=datetime.utcnow)
-    updated_at: datetime | None = Field(default_factory=datetime.utcnow)
+    created_at: datetime | None = Field(default_factory=utc_now)
+    updated_at: datetime | None = Field(default_factory=utc_now)
 
     __table_args__ = (Index("idx_conversations_updated_at", "updated_at"),)
 
@@ -122,7 +124,9 @@ class MessageDB(SQLModel, table=True):
     conversation_id: str = Field(foreign_key="conversations.id")
     role: str
     content: str
-    created_at: datetime | None = Field(default_factory=datetime.utcnow)
+    tool_call_id: str | None = None
+    name: str | None = None
+    created_at: datetime | None = Field(default_factory=utc_now)
 
     __table_args__ = (Index("idx_messages_conversation", "conversation_id"),)
 
@@ -138,8 +142,8 @@ class MemoryEntryDB(SQLModel, table=True):
     key: str
     value: str
     tags: list[str] | None = Field(default=None, sa_column=Column(JSON))
-    created_at: datetime | None = Field(default_factory=datetime.utcnow)
-    updated_at: datetime | None = Field(default_factory=datetime.utcnow)
+    created_at: datetime | None = Field(default_factory=utc_now)
+    updated_at: datetime | None = Field(default_factory=utc_now)
     ttl: int | None = None
     version: int = Field(default=1)
     last_writer_agent_id: str | None = None
@@ -162,7 +166,7 @@ class SessionPromotionDB(SQLModel, table=True):
     target_layer: str  # 'L3_project' or 'L2_team'
     target_scope_id: str
     key_filter: list[str] | None = Field(default=None, sa_column=Column(JSON))
-    promoted_at: datetime | None = Field(default_factory=datetime.utcnow)
+    promoted_at: datetime | None = Field(default_factory=utc_now)
     snapshot_count: int = Field(default=0)
 
 
@@ -177,7 +181,7 @@ class CompactionHintDB(SQLModel, table=True):
     policy: str  # 'dedup', 'compress', 'archive'
     trigger_count: int = Field(default=0)
     fired_at: datetime | None = None
-    created_at: datetime | None = Field(default_factory=datetime.utcnow)
+    created_at: datetime | None = Field(default_factory=utc_now)
 
     __table_args__ = (Index("idx_compaction_scope", "scope_layer", "scope_id"),)
 
@@ -198,8 +202,8 @@ class RuntimeModelDB(SQLModel, table=True):
     supports_vision: int = Field(default=0)
     enabled: int = Field(default=1)
     source: str = Field(default="manual")
-    created_at: datetime | None = Field(default_factory=datetime.utcnow)
-    updated_at: datetime | None = Field(default_factory=datetime.utcnow)
+    created_at: datetime | None = Field(default_factory=utc_now)
+    updated_at: datetime | None = Field(default_factory=utc_now)
 
     __table_args__ = (
         Index("idx_runtime_models_enabled", "enabled"),
@@ -216,6 +220,6 @@ class RuntimeModelAssignmentDB(SQLModel, table=True):
     subject_id: str = Field(primary_key=True)
     model_name: str = Field(foreign_key="runtime_models.name", primary_key=True)
     is_default: int = Field(default=0)
-    created_at: datetime | None = Field(default_factory=datetime.utcnow)
+    created_at: datetime | None = Field(default_factory=utc_now)
 
     __table_args__ = (Index("idx_runtime_model_assignments_subject", "subject_type", "subject_id"),)

--- a/swarmmind/layered_memory.py
+++ b/swarmmind/layered_memory.py
@@ -37,7 +37,7 @@ class MemoryWriteForbidden(LayeredMemoryError):
 
 
 class LayeredMemory:
-    """4-layer scoped KV store backed by SQLite.
+    """4-layer scoped KV store backed by the configured ORM database.
 
     Layers (L1=L4, L4=USER_SOUL):
       L1 TMP    — session-scoped, TTL support (default 24h)

--- a/swarmmind/models.py
+++ b/swarmmind/models.py
@@ -244,6 +244,8 @@ class Message(BaseModel):
     conversation_id: str
     role: str  # 'user' | 'assistant'
     content: str
+    tool_call_id: str | None = None
+    name: str | None = None
     created_at: str
 
 

--- a/swarmmind/repositories/action_proposal.py
+++ b/swarmmind/repositories/action_proposal.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import uuid
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from fastapi import HTTPException
 from sqlalchemy import func
@@ -13,6 +13,7 @@ from sqlmodel import select
 from swarmmind.db import session_scope
 from swarmmind.db_models import ActionProposalDB
 from swarmmind.models import ActionProposal, ProposalStatus
+from swarmmind.time_utils import utc_now
 
 
 def _db_to_action_proposal(db_proposal: ActionProposalDB) -> ActionProposal:
@@ -25,7 +26,7 @@ def _db_to_action_proposal(db_proposal: ActionProposalDB) -> ActionProposal:
         postconditions=json.loads(db_proposal.postconditions) if db_proposal.postconditions else None,
         confidence=db_proposal.confidence,
         status=ProposalStatus(db_proposal.status),
-        created_at=db_proposal.created_at or datetime.utcnow(),
+        created_at=db_proposal.created_at or utc_now(),
     )
 
 
@@ -59,7 +60,7 @@ class ActionProposalRepository:
                 postconditions=json.dumps(postconditions) if postconditions else None,
                 confidence=confidence,
                 status=ProposalStatus.PENDING.value,
-                created_at=datetime.utcnow(),
+                created_at=utc_now(),
             )
             session.add(db_proposal)
             session.commit()
@@ -137,7 +138,7 @@ class ActionProposalRepository:
     def list_stale(self, timeout_seconds: int) -> list[ActionProposalDB]:
         """Return proposals pending older than timeout_seconds."""
         with session_scope() as session:
-            cutoff = datetime.utcnow() - timedelta(seconds=timeout_seconds)
+            cutoff = utc_now() - timedelta(seconds=timeout_seconds)
             results = session.exec(
                 select(ActionProposalDB).where(
                     ActionProposalDB.status == ProposalStatus.PENDING.value,

--- a/swarmmind/repositories/conversation.py
+++ b/swarmmind/repositories/conversation.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import uuid
-from datetime import datetime
 
 from fastapi import HTTPException
 from sqlmodel import select
 
 from swarmmind.db import session_scope
 from swarmmind.db_models import ConversationDB
+from swarmmind.time_utils import utc_now
 
 
 class ConversationRepository:
@@ -77,14 +77,14 @@ class ConversationRepository:
                 conv.title = title
                 conv.title_status = title_status
                 conv.title_source = title_source
-                conv.title_generated_at = datetime.utcnow()
+                conv.title_generated_at = utc_now()
 
     def touch(self, conversation_id: str) -> None:
         """Bump updated_at for a conversation."""
         with session_scope() as session:
             conv = session.get(ConversationDB, conversation_id)
             if conv is not None:
-                conv.updated_at = datetime.utcnow()
+                conv.updated_at = utc_now()
 
     def delete(self, conversation_id: str) -> None:
         """Delete a conversation and its messages (cascade via FK)."""

--- a/swarmmind/repositories/event_log.py
+++ b/swarmmind/repositories/event_log.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
-from datetime import datetime
-
 from swarmmind.db import session_scope
 from swarmmind.db_models import EventLogDB
 from swarmmind.models import SupervisorDecision
+from swarmmind.time_utils import utc_now
 
 
 class EventLogRepository:
@@ -27,7 +26,7 @@ class EventLogRepository:
                 dispatched_agent_id=dispatched_agent_id,
                 action_proposal_id=action_proposal_id,
                 outcome="pending",
-                timestamp=datetime.utcnow(),
+                timestamp=utc_now(),
             )
             session.add(entry)
 

--- a/swarmmind/repositories/memory.py
+++ b/swarmmind/repositories/memory.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 import json
 import uuid
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from sqlmodel import select
 
 from swarmmind.db import session_scope
 from swarmmind.db_models import CompactionHintDB, MemoryEntryDB, SessionPromotionDB
 from swarmmind.models import MemoryLayer, MemoryScope
+from swarmmind.time_utils import utc_now
 
 
 class MemoryRepository:
@@ -93,8 +94,8 @@ class MemoryRepository:
                     ttl=ttl,
                     version=new_version,
                     last_writer_agent_id=agent_id,
-                    created_at=datetime.utcnow(),
-                    updated_at=datetime.utcnow(),
+                    created_at=utc_now(),
+                    updated_at=utc_now(),
                 )
                 session.add(entry)
             else:
@@ -103,7 +104,7 @@ class MemoryRepository:
                 entry.ttl = ttl
                 entry.version = new_version
                 entry.last_writer_agent_id = agent_id
-                entry.updated_at = datetime.utcnow()
+                entry.updated_at = utc_now()
 
             session.commit()
             session.refresh(entry)
@@ -149,8 +150,8 @@ class MemoryRepository:
                         ttl=None,
                         version=1,
                         last_writer_agent_id=row.last_writer_agent_id,
-                        created_at=datetime.utcnow(),
-                        updated_at=datetime.utcnow(),
+                        created_at=utc_now(),
+                        updated_at=utc_now(),
                     )
                     session.add(entry)
                 else:
@@ -158,7 +159,7 @@ class MemoryRepository:
                     entry.tags = row.tags
                     entry.version += 1
                     entry.last_writer_agent_id = row.last_writer_agent_id
-                    entry.updated_at = datetime.utcnow()
+                    entry.updated_at = utc_now()
                 migrated += 1
 
             promo = SessionPromotionDB(
@@ -195,18 +196,15 @@ class MemoryRepository:
 
     def delete_expired(self) -> int:
         """Delete memory entries whose TTL has elapsed. Returns delete count."""
-        from sqlalchemy import func
-
         with session_scope() as session:
-            # SQLite-compatible: strftime('%s', 'now') - strftime('%s', created_at) > ttl
-            results = session.exec(
-                select(MemoryEntryDB).where(
-                    MemoryEntryDB.ttl.is_not(None),
-                    (func.strftime("%s", "now") - func.strftime("%s", MemoryEntryDB.created_at)) > MemoryEntryDB.ttl,
-                ),
-            ).all()
+            now = utc_now()
+            results = session.exec(select(MemoryEntryDB).where(MemoryEntryDB.ttl.is_not(None))).all()
             count = 0
             for row in results:
-                session.delete(row)
-                count += 1
+                created_at = datetime.fromisoformat(row.created_at) if isinstance(row.created_at, str) else row.created_at
+                if created_at is None or row.ttl is None:
+                    continue
+                if created_at + timedelta(seconds=row.ttl) <= now:
+                    session.delete(row)
+                    count += 1
             return count

--- a/swarmmind/repositories/message.py
+++ b/swarmmind/repositories/message.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import uuid
-from datetime import datetime
 
 from fastapi import HTTPException
 from sqlmodel import select
@@ -35,17 +34,15 @@ class MessageRepository:
         tool_call_id: str | None = None,
         name: str | None = None,
     ) -> MessageDB:
-        """Create a new message.
-
-        Note: tool_call_id and name are not yet persisted because the
-        MessageDB model does not include those columns.
-        """
+        """Create a new message."""
         with session_scope() as session:
             msg = MessageDB(
                 id=str(uuid.uuid4()),
                 conversation_id=conversation_id,
                 role=role,
                 content=content,
+                tool_call_id=tool_call_id,
+                name=name,
             )
             session.add(msg)
             session.commit()
@@ -61,46 +58,3 @@ class MessageRepository:
                 raise HTTPException(status_code=404, detail="Message not found")
             session.expunge(msg)
             return msg
-
-    def create_clarification_response(
-        self,
-        conversation_id: str,
-        role: str,
-        content: str,
-        tool_call_id: str,
-        name: str,
-    ) -> dict:
-        """Persist a clarification response with raw SQL for tool_call_id/name.
-
-        This uses session-bound raw execution because MessageDB does not yet
-        include tool_call_id and name columns.
-        """
-        from sqlalchemy import text
-
-        message_id = str(uuid.uuid4())
-        now = datetime.utcnow().isoformat()
-        with session_scope() as session:
-            session.exec(
-                text(
-                    """
-                    INSERT INTO messages (id, conversation_id, role, content, created_at, tool_call_id, name)
-                    VALUES (:id, :conversation_id, :role, :content, :created_at, :tool_call_id, :name)
-                    """,
-                ),
-                {
-                    "id": message_id,
-                    "conversation_id": conversation_id,
-                    "role": role,
-                    "content": content,
-                    "created_at": now,
-                    "tool_call_id": tool_call_id,
-                    "name": name,
-                },
-            )
-            return {
-                "id": message_id,
-                "role": role,
-                "content": content,
-                "tool_call_id": tool_call_id,
-                "created_at": now,
-            }

--- a/swarmmind/repositories/runtime_catalog.py
+++ b/swarmmind/repositories/runtime_catalog.py
@@ -158,8 +158,7 @@ class RuntimeCatalogRepository:
     ) -> list[RuntimeSelectableModel]:
         """Return models assigned to the given subject."""
         with self._with_session() as session:
-            # Use explicit join via WHERE clauses since SQLite + SQLModel
-            # handles this cleanly.
+            # Keep the join explicit so result mapping stays predictable across dialects.
             results = session.exec(
                 select(RuntimeModelDB, RuntimeModelAssignmentDB.is_default)
                 .join(

--- a/swarmmind/repositories/working_memory.py
+++ b/swarmmind/repositories/working_memory.py
@@ -1,29 +1,25 @@
-"""Working memory repository."""
+"""Working memory repository compatibility wrapper."""
 
 from __future__ import annotations
 
-from sqlmodel import select
-
-from swarmmind.db import session_scope
-from swarmmind.db_models import WorkingMemoryDB
+from swarmmind.shared_memory import SharedMemory
 
 
 class WorkingMemoryRepository:
-    """Repository for shared working memory operations."""
+    """Compatibility wrapper over SharedMemory.
+
+    Keep the repository API stable while routing all working-memory semantics
+    through a single implementation source in ``SharedMemory``.
+    """
+
+    _READ_AGENT_ID = "working_memory_repository"
+
+    def _shared_memory(self, agent_id: str | None = None) -> SharedMemory:
+        return SharedMemory(agent_id or self._READ_AGENT_ID)
 
     def read(self, key: str) -> dict | None:
         """Read a key from working memory. Returns None if not found."""
-        with session_scope() as session:
-            entry = session.get(WorkingMemoryDB, key)
-            if entry is None:
-                return None
-            return {
-                "key": entry.key,
-                "value": entry.value,
-                "domain_tags": entry.domain_tags,
-                "last_writer_agent_id": entry.last_writer_agent_id,
-                "updated_at": entry.updated_at,
-            }
+        return self._shared_memory().read(key)
 
     def write(
         self,
@@ -33,53 +29,12 @@ class WorkingMemoryRepository:
         agent_id: str,
     ) -> None:
         """Write a key to working memory."""
-        with session_scope() as session:
-            entry = session.get(WorkingMemoryDB, key)
-            if entry is None:
-                entry = WorkingMemoryDB(
-                    key=key,
-                    value=value,
-                    domain_tags=domain_tags,
-                    last_writer_agent_id=agent_id,
-                )
-                session.add(entry)
-            else:
-                entry.value = value
-                entry.domain_tags = domain_tags or entry.domain_tags
-                entry.last_writer_agent_id = agent_id
+        self._shared_memory(agent_id).write(key, value, domain_tags)
 
     def read_all_by_tag(self, domain_tag: str) -> list[dict]:
         """Read all entries matching a domain tag."""
-        with session_scope() as session:
-            results = session.exec(
-                select(WorkingMemoryDB).where(
-                    WorkingMemoryDB.domain_tags.contains(domain_tag),
-                ),
-            ).all()
-            return [
-                {
-                    "key": r.key,
-                    "value": r.value,
-                    "domain_tags": r.domain_tags,
-                    "last_writer_agent_id": r.last_writer_agent_id,
-                    "updated_at": r.updated_at,
-                }
-                for r in results
-            ]
+        return self._shared_memory().read_all_by_tag(domain_tag)
 
     def read_all(self) -> list[dict]:
         """Read all entries in working memory."""
-        with session_scope() as session:
-            results = session.exec(
-                select(WorkingMemoryDB).order_by(WorkingMemoryDB.updated_at.desc()),
-            ).all()
-            return [
-                {
-                    "key": r.key,
-                    "value": r.value,
-                    "domain_tags": r.domain_tags,
-                    "last_writer_agent_id": r.last_writer_agent_id,
-                    "updated_at": r.updated_at,
-                }
-                for r in results
-            ]
+        return self._shared_memory().read_all()

--- a/swarmmind/runtime/catalog.py
+++ b/swarmmind/runtime/catalog.py
@@ -1,4 +1,4 @@
-"""Runtime model catalog backed by SQLite with env bootstrap for MVP.
+"""Runtime model catalog backed by the configured SwarmMind database.
 
 Design Principle: Zero hardcoded model/provider details.
 All model configuration comes from environment variables.

--- a/swarmmind/services/conversation_support.py
+++ b/swarmmind/services/conversation_support.py
@@ -1,0 +1,149 @@
+"""Conversation title and message helper service."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import Any
+
+from swarmmind.models import Conversation, Message
+from swarmmind.repositories.conversation import ConversationRepository
+from swarmmind.repositories.message import MessageRepository
+
+logger = logging.getLogger(__name__)
+
+NEW_CONVERSATION_TITLE = "New Conversation"
+
+
+def _normalize_content(content: object) -> str:
+    """Normalize possibly nested message content into plain text."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = [_normalize_content(item) for item in content]
+        return "\n".join(part for part in parts if part)
+    if isinstance(content, dict):
+        text_value = content.get("text")
+        if isinstance(text_value, str):
+            return text_value
+        nested = content.get("content")
+        if nested is not None:
+            return _normalize_content(nested)
+    return ""
+
+
+def generate_title_with_deerflow(user_msg: str, assistant_msg: str) -> tuple[str, str]:
+    """Generate title in isolated session using deer-flow's capabilities."""
+    try:
+        from deerflow.config.title_config import get_title_config
+        from deerflow.models import create_chat_model
+    except ImportError:
+        title = user_msg[:50] if len(user_msg) <= 50 else user_msg[:47] + "..."
+        return title or NEW_CONVERSATION_TITLE, "fallback"
+
+    config = get_title_config()
+    user_normalized = _normalize_content(user_msg)[:500]
+    assistant_normalized = _normalize_content(assistant_msg)[:500]
+    prompt = config.prompt_template.format(
+        max_words=config.max_words,
+        user_msg=user_normalized,
+        assistant_msg=assistant_normalized,
+    )
+
+    model = create_chat_model(name=config.model_name, thinking_enabled=False)
+
+    try:
+        response = model.invoke(prompt)
+        title_content = _normalize_content(response.content).strip().strip('"').strip("'")
+        title = title_content[: config.max_chars] if len(title_content) > config.max_chars else title_content
+        if title:
+            return title, "llm"
+    except Exception:
+        logger.exception("Title generation failed, using fallback")
+
+    fallback_chars = min(config.max_chars, 50)
+    if len(user_normalized) > fallback_chars:
+        return user_normalized[:fallback_chars].rstrip() + "...", "fallback"
+    return user_normalized or NEW_CONVERSATION_TITLE, "fallback"
+
+
+class ConversationSupportService:
+    """Lightweight support API for conversation/message helper responsibilities."""
+
+    def __init__(
+        self,
+        conversation_repo: ConversationRepository,
+        message_repo: MessageRepository,
+        title_generator: Callable[[str, str], tuple[str, str]] = generate_title_with_deerflow,
+        new_conversation_title: str = NEW_CONVERSATION_TITLE,
+    ) -> None:
+        self._conversation_repo = conversation_repo
+        self._message_repo = message_repo
+        self._title_generator = title_generator
+        self._new_conversation_title = new_conversation_title
+
+    def db_to_conversation(self, conv: Any) -> Conversation:
+        """Convert a conversation ORM row into the API model."""
+        return Conversation(
+            id=conv.id,
+            title=conv.title,
+            title_status=conv.title_status,
+            title_source=conv.title_source,
+            title_generated_at=(str(conv.title_generated_at) if conv.title_generated_at is not None else None),
+            runtime_profile_id=(str(conv.runtime_profile_id) if conv.runtime_profile_id is not None else None),
+            runtime_instance_id=(str(conv.runtime_instance_id) if conv.runtime_instance_id is not None else None),
+            thread_id=str(conv.thread_id) if conv.thread_id is not None else None,
+            created_at=str(conv.created_at) if conv.created_at is not None else "",
+            updated_at=str(conv.updated_at) if conv.updated_at is not None else "",
+        )
+
+    def db_to_message(self, msg: Any) -> Message:
+        """Convert a message ORM row into the API model."""
+        return Message(
+            id=msg.id,
+            conversation_id=msg.conversation_id,
+            role=msg.role,
+            content=msg.content,
+            tool_call_id=msg.tool_call_id,
+            name=msg.name,
+            created_at=str(msg.created_at) if msg.created_at is not None else "",
+        )
+
+    def persist_user_message(self, conversation_id: str, content: str) -> Message:
+        """Persist a user message and update the conversation timestamp."""
+        self._conversation_repo.get_by_id(conversation_id)
+        msg = self._message_repo.create(conversation_id, "user", content)
+        self._conversation_repo.touch(conversation_id)
+        return self.db_to_message(msg)
+
+    def persist_assistant_message(self, conversation_id: str, content: str) -> Message:
+        """Persist an assistant message and update the conversation timestamp."""
+        msg = self._message_repo.create(conversation_id, "assistant", content)
+        self._conversation_repo.touch(conversation_id)
+        return self.db_to_message(msg)
+
+    def maybe_generate_conversation_title(
+        self,
+        conversation_id: str,
+        title_generator: Callable[[str, str], tuple[str, str]] | None = None,
+    ) -> None:
+        """Generate title after the first complete user+assistant exchange."""
+        active_title_generator = title_generator or self._title_generator
+        conversation = self._conversation_repo.get_by_id(conversation_id)
+        if conversation.title_status != "pending":
+            return
+
+        messages = self._message_repo.list_by_conversation(conversation_id)
+        user_messages = [msg.content for msg in messages if msg.role == "user"]
+        assistant_messages = [msg.content for msg in messages if msg.role == "assistant"]
+
+        if len(user_messages) != 1 or len(assistant_messages) < 1:
+            return
+
+        title, source = active_title_generator(user_messages[0], assistant_messages[0])
+        self._conversation_repo.update_title(
+            conversation_id,
+            title or self._new_conversation_title,
+            "generated" if source == "llm" else "fallback",
+            source,
+        )

--- a/swarmmind/services/lifecycle.py
+++ b/swarmmind/services/lifecycle.py
@@ -1,0 +1,86 @@
+"""Lifecycle service for startup bootstrap and cleanup scanner responsibilities."""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from collections.abc import Callable
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def startup_lifecycle(  # noqa: PLR0913
+    *,
+    init_db: Callable[[], None],
+    seed_default_agents: Callable[[], None],
+    sync_env_runtime_model: Callable[[], None],
+    ensure_default_runtime_instance: Callable[[], None],
+    cleanup_scanner: Callable[[], None],
+    api_host: str,
+    api_port: int | str,
+    thread_factory: Callable[..., Any] = threading.Thread,
+    lifecycle_logger: logging.Logger = logger,
+) -> Any:
+    """Run startup initialization and launch cleanup scanner in background."""
+    init_db()
+    seed_default_agents()
+    sync_env_runtime_model()
+    ensure_default_runtime_instance()
+    lifecycle_logger.info("SwarmMind API started on %s:%s", api_host, api_port)
+    scanner_thread = thread_factory(target=cleanup_scanner, daemon=True)
+    scanner_thread.start()
+    return scanner_thread
+
+
+def run_cleanup_once(
+    *,
+    action_proposal_repo: Any,
+    memory_repo: Any,
+    action_timeout_seconds: int,
+    record_supervisor_decision: Callable[[str, Any], None],
+    supervisor_timeout_decision: Any,
+    lifecycle_logger: logging.Logger = logger,
+) -> None:
+    """Run a single cleanup pass for stale proposals and expired memory."""
+    stale = action_proposal_repo.list_stale(action_timeout_seconds)
+    for proposal in stale:
+        lifecycle_logger.info(
+            "Auto-rejecting stale proposal: id=%s (created=%s)",
+            proposal.id,
+            proposal.created_at,
+        )
+        action_proposal_repo.reject_proposal(proposal.id)
+        record_supervisor_decision(proposal.id, supervisor_timeout_decision)
+
+    deleted_memory = memory_repo.delete_expired()
+    if deleted_memory > 0:
+        lifecycle_logger.info("Cleaned up %d expired memory entries.", deleted_memory)
+
+
+def run_cleanup_scanner(
+    *,
+    action_proposal_repo: Any,
+    memory_repo: Any,
+    action_timeout_seconds: int,
+    record_supervisor_decision: Callable[[str, Any], None],
+    supervisor_timeout_decision: Any,
+    lifecycle_logger: logging.Logger = logger,
+    sleep_seconds: int = 30,
+    sleeper: Callable[[float], None] = time.sleep,
+) -> None:
+    """Background loop: periodically clean stale proposals and expired memory."""
+    while True:
+        sleeper(sleep_seconds)
+        try:
+            run_cleanup_once(
+                action_proposal_repo=action_proposal_repo,
+                memory_repo=memory_repo,
+                action_timeout_seconds=action_timeout_seconds,
+                record_supervisor_decision=record_supervisor_decision,
+                supervisor_timeout_decision=supervisor_timeout_decision,
+                lifecycle_logger=lifecycle_logger,
+            )
+        except Exception as exc:
+            lifecycle_logger.error("Cleanup scanner error: %s", exc)

--- a/swarmmind/services/runtime_support.py
+++ b/swarmmind/services/runtime_support.py
@@ -1,0 +1,157 @@
+"""Runtime support helpers extracted from supervisor orchestration."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Mapping
+from typing import Any
+
+from fastapi import HTTPException
+
+from swarmmind.models import ConversationMode, ConversationRuntimeOptions, SendMessageRequest
+from swarmmind.repositories.conversation import ConversationRepository
+from swarmmind.runtime import (
+    RuntimeConfigError,
+    RuntimeExecutionError,
+    RuntimeUnavailableError,
+    ensure_default_runtime_instance,
+)
+from swarmmind.runtime.catalog import (
+    ANONYMOUS_SUBJECT_ID,
+    ANONYMOUS_SUBJECT_TYPE,
+    resolve_model_for_subject,
+)
+
+logger = logging.getLogger(__name__)
+
+MODE_RUNTIME_MAP: dict[ConversationMode, dict[str, bool]] = {
+    ConversationMode.FLASH: {
+        "thinking_enabled": False,
+        "plan_mode": False,
+        "subagent_enabled": False,
+    },
+    ConversationMode.THINKING: {
+        "thinking_enabled": True,
+        "plan_mode": False,
+        "subagent_enabled": False,
+    },
+    ConversationMode.PRO: {
+        "thinking_enabled": True,
+        "plan_mode": True,
+        "subagent_enabled": False,
+    },
+    ConversationMode.ULTRA: {
+        "thinking_enabled": True,
+        "plan_mode": True,
+        "subagent_enabled": True,
+    },
+}
+
+
+def normalize_model_name(model_name: str | None) -> str | None:
+    """Trim a user-supplied model name and collapse blank values to None."""
+    if model_name is None:
+        return None
+
+    value = model_name.strip()
+    return value or None
+
+
+def conversation_thread_id(conversation_id: str) -> str:
+    """Map a conversation to its DeerFlow thread identifier."""
+    return conversation_id
+
+
+def format_runtime_error(exc: Exception) -> str:
+    """Normalize runtime exceptions into user-facing error strings."""
+    if isinstance(exc, (RuntimeConfigError, RuntimeUnavailableError, RuntimeExecutionError)):
+        return f"DeerFlow Runtime error: {exc}"
+    return f"Unexpected DeerFlow execution error: {exc}"
+
+
+class RuntimeSupportService:
+    """Lightweight runtime support API for conversation execution orchestration."""
+
+    def __init__(
+        self,
+        conversation_repo: ConversationRepository,
+        mode_runtime_map: Mapping[ConversationMode, Mapping[str, bool]] = MODE_RUNTIME_MAP,
+        resolve_model_for_subject_fn: Callable[..., Any] = resolve_model_for_subject,
+        ensure_default_runtime_instance_fn: Callable[[], Any] = ensure_default_runtime_instance,
+        subject_type: str = ANONYMOUS_SUBJECT_TYPE,
+        subject_id: str = ANONYMOUS_SUBJECT_ID,
+    ) -> None:
+        self._conversation_repo = conversation_repo
+        self._mode_runtime_map = mode_runtime_map
+        self._resolve_model_for_subject_fn = resolve_model_for_subject_fn
+        self._ensure_default_runtime_instance_fn = ensure_default_runtime_instance_fn
+        self._subject_type = subject_type
+        self._subject_id = subject_id
+
+    def normalize_model_name(self, model_name: str | None) -> str | None:
+        """Normalize a requested model name before catalog resolution."""
+        return normalize_model_name(model_name)
+
+    def resolve_model_name_for_request(self, model_name: str | None) -> str:
+        """Resolve the effective runtime model or raise an HTTP-friendly error."""
+        normalized_model_name = self.normalize_model_name(model_name)
+        try:
+            selected_model = self._resolve_model_for_subject_fn(
+                requested_model_name=normalized_model_name,
+                subject_type=self._subject_type,
+                subject_id=self._subject_id,
+            )
+        except RuntimeConfigError as exc:
+            raise HTTPException(
+                status_code=400 if normalized_model_name else 503,
+                detail=str(exc),
+            ) from exc
+        return selected_model.name
+
+    def conversation_thread_id(self, conversation_id: str) -> str:
+        """Return the runtime thread identifier for a conversation."""
+        return conversation_thread_id(conversation_id)
+
+    def bind_conversation_runtime(self, conversation_id: str) -> tuple[object, str]:
+        """Bind the default runtime instance metadata onto the conversation."""
+        runtime_instance = self._ensure_default_runtime_instance_fn()
+        thread_id = self.conversation_thread_id(conversation_id)
+
+        self._conversation_repo.update_runtime(
+            conversation_id,
+            runtime_instance.runtime_profile_id,
+            runtime_instance.runtime_instance_id,
+            thread_id,
+        )
+
+        return runtime_instance, thread_id
+
+    def format_runtime_error(self, exc: Exception) -> str:
+        """Convert runtime failures into a stable user-facing message."""
+        return format_runtime_error(exc)
+
+    def resolve_runtime_options(self, body: SendMessageRequest) -> ConversationRuntimeOptions:
+        """Map request flags and mode selection into runtime execution options."""
+        effective_mode = body.mode
+        logger.info(
+            "[DEBUG] _resolve_runtime_options: body.mode=%s, effective_mode=%s",
+            body.mode,
+            effective_mode,
+        )
+        if effective_mode is None:
+            effective_mode = ConversationMode.THINKING if body.reasoning else ConversationMode.FLASH
+
+        runtime_flags = self._mode_runtime_map[effective_mode]
+        logger.info("[DEBUG] _resolve_runtime_options: runtime_flags=%s", runtime_flags)
+        options = ConversationRuntimeOptions(
+            mode=effective_mode,
+            model_name=self.resolve_model_name_for_request(body.model_name),
+            thinking_enabled=runtime_flags["thinking_enabled"],
+            plan_mode=runtime_flags["plan_mode"],
+            subagent_enabled=runtime_flags["subagent_enabled"],
+        )
+        logger.info(
+            "[DEBUG] _resolve_runtime_options: returning options with subagent_enabled=%s",
+            options.subagent_enabled,
+        )
+        return options

--- a/swarmmind/services/stream_events.py
+++ b/swarmmind/services/stream_events.py
@@ -1,0 +1,293 @@
+"""Stream event serialization and translation helpers.
+
+This module extracts the stream-event translation logic from supervisor,
+so it can be tested and reused independently.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+
+from swarmmind.models import ConversationMode, ConversationRuntimeOptions
+
+
+def serialize_stream_event(event_type: str, **payload) -> str:
+    """Serialize a single streaming event as NDJSON line."""
+    return json.dumps({"type": event_type, **payload}, ensure_ascii=False) + "\n"
+
+
+def tool_activity_label(tool_name: str, args: dict | None = None) -> str:
+    """Build localized activity label for tool calls."""
+    args = args or {}
+
+    if tool_name == "search":
+        query = args.get("query")
+        if isinstance(query, str) and query.strip():
+            return f"检索资料：{query.strip()[:60]}"
+        return "检索外部资料"
+    if tool_name == "crawl":
+        return "抓取网页内容"
+    if tool_name == "fetch":
+        return "获取远端内容"
+    if tool_name == "view_image":
+        return "查看图像资料"
+    if tool_name == "read_file":
+        return "读取文件"
+    if tool_name == "write_file":
+        return "写入文件"
+    if tool_name == "edit_file":
+        return "编辑文件"
+    if tool_name == "bash":
+        return "执行命令"
+    if tool_name == "present_files":
+        return "整理输出产物"
+    if tool_name == "ask_clarification":
+        return "请求补充信息"
+    if tool_name == "tool_search":
+        return "搜索可用工具"
+
+    return f"执行工具：{tool_name}"
+
+
+def task_card_title(tool_args: dict | None) -> str:
+    """Build a task card title from tool call args."""
+    if not isinstance(tool_args, dict):
+        return "新的协作分工"
+
+    description = tool_args.get("description")
+    if isinstance(description, str) and description.strip():
+        return description.strip()
+
+    prompt = tool_args.get("prompt")
+    if isinstance(prompt, str) and prompt.strip():
+        return prompt.strip().splitlines()[0][:80]
+
+    return "新的协作分工"
+
+
+def task_status_from_result(content: str) -> tuple[str, str | None]:
+    """Derive task status/detail from task-tool result content."""
+    normalized = content.strip()
+    if normalized.startswith("Task Succeeded. Result:"):
+        return "completed", normalized.split("Task Succeeded. Result:", 1)[1].strip() or None
+    if normalized.startswith("Task failed."):
+        return "failed", normalized.split("Task failed.", 1)[1].strip() or None
+    if normalized.startswith("Task timed out"):
+        return "failed", normalized
+    return "running", normalized or None
+
+
+def general_agent_status_labels(runtime_options: ConversationRuntimeOptions) -> tuple[str, str]:
+    """Return phase labels for status events by runtime mode."""
+    if runtime_options.mode == ConversationMode.ULTRA:
+        return (
+            "Agent Team 正在判断这轮探索需要怎样的协作方式",
+            "Agent Team 正在协作处理你的问题",
+        )
+    if runtime_options.mode == ConversationMode.PRO:
+        return (
+            "正在规划这轮任务的执行方式",
+            "正在按规划生成结果",
+        )
+    if runtime_options.mode == ConversationMode.THINKING:
+        return (
+            "正在分析你的问题",
+            "正在整理深入回复",
+        )
+    return (
+        "正在准备快速回复",
+        "正在快速生成结果",
+    )
+
+
+def translate_general_agent_event(
+    event: dict,
+    runtime_options: ConversationRuntimeOptions,
+) -> list[str]:
+    """Translate DeerFlow/GeneralAgent events into supervisor stream events."""
+    event_type = event.get("type")
+
+    if event_type == "assistant_reasoning":
+        if not runtime_options.thinking_enabled:
+            return []
+        content = event.get("content")
+        if isinstance(content, str) and content.strip():
+            return [
+                serialize_stream_event(
+                    "thinking",
+                    message_id=event.get("message_id"),
+                    content=content,
+                ),
+            ]
+        return []
+
+    if event_type == "assistant_message":
+        content = event.get("content")
+        if isinstance(content, str) and content:
+            return [
+                serialize_stream_event(
+                    "assistant_message",
+                    message_id=event.get("message_id"),
+                    content=content,
+                ),
+            ]
+        return []
+
+    if event_type == "assistant_tool_calls":
+        if not runtime_options.subagent_enabled:
+            return []
+        tool_calls = event.get("tool_calls")
+        if not isinstance(tool_calls, list):
+            return []
+
+        lines: list[str] = []
+        for tool_call in tool_calls:
+            if not isinstance(tool_call, dict):
+                continue
+
+            tool_name = tool_call.get("name")
+            tool_args = tool_call.get("args", {})
+            tool_call_id = tool_call.get("id")
+
+            if tool_name == "task":
+                lines.append(
+                    serialize_stream_event(
+                        "team_task",
+                        task={
+                            "id": tool_call_id,
+                            "title": task_card_title(tool_args if isinstance(tool_args, dict) else {}),
+                            "status": "running",
+                            "detail": "Agent Team 正在协同处理这个子任务。",
+                        },
+                    ),
+                )
+                continue
+
+            lines.append(
+                serialize_stream_event(
+                    "team_activity",
+                    activity={
+                        "id": tool_call_id or str(uuid.uuid4()),
+                        "tool_name": tool_name,
+                        "label": tool_activity_label(
+                            str(tool_name),
+                            tool_args if isinstance(tool_args, dict) else {},
+                        ),
+                        "status": "running",
+                    },
+                ),
+            )
+        return lines
+
+    if event_type == "tool_result":
+        tool_name = str(event.get("tool_name") or "unknown")
+        tool_call_id = event.get("tool_call_id")
+        content = str(event.get("content") or "").strip()
+
+        # ask_clarification is available in all modes, not just subagent mode.
+        if tool_name == "ask_clarification":
+            return [
+                serialize_stream_event(
+                    "clarification_request",
+                    clarification={
+                        "id": tool_call_id,
+                        "content": content,
+                    },
+                ),
+            ]
+
+        if not runtime_options.subagent_enabled:
+            return []
+
+        if tool_name == "task":
+            status, detail = task_status_from_result(content)
+            return [
+                serialize_stream_event(
+                    "team_task",
+                    task={
+                        "id": tool_call_id,
+                        "status": status,
+                        "detail": detail,
+                    },
+                ),
+            ]
+
+        return [
+            serialize_stream_event(
+                "team_activity",
+                activity={
+                    "id": tool_call_id or str(uuid.uuid4()),
+                    "tool_name": tool_name,
+                    "label": tool_activity_label(tool_name),
+                    "status": "completed",
+                    "detail": content[:240] if content else None,
+                },
+            ),
+        ]
+
+    if event_type == "custom_event":
+        if not runtime_options.subagent_enabled:
+            return []
+
+        custom_event_type = event.get("event_type")
+        task_id = event.get("task_id")
+
+        if custom_event_type == "task_started":
+            return [
+                serialize_stream_event(
+                    "task_started",
+                    task={
+                        "id": task_id,
+                        "description": event.get("description"),
+                        "status": "in_progress",
+                    },
+                ),
+            ]
+
+        if custom_event_type == "task_running":
+            return [
+                serialize_stream_event(
+                    "task_running",
+                    task={
+                        "id": task_id,
+                        "message": event.get("message"),
+                    },
+                ),
+            ]
+
+        if custom_event_type == "task_completed":
+            return [
+                serialize_stream_event(
+                    "task_completed",
+                    task={
+                        "id": task_id,
+                        "result": event.get("result"),
+                        "status": "completed",
+                    },
+                ),
+            ]
+
+        if custom_event_type == "task_failed":
+            return [
+                serialize_stream_event(
+                    "task_failed",
+                    task={
+                        "id": task_id,
+                        "error": event.get("error"),
+                        "status": "failed",
+                    },
+                ),
+            ]
+
+    return []
+
+
+__all__ = [
+    "general_agent_status_labels",
+    "serialize_stream_event",
+    "task_card_title",
+    "task_status_from_result",
+    "tool_activity_label",
+    "translate_general_agent_event",
+]

--- a/swarmmind/services/trace_service.py
+++ b/swarmmind/services/trace_service.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import sqlite3
 from datetime import UTC, datetime
 from pathlib import Path
@@ -18,10 +19,42 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
-# 复用 deer-flow 的 runtime root 路径结构
-DEFAULT_CHECKPOINTER_PATH = (
+# 复用当前 SwarmMind runtime bundle 的 legacy 路径结构
+LEGACY_DEFAULT_CHECKPOINTER_PATH = (
     Path(__file__).resolve().parents[2] / ".runtime" / "deerflow" / "local-default" / "checkpoints.db"
 )
+DEFAULT_CHECKPOINTER_FILENAME = "checkpoints.db"
+
+
+def _resolve_default_checkpointer_path() -> Path:
+    """Resolve the default SqliteSaver path from runtime env when available.
+
+    Resolution order:
+    1. If ``DEER_FLOW_HOME`` is set, prefer an existing checkpointer next to or
+       inside that home directory.
+    2. If no checkpointer exists yet, keep SwarmMind's current bundle layout as
+       the default for ``.../home`` directories by choosing the parent sibling.
+    3. Fall back to the previous fixed repo-local path.
+    """
+    deer_flow_home = os.environ.get("DEER_FLOW_HOME")
+    if not deer_flow_home:
+        return LEGACY_DEFAULT_CHECKPOINTER_PATH
+
+    runtime_home = Path(deer_flow_home).expanduser()
+    direct_candidate = runtime_home / DEFAULT_CHECKPOINTER_FILENAME
+    sibling_candidate = runtime_home.parent / DEFAULT_CHECKPOINTER_FILENAME
+
+    for candidate in (direct_candidate, sibling_candidate):
+        if candidate.exists():
+            return candidate
+
+    if runtime_home.name == "home":
+        return sibling_candidate
+
+    return direct_candidate
+
+
+DEFAULT_CHECKPOINTER_PATH = _resolve_default_checkpointer_path()
 
 
 class TraceService:
@@ -38,7 +71,7 @@ class TraceService:
             checkpointer_path: Path to SqliteSaver database.
                 Defaults to deer-flow's default location.
         """
-        self.checkpointer_path = Path(checkpointer_path) if checkpointer_path else DEFAULT_CHECKPOINTER_PATH
+        self.checkpointer_path = Path(checkpointer_path) if checkpointer_path else _resolve_default_checkpointer_path()
 
     def get_conversation_trace(self, thread_id: str) -> dict[str, Any]:
         """获取会话的协作轨迹。

--- a/swarmmind/shared_memory.py
+++ b/swarmmind/shared_memory.py
@@ -1,4 +1,4 @@
-"""Shared memory layer — SQLite-backed KV store with last-write-wins + 409 retry."""
+"""Shared memory layer backed by the configured SwarmMind control-plane database."""
 
 import logging
 import time
@@ -17,7 +17,7 @@ class SharedMemoryConflict(Exception):
 
 
 class SharedMemory:
-    """Key-value store backed by SQLite.
+    """Key-value store backed by the configured ORM database.
 
     Phase 1 protocol (last-write-wins):
     1. Read current value + updated_at

--- a/swarmmind/time_utils.py
+++ b/swarmmind/time_utils.py
@@ -1,0 +1,10 @@
+"""Time helpers for SwarmMind persistence and API layers."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+
+def utc_now() -> datetime:
+    """Return the current UTC time as a naive datetime for schema compatibility."""
+    return datetime.now(UTC).replace(tzinfo=None)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,10 @@ import os
 import sys
 from types import ModuleType
 
+import pytest
+
+from swarmmind.db import dispose_engines
+
 
 def _ensure_litellm_stub() -> None:
     try:
@@ -64,3 +68,11 @@ _ensure_litellm_stub()
 _ensure_deerflow_stub()
 
 os.environ.setdefault("OPENAI_API_KEY", "test-openai-key")
+
+
+@pytest.fixture(autouse=True)
+def cleanup_db_engines():
+    """Keep test DB engine lifecycle bounded when URLs change across cases."""
+    dispose_engines()
+    yield
+    dispose_engines()

--- a/tests/test_clarification_middleware.py
+++ b/tests/test_clarification_middleware.py
@@ -1,0 +1,113 @@
+"""Regression tests for clarification middleware interception behavior."""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import Mock
+
+import pytest
+from langchain_core.messages import ToolMessage
+from langgraph.graph import END
+from langgraph.prebuilt.tool_node import ToolCallRequest
+from langgraph.types import Command
+
+from swarmmind.agents.middlewares.clarification_middleware import ClarificationMiddleware
+
+
+def _build_request(*, name: str, args: dict | None = None, tool_call_id: str = "tool-call-1") -> ToolCallRequest:
+    return ToolCallRequest(
+        tool_call={
+            "id": tool_call_id,
+            "name": name,
+            "args": args or {},
+            "type": "tool_call",
+        },
+        tool=None,
+        state={},
+        runtime=None,
+    )
+
+
+def test_wrap_tool_call_intercepts_ask_clarification(caplog: pytest.LogCaptureFixture) -> None:
+    middleware = ClarificationMiddleware()
+    request = _build_request(
+        name="ask_clarification",
+        args={
+            "question": "请确认目标用户是谁？",
+            "clarification_type": "missing_info",
+            "context": "当前需求缺少核心用户画像。",
+            "options": ["企业销售", "运营团队"],
+        },
+        tool_call_id="clarify-sync",
+    )
+    handler = Mock(side_effect=AssertionError("clarification requests should be intercepted"))
+
+    with caplog.at_level(logging.INFO):
+        result = middleware.wrap_tool_call(request, handler)
+
+    assert isinstance(result, Command)
+    assert result.goto == END
+    assert len(result.update["messages"]) == 1
+    message = result.update["messages"][0]
+    assert isinstance(message, ToolMessage)
+    assert message.tool_call_id == "clarify-sync"
+    assert message.name == "ask_clarification"
+    assert message.content == "❓ 当前需求缺少核心用户画像。\n\n请确认目标用户是谁？\n\n  1. 企业销售\n  2. 运营团队"
+    handler.assert_not_called()
+    assert "tool_call_id=clarify-sync" in caplog.text
+    assert "clarification_type=missing_info" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_awrap_tool_call_intercepts_ask_clarification() -> None:
+    middleware = ClarificationMiddleware()
+    request = _build_request(
+        name="ask_clarification",
+        args={
+            "question": "Which rollout should I use?",
+            "clarification_type": "approach_choice",
+            "options": ["Blue/green", "Canary"],
+        },
+        tool_call_id="clarify-async",
+    )
+
+    async def handler(_request: ToolCallRequest) -> ToolMessage:
+        raise AssertionError("clarification requests should be intercepted")
+
+    result = await middleware.awrap_tool_call(request, handler)
+
+    assert isinstance(result, Command)
+    assert result.goto == END
+    assert len(result.update["messages"]) == 1
+    message = result.update["messages"][0]
+    assert isinstance(message, ToolMessage)
+    assert message.tool_call_id == "clarify-async"
+    assert message.name == "ask_clarification"
+    assert message.content == "🔀 Which rollout should I use?\n\n  1. Blue/green\n  2. Canary"
+
+
+def test_wrap_tool_call_passthrough_for_non_clarification_tools() -> None:
+    middleware = ClarificationMiddleware()
+    request = _build_request(name="search_docs", args={"query": "runtime profile"})
+    expected = ToolMessage(content="ok", tool_call_id="tool-call-1", name="search_docs")
+    handler = Mock(return_value=expected)
+
+    result = middleware.wrap_tool_call(request, handler)
+
+    assert result is expected
+    handler.assert_called_once_with(request)
+
+
+@pytest.mark.asyncio
+async def test_awrap_tool_call_passthrough_for_non_clarification_tools() -> None:
+    middleware = ClarificationMiddleware()
+    request = _build_request(name="search_docs", args={"query": "runtime profile"})
+    expected = ToolMessage(content="ok", tool_call_id="tool-call-1", name="search_docs")
+
+    async def handler(_request: ToolCallRequest) -> ToolMessage:
+        assert _request is request
+        return expected
+
+    result = await middleware.awrap_tool_call(request, handler)
+
+    assert result is expected

--- a/tests/test_clarification_persistence.py
+++ b/tests/test_clarification_persistence.py
@@ -1,0 +1,66 @@
+"""Regression tests for clarification response persistence."""
+
+from __future__ import annotations
+
+from sqlalchemy import text
+
+from swarmmind.api import supervisor
+from swarmmind.db import init_db, seed_default_agents, session_scope
+from swarmmind.models import GoalRequest
+
+
+def _message_columns() -> set[str]:
+    with session_scope() as session:
+        rows = session.exec(text("PRAGMA table_info(messages)")).all()
+    return {str(row[1]) for row in rows}
+
+
+def test_clarification_response_persists_as_tool_message_and_is_readable(tmp_path, monkeypatch):
+    db_path = str(tmp_path / "test.db")
+    monkeypatch.setenv("SWARMMIND_DATABASE_URL", f"sqlite:///{db_path}")
+    init_db()
+    seed_default_agents()
+
+    columns = _message_columns()
+    assert "tool_call_id" in columns
+    assert "name" in columns
+
+    conversation = supervisor.create_conversation(GoalRequest(goal="clarification 持久化回归"))
+    result = supervisor.respond_to_clarification(
+        conversation.id,
+        supervisor.ClarificationResponseRequest(
+            tool_call_id="clarify-001",
+            response="范围锁定在 sales pipeline 与 reporting",
+        ),
+    )
+
+    assert result.id
+    assert result.role == "tool"
+    assert result.content == "范围锁定在 sales pipeline 与 reporting"
+    assert result.tool_call_id == "clarify-001"
+    assert result.name == "ask_clarification_response"
+
+    messages = supervisor.get_conversation_messages(conversation.id)
+    assert messages.total == 1
+    assert messages.items[0].id == result.id
+    assert messages.items[0].role == "tool"
+    assert messages.items[0].content == "范围锁定在 sales pipeline 与 reporting"
+    assert messages.items[0].tool_call_id == "clarify-001"
+    assert messages.items[0].name == "ask_clarification_response"
+
+    with session_scope() as session:
+        row = session.exec(
+            text(
+                """
+                SELECT role, content, tool_call_id, name
+                FROM messages
+                WHERE id = :id
+                """,
+            ).bindparams(id=result.id),
+        ).first()
+
+    assert row is not None
+    assert row[0] == "tool"
+    assert row[1] == "范围锁定在 sales pipeline 与 reporting"
+    assert row[2] == "clarify-001"
+    assert isinstance(row[3], str) and row[3]

--- a/tests/test_conversation_stream.py
+++ b/tests/test_conversation_stream.py
@@ -16,7 +16,7 @@ from swarmmind.models import ConversationMode, GoalRequest, SendMessageRequest
 @pytest.fixture(autouse=True)
 def setup_db(tmp_path, monkeypatch):
     db_path = str(tmp_path / "test.db")
-    monkeypatch.setenv("SWARMMIND_DB_PATH", db_path)
+    monkeypatch.setenv("SWARMMIND_DATABASE_URL", f"sqlite:///{db_path}")
     init_db()
     seed_default_agents()
     yield
@@ -271,3 +271,37 @@ def test_reasoning_compatibility_uses_thinking_mode_without_team_events(monkeypa
     assert not any(event["type"] == "team_task" for event in events)
     assert not any(event["type"] == "team_activity" for event in events)
     assert FakeDeerFlowRuntimeAdapter.stream_runtime_options[-1].mode == ConversationMode.THINKING
+
+
+def test_streaming_messages_api_remains_compatible_when_message_schema_extends(monkeypatch):
+    monkeypatch.setattr(supervisor, "DeerFlowRuntimeAdapter", FakeDeerFlowRuntimeAdapter)
+    monkeypatch.setattr(supervisor, "derive_situation_tag", lambda _: "unknown")
+
+    conversation = supervisor.create_conversation(
+        GoalRequest(goal="验证消息 schema 扩展后的兼容性"),
+    )
+
+    list(
+        supervisor._stream_conversation_message(
+            conversation.id,
+            SendMessageRequest(content="请给我一版结论", mode=ConversationMode.FLASH),
+        ),
+    )
+
+    response = supervisor.get_conversation_messages(conversation.id)
+    assert response.total == 2
+
+    for message in response.items:
+        dumped = message.model_dump()
+        assert dumped["id"]
+        assert dumped["conversation_id"] == conversation.id
+        assert dumped["role"] in {"user", "assistant"}
+        assert isinstance(dumped["content"], str) and dumped["content"]
+        assert isinstance(dumped["created_at"], str) and dumped["created_at"]
+
+        # Future-proof check: when Message adds tool metadata fields,
+        # user/assistant rows should still be readable as normal messages.
+        if "tool_call_id" in dumped:
+            assert dumped["tool_call_id"] in (None, "")
+        if "name" in dumped:
+            assert dumped["name"] in (None, "")

--- a/tests/test_conversation_support.py
+++ b/tests/test_conversation_support.py
@@ -1,0 +1,176 @@
+"""Tests for conversation support service helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from types import SimpleNamespace
+
+from swarmmind.services.conversation_support import ConversationSupportService
+
+
+@dataclass
+class FakeConversation:
+    id: str = "conv-1"
+    title: str = "New Conversation"
+    title_status: str = "pending"
+    title_source: str | None = None
+    title_generated_at: datetime | None = None
+    runtime_profile_id: str | None = None
+    runtime_instance_id: str | None = None
+    thread_id: str | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+
+class FakeConversationRepo:
+    def __init__(self, conversation: FakeConversation | None = None):
+        self.conversation = conversation or FakeConversation()
+        self.touched_ids: list[str] = []
+        self.updated_titles: list[tuple[str, str, str, str | None]] = []
+
+    def get_by_id(self, conversation_id: str):
+        return self.conversation
+
+    def touch(self, conversation_id: str) -> None:
+        self.touched_ids.append(conversation_id)
+
+    def update_title(self, conversation_id: str, title: str, title_status: str, title_source: str | None) -> None:
+        self.updated_titles.append((conversation_id, title, title_status, title_source))
+
+
+class FakeMessageRepo:
+    def __init__(self, messages: list[SimpleNamespace] | None = None):
+        self.messages = messages or []
+        self.create_calls: list[tuple[str, str, str]] = []
+
+    def create(self, conversation_id: str, role: str, content: str):
+        self.create_calls.append((conversation_id, role, content))
+        return SimpleNamespace(
+            id="msg-created",
+            conversation_id=conversation_id,
+            role=role,
+            content=content,
+            tool_call_id=None,
+            name=None,
+            created_at=datetime(2026, 1, 1, 0, 0, 0),
+        )
+
+    def list_by_conversation(self, conversation_id: str):
+        return self.messages
+
+
+def test_db_to_message_maps_tool_fields() -> None:
+    service = ConversationSupportService(
+        conversation_repo=FakeConversationRepo(),
+        message_repo=FakeMessageRepo(),
+    )
+    row = SimpleNamespace(
+        id="msg-1",
+        conversation_id="conv-1",
+        role="tool",
+        content="clarification response",
+        tool_call_id="tool-123",
+        name="ask_clarification_response",
+        created_at=datetime(2026, 1, 1, 0, 0, 0),
+    )
+
+    message = service.db_to_message(row)
+
+    assert message.id == "msg-1"
+    assert message.role == "tool"
+    assert message.tool_call_id == "tool-123"
+    assert message.name == "ask_clarification_response"
+
+
+def test_persist_user_message_creates_and_touches_conversation() -> None:
+    conversation_repo = FakeConversationRepo()
+    message_repo = FakeMessageRepo()
+    service = ConversationSupportService(
+        conversation_repo=conversation_repo,
+        message_repo=message_repo,
+    )
+
+    saved = service.persist_user_message("conv-1", "hello")
+
+    assert saved.role == "user"
+    assert message_repo.create_calls == [("conv-1", "user", "hello")]
+    assert conversation_repo.touched_ids == ["conv-1"]
+
+
+def test_maybe_generate_conversation_title_generates_only_for_first_exchange() -> None:
+    conversation_repo = FakeConversationRepo(conversation=FakeConversation(title_status="pending"))
+    message_repo = FakeMessageRepo(
+        messages=[
+            SimpleNamespace(role="user", content="first user"),
+            SimpleNamespace(role="assistant", content="first assistant"),
+        ],
+    )
+    calls: list[tuple[str, str]] = []
+
+    def fake_title_generator(user: str, assistant: str) -> tuple[str, str]:
+        calls.append((user, assistant))
+        return "Generated Title", "llm"
+
+    service = ConversationSupportService(
+        conversation_repo=conversation_repo,
+        message_repo=message_repo,
+        title_generator=fake_title_generator,
+    )
+
+    service.maybe_generate_conversation_title("conv-1")
+
+    assert calls == [("first user", "first assistant")]
+    assert conversation_repo.updated_titles == [("conv-1", "Generated Title", "generated", "llm")]
+
+
+def test_maybe_generate_conversation_title_skips_non_pending_or_non_first_exchange() -> None:
+    conversation_repo = FakeConversationRepo(conversation=FakeConversation(title_status="generated"))
+    message_repo = FakeMessageRepo(
+        messages=[
+            SimpleNamespace(role="user", content="u1"),
+            SimpleNamespace(role="assistant", content="a1"),
+        ],
+    )
+    service = ConversationSupportService(
+        conversation_repo=conversation_repo,
+        message_repo=message_repo,
+        title_generator=lambda *_: ("should-not-run", "llm"),
+    )
+    service.maybe_generate_conversation_title("conv-1")
+    assert conversation_repo.updated_titles == []
+
+    conversation_repo2 = FakeConversationRepo(conversation=FakeConversation(title_status="pending"))
+    message_repo2 = FakeMessageRepo(
+        messages=[
+            SimpleNamespace(role="user", content="u1"),
+            SimpleNamespace(role="user", content="u2"),
+            SimpleNamespace(role="assistant", content="a1"),
+        ],
+    )
+    service2 = ConversationSupportService(
+        conversation_repo=conversation_repo2,
+        message_repo=message_repo2,
+        title_generator=lambda *_: ("should-not-run", "llm"),
+    )
+    service2.maybe_generate_conversation_title("conv-1")
+    assert conversation_repo2.updated_titles == []
+
+
+def test_maybe_generate_conversation_title_uses_fallback_status_for_non_llm_source() -> None:
+    conversation_repo = FakeConversationRepo(conversation=FakeConversation(title_status="pending"))
+    message_repo = FakeMessageRepo(
+        messages=[
+            SimpleNamespace(role="user", content="u1"),
+            SimpleNamespace(role="assistant", content="a1"),
+        ],
+    )
+    service = ConversationSupportService(
+        conversation_repo=conversation_repo,
+        message_repo=message_repo,
+        title_generator=lambda *_: ("fallback title", "fallback"),
+    )
+
+    service.maybe_generate_conversation_title("conv-1")
+
+    assert conversation_repo.updated_titles == [("conv-1", "fallback title", "fallback", "fallback")]

--- a/tests/test_conversation_titles.py
+++ b/tests/test_conversation_titles.py
@@ -14,7 +14,7 @@ from swarmmind.models import GoalRequest, SendMessageRequest
 def setup_db(tmp_path, monkeypatch):
     """Use a temporary DB for each test."""
     db_path = str(tmp_path / "test.db")
-    monkeypatch.setenv("SWARMMIND_DB_PATH", db_path)
+    monkeypatch.setenv("SWARMMIND_DATABASE_URL", f"sqlite:///{db_path}")
     init_db()
     seed_default_agents()
     yield

--- a/tests/test_db_config.py
+++ b/tests/test_db_config.py
@@ -1,0 +1,104 @@
+"""Tests for dialect-aware database configuration."""
+
+from __future__ import annotations
+
+from swarmmind import db
+
+
+def test_database_url_takes_precedence_over_legacy_db_path(monkeypatch):
+    monkeypatch.setenv("SWARMMIND_DATABASE_URL", "postgresql+psycopg://user:pass@localhost:5432/swarmmind")
+    monkeypatch.setenv("SWARMMIND_DB_PATH", "ignored.db")
+
+    assert db._get_database_url() == "postgresql+psycopg://user:pass@localhost:5432/swarmmind"
+
+
+def test_database_url_falls_back_to_sqlite_path(monkeypatch, tmp_path):
+    monkeypatch.delenv("SWARMMIND_DATABASE_URL", raising=False)
+    monkeypatch.setenv("SWARMMIND_DB_PATH", str(tmp_path / "fallback.db"))
+
+    resolved = db._get_database_url()
+
+    assert resolved.startswith("sqlite:///")
+    assert resolved.endswith("fallback.db")
+
+
+def test_get_engine_uses_dialect_aware_options(monkeypatch):
+    calls: list[tuple[str, dict]] = []
+    listens: list[tuple[object, str, object]] = []
+
+    def fake_create_engine(url, **kwargs):
+        calls.append((url, kwargs))
+        return object()
+
+    def fake_listen(engine, event_name, callback):
+        listens.append((engine, event_name, callback))
+
+    monkeypatch.setattr(db, "create_engine", fake_create_engine)
+    monkeypatch.setattr(db.event, "listen", fake_listen)
+    db.dispose_engines()
+
+    monkeypatch.setenv("SWARMMIND_DATABASE_URL", "postgresql+psycopg://user:pass@localhost:5432/swarmmind")
+    db.get_engine()
+    assert calls[-1][0] == "postgresql+psycopg://user:pass@localhost:5432/swarmmind"
+    assert calls[-1][1] == {"pool_pre_ping": True}
+    assert listens == []
+
+    monkeypatch.setenv("SWARMMIND_DATABASE_URL", "sqlite:////tmp/swarmmind.db")
+    db.get_engine()
+    assert calls[-1][0] == "sqlite:////tmp/swarmmind.db"
+    assert calls[-1][1] == {"pool_pre_ping": True, "connect_args": {"check_same_thread": False}}
+    assert listens[-1][1] == "connect"
+    assert listens[-1][2] is db._set_sqlite_pragma
+
+
+def test_get_engine_caches_per_database_url_and_disposes_stale_engines(monkeypatch):
+    class FakeEngine:
+        def __init__(self, name: str):
+            self.name = name
+            self.dispose_calls = 0
+
+        def dispose(self):
+            self.dispose_calls += 1
+
+    calls: list[str] = []
+    created: list[FakeEngine] = []
+
+    def fake_create_engine(url, **_kwargs):
+        calls.append(url)
+        engine = FakeEngine(url)
+        created.append(engine)
+        return engine
+
+    monkeypatch.setattr(db, "create_engine", fake_create_engine)
+    monkeypatch.setattr(db.event, "listen", lambda *_args, **_kwargs: None)
+    db.dispose_engines()
+
+    monkeypatch.setenv("SWARMMIND_DATABASE_URL", "sqlite:////tmp/one.db")
+    engine_one = db.get_engine()
+    engine_one_again = db.get_engine()
+
+    assert engine_one is engine_one_again
+    assert calls == ["sqlite:////tmp/one.db"]
+
+    monkeypatch.setenv("SWARMMIND_DATABASE_URL", "sqlite:////tmp/two.db")
+    engine_two = db.get_engine()
+
+    assert engine_two is created[-1]
+    assert calls == ["sqlite:////tmp/one.db", "sqlite:////tmp/two.db"]
+    assert created[0].dispose_calls == 1
+
+
+def test_apply_schema_respects_init_mode(monkeypatch):
+    calls: list[str] = []
+
+    monkeypatch.setattr(db, "init_orm_db", lambda: calls.append("create_all"))
+    monkeypatch.setattr(db, "run_migrations_to_head", lambda: calls.append("migrate"))
+
+    monkeypatch.setenv("SWARMMIND_DB_INIT_MODE", "create_all")
+    db.apply_schema()
+    assert calls == ["create_all"]
+
+    calls.clear()
+    monkeypatch.setenv("SWARMMIND_DB_INIT_MODE", "migrate")
+    db.apply_schema()
+    assert calls == ["migrate"]

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -10,7 +10,7 @@ from swarmmind.db import init_db, seed_default_agents
 def setup_db(tmp_path, monkeypatch):
     """Use a temporary DB for each test."""
     db_path = str(tmp_path / "test.db")
-    monkeypatch.setenv("SWARMMIND_DB_PATH", db_path)
+    monkeypatch.setenv("SWARMMIND_DATABASE_URL", f"sqlite:///{db_path}")
     init_db()
     seed_default_agents()
     yield

--- a/tests/test_general_agent_prompt.py
+++ b/tests/test_general_agent_prompt.py
@@ -31,7 +31,7 @@ You are DeerFlow 2.0, an open-source super agent.
 
 def test_seed_default_agents_updates_general_identity_prompt(tmp_path, monkeypatch):
     db_path = str(tmp_path / "test.db")
-    monkeypatch.setenv("SWARMMIND_DB_PATH", db_path)
+    monkeypatch.setenv("SWARMMIND_DATABASE_URL", f"sqlite:///{db_path}")
     init_db()
 
     from swarmmind.db import get_session

--- a/tests/test_general_agent_stream_bridge.py
+++ b/tests/test_general_agent_stream_bridge.py
@@ -1,0 +1,83 @@
+"""Regression tests for the sync/async stream bridge in DeerFlowRuntimeAdapter."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from langchain_core.messages import AIMessage, AIMessageChunk
+
+from swarmmind.agents.general_agent import DeerFlowRuntimeAdapter
+
+
+def test_stream_events_yields_async_events_and_returns_final_result() -> None:
+    agent = DeerFlowRuntimeAdapter.__new__(DeerFlowRuntimeAdapter)
+
+    async def fake_astream_events(goal, ctx=None, runtime_options=None):
+        assert goal == "investigate"
+        assert ctx.session_id == "conv-1"
+        yield {"type": "assistant_message", "content": "partial"}
+        agent._last_final_text = "final answer"
+        agent._last_tool_results = ["tool:done"]
+
+    agent._astream_events = fake_astream_events
+
+    stream = agent.stream_events("investigate", ctx=SimpleNamespace(session_id="conv-1"), runtime_options=SimpleNamespace())
+    events: list[dict] = []
+    while True:
+        try:
+            events.append(next(stream))
+        except StopIteration as stop:
+            final_text, tool_results = stop.value
+            break
+
+    assert events == [{"type": "assistant_message", "content": "partial"}]
+    assert final_text == "final answer"
+    assert tool_results == ["tool:done"]
+
+
+def test_stream_events_reraises_async_failure() -> None:
+    agent = DeerFlowRuntimeAdapter.__new__(DeerFlowRuntimeAdapter)
+
+    async def fake_astream_events(goal, ctx=None, runtime_options=None):
+        raise RuntimeError("stream exploded")
+        yield  # pragma: no cover
+
+    agent._astream_events = fake_astream_events
+
+    stream = agent.stream_events("investigate", ctx=SimpleNamespace(session_id="conv-1"), runtime_options=SimpleNamespace())
+
+    try:
+        next(stream)
+    except RuntimeError as exc:
+        assert str(exc) == "stream exploded"
+    else:  # pragma: no cover
+        raise AssertionError("RuntimeError was not re-raised")
+
+
+def test_extract_reasoning_delta_prefers_additional_kwargs() -> None:
+    chunk = AIMessageChunk(content="", additional_kwargs={"reasoning_content": "step by step"})
+
+    assert DeerFlowRuntimeAdapter._extract_reasoning_delta(chunk) == "step by step"
+
+
+def test_extract_reasoning_delta_falls_back_to_thinking_blocks() -> None:
+    chunk = AIMessageChunk(content=[{"type": "thinking", "thinking": "consider option A"}])
+
+    assert DeerFlowRuntimeAdapter._extract_reasoning_delta(chunk) == "consider option A"
+
+
+def test_extract_content_delta_handles_text_blocks() -> None:
+    chunk = AIMessageChunk(content=[{"type": "text", "text": "hello"}, {"type": "text", "text": " world"}])
+
+    assert DeerFlowRuntimeAdapter._extract_content_delta(chunk) == "hello world"
+
+
+def test_extract_reasoning_collects_multiple_blocks() -> None:
+    message = AIMessage(
+        content=[
+            {"type": "thinking", "thinking": "first pass"},
+            {"type": "thinking", "thinking": "second pass"},
+        ]
+    )
+
+    assert DeerFlowRuntimeAdapter._extract_reasoning(message) == "first pass\n\nsecond pass"

--- a/tests/test_layered_memory.py
+++ b/tests/test_layered_memory.py
@@ -15,7 +15,7 @@ from swarmmind.models import MemoryContext, MemoryLayer, MemoryScope
 def setup_db(tmp_path, monkeypatch):
     """Use a temporary DB for each test."""
     db_path = str(tmp_path / "test.db")
-    monkeypatch.setenv("SWARMMIND_DB_PATH", db_path)
+    monkeypatch.setenv("SWARMMIND_DATABASE_URL", f"sqlite:///{db_path}")
     init_db()
     seed_default_agents()
     yield

--- a/tests/test_lifecycle_service.py
+++ b/tests/test_lifecycle_service.py
@@ -1,0 +1,132 @@
+"""Tests for lifecycle service startup and cleanup scanner behavior."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+import pytest
+
+from swarmmind.services.lifecycle import run_cleanup_once, run_cleanup_scanner, startup_lifecycle
+
+
+@dataclass
+class FakeProposal:
+    id: str
+    created_at: datetime
+
+
+class FakeActionProposalRepo:
+    def __init__(self, stale: list[FakeProposal] | None = None, list_error: Exception | None = None):
+        self._stale = stale or []
+        self._list_error = list_error
+        self.rejected_ids: list[str] = []
+        self.list_stale_calls: list[int] = []
+
+    def list_stale(self, timeout_seconds: int):
+        self.list_stale_calls.append(timeout_seconds)
+        if self._list_error is not None:
+            raise self._list_error
+        return self._stale
+
+    def reject_proposal(self, proposal_id: str) -> None:
+        self.rejected_ids.append(proposal_id)
+
+
+class FakeMemoryRepo:
+    def __init__(self, deleted: int = 0):
+        self.deleted = deleted
+        self.delete_calls = 0
+
+    def delete_expired(self) -> int:
+        self.delete_calls += 1
+        return self.deleted
+
+
+class FakeThread:
+    def __init__(self, target, daemon):
+        self.target = target
+        self.daemon = daemon
+        self.started = False
+
+    def start(self) -> None:
+        self.started = True
+
+
+def test_startup_lifecycle_runs_bootstrap_and_starts_cleanup_thread() -> None:
+    calls: list[str] = []
+    built_threads: list[FakeThread] = []
+
+    def fake_thread_factory(*, target, daemon):
+        thread = FakeThread(target=target, daemon=daemon)
+        built_threads.append(thread)
+        return thread
+
+    def fake_cleanup() -> None:
+        return None
+
+    startup_lifecycle(
+        init_db=lambda: calls.append("init_db"),
+        seed_default_agents=lambda: calls.append("seed_default_agents"),
+        sync_env_runtime_model=lambda: calls.append("sync_env_runtime_model"),
+        ensure_default_runtime_instance=lambda: calls.append("ensure_default_runtime_instance"),
+        cleanup_scanner=fake_cleanup,
+        api_host="127.0.0.1",
+        api_port=8000,
+        thread_factory=fake_thread_factory,
+    )
+
+    assert calls == [
+        "init_db",
+        "seed_default_agents",
+        "sync_env_runtime_model",
+        "ensure_default_runtime_instance",
+    ]
+    assert len(built_threads) == 1
+    assert built_threads[0].target is fake_cleanup
+    assert built_threads[0].daemon is True
+    assert built_threads[0].started is True
+
+
+def test_run_cleanup_once_matches_supervisor_cleanup_behavior() -> None:
+    action_repo = FakeActionProposalRepo(
+        stale=[FakeProposal(id="p-1", created_at=datetime(2026, 1, 1, 0, 0, 0)), FakeProposal(id="p-2", created_at=datetime(2026, 1, 1, 0, 1, 0))]
+    )
+    memory_repo = FakeMemoryRepo(deleted=3)
+    decisions: list[tuple[str, str]] = []
+
+    run_cleanup_once(
+        action_proposal_repo=action_repo,
+        memory_repo=memory_repo,
+        action_timeout_seconds=42,
+        record_supervisor_decision=lambda proposal_id, decision: decisions.append((proposal_id, decision)),
+        supervisor_timeout_decision="TIMEOUT",
+    )
+
+    assert action_repo.list_stale_calls == [42]
+    assert action_repo.rejected_ids == ["p-1", "p-2"]
+    assert decisions == [("p-1", "TIMEOUT"), ("p-2", "TIMEOUT")]
+    assert memory_repo.delete_calls == 1
+
+
+def test_run_cleanup_scanner_catches_iteration_errors_without_crashing() -> None:
+    action_repo = FakeActionProposalRepo(list_error=RuntimeError("boom"))
+    memory_repo = FakeMemoryRepo()
+    sleep_calls = {"count": 0}
+
+    def fake_sleep(seconds: float) -> None:
+        sleep_calls["count"] += 1
+        if sleep_calls["count"] > 1:
+            raise StopIteration("stop test loop")
+
+    with pytest.raises(StopIteration):
+        run_cleanup_scanner(
+            action_proposal_repo=action_repo,
+            memory_repo=memory_repo,
+            action_timeout_seconds=30,
+            record_supervisor_decision=lambda *_: None,
+            supervisor_timeout_decision="TIMEOUT",
+            sleeper=fake_sleep,
+        )
+
+    assert action_repo.list_stale_calls == [30]

--- a/tests/test_memory_repository.py
+++ b/tests/test_memory_repository.py
@@ -1,0 +1,68 @@
+"""Tests for dialect-agnostic memory repository behavior."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+
+from swarmmind.db import get_session, init_db, seed_default_agents
+from swarmmind.db_models import MemoryEntryDB
+from swarmmind.models import MemoryLayer, MemoryScope
+from swarmmind.repositories.memory import MemoryRepository
+from swarmmind.time_utils import utc_now
+
+
+@pytest.fixture(autouse=True)
+def setup_db(tmp_path, monkeypatch):
+    db_path = str(tmp_path / "test.db")
+    monkeypatch.setenv("SWARMMIND_DATABASE_URL", f"sqlite:///{db_path}")
+    init_db()
+    seed_default_agents()
+    yield
+
+
+def test_delete_expired_removes_only_elapsed_ttl_entries() -> None:
+    repo = MemoryRepository()
+    scope = MemoryScope(layer=MemoryLayer.TMP, scope_id="session-1")
+
+    expired = repo.write(
+        scope=scope,
+        key="expired-key",
+        value="expired",
+        tags=["temp"],
+        ttl=60,
+        agent_id="finance",
+    )
+    fresh = repo.write(
+        scope=scope,
+        key="fresh-key",
+        value="fresh",
+        tags=["temp"],
+        ttl=600,
+        agent_id="finance",
+    )
+
+    session = get_session()
+    try:
+        expired_row = session.get(MemoryEntryDB, expired.id)
+        fresh_row = session.get(MemoryEntryDB, fresh.id)
+        assert expired_row is not None
+        assert fresh_row is not None
+
+        expired_row.created_at = utc_now() - timedelta(seconds=120)
+        fresh_row.created_at = utc_now() - timedelta(seconds=30)
+        session.commit()
+    finally:
+        session.close()
+
+    deleted = repo.delete_expired()
+
+    assert deleted == 1
+
+    session = get_session()
+    try:
+        assert session.get(MemoryEntryDB, expired.id) is None
+        assert session.get(MemoryEntryDB, fresh.id) is not None
+    finally:
+        session.close()

--- a/tests/test_runtime_model_catalog.py
+++ b/tests/test_runtime_model_catalog.py
@@ -19,7 +19,7 @@ from swarmmind.runtime.catalog import (
 @pytest.fixture(autouse=True)
 def setup_db(tmp_path, monkeypatch):
     db_path = str(tmp_path / "test.db")
-    monkeypatch.setenv("SWARMMIND_DB_PATH", db_path)
+    monkeypatch.setenv("SWARMMIND_DATABASE_URL", f"sqlite:///{db_path}")
     monkeypatch.setenv("LLM_PROVIDER", "openai")
     monkeypatch.setenv("LLM_MODEL", "qwen3.5-plus")
     monkeypatch.setenv("OPENAI_API_KEY", "test-openai-key")

--- a/tests/test_runtime_support.py
+++ b/tests/test_runtime_support.py
@@ -1,0 +1,168 @@
+"""Tests for runtime support helpers extracted from supervisor."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+from fastapi import HTTPException
+
+from swarmmind.models import ConversationMode, SendMessageRequest
+from swarmmind.runtime import RuntimeConfigError, RuntimeExecutionError, RuntimeUnavailableError
+from swarmmind.services.runtime_support import (
+    RuntimeSupportService,
+    conversation_thread_id,
+    format_runtime_error,
+    normalize_model_name,
+)
+
+
+class FakeConversationRepo:
+    def __init__(self) -> None:
+        self.update_calls: list[tuple[str, str | None, str | None, str | None]] = []
+
+    def update_runtime(
+        self,
+        conversation_id: str,
+        runtime_profile_id: str | None,
+        runtime_instance_id: str | None,
+        thread_id: str | None,
+    ) -> None:
+        self.update_calls.append((conversation_id, runtime_profile_id, runtime_instance_id, thread_id))
+
+
+@dataclass
+class FakeRuntimeInstance:
+    runtime_profile_id: str
+    runtime_instance_id: str
+
+
+@dataclass
+class FakeModelSelection:
+    name: str
+
+
+def test_normalize_model_name_behavior() -> None:
+    assert normalize_model_name(None) is None
+    assert normalize_model_name("") is None
+    assert normalize_model_name("   ") is None
+    assert normalize_model_name("  gpt-4o-mini ") == "gpt-4o-mini"
+
+
+def test_conversation_thread_id_passthrough() -> None:
+    assert conversation_thread_id("conv-123") == "conv-123"
+
+
+def test_format_runtime_error_behavior() -> None:
+    assert format_runtime_error(RuntimeConfigError("bad config")) == "DeerFlow Runtime error: bad config"
+    assert format_runtime_error(RuntimeUnavailableError("offline")) == "DeerFlow Runtime error: offline"
+    assert format_runtime_error(RuntimeExecutionError("boom")) == "DeerFlow Runtime error: boom"
+    assert format_runtime_error(ValueError("unexpected")) == "Unexpected DeerFlow execution error: unexpected"
+
+
+def test_resolve_model_name_for_request_success_and_params() -> None:
+    repo = FakeConversationRepo()
+    seen: dict[str, str | None] = {}
+
+    def fake_resolve_model_for_subject(**kwargs):
+        seen["requested_model_name"] = kwargs["requested_model_name"]
+        seen["subject_type"] = kwargs["subject_type"]
+        seen["subject_id"] = kwargs["subject_id"]
+        return FakeModelSelection(name="resolved-model")
+
+    service = RuntimeSupportService(
+        conversation_repo=repo,  # type: ignore[arg-type]
+        resolve_model_for_subject_fn=fake_resolve_model_for_subject,
+        subject_type="anon_type",
+        subject_id="anon_id",
+    )
+
+    model_name = service.resolve_model_name_for_request("  requested-model  ")
+
+    assert model_name == "resolved-model"
+    assert seen == {
+        "requested_model_name": "requested-model",
+        "subject_type": "anon_type",
+        "subject_id": "anon_id",
+    }
+
+
+def test_resolve_model_name_for_request_runtime_config_error_status_codes() -> None:
+    repo = FakeConversationRepo()
+
+    def fake_resolve_model_for_subject(**_kwargs):
+        raise RuntimeConfigError("invalid runtime setup")
+
+    service = RuntimeSupportService(
+        conversation_repo=repo,  # type: ignore[arg-type]
+        resolve_model_for_subject_fn=fake_resolve_model_for_subject,
+    )
+
+    with pytest.raises(HTTPException) as specified_exc:
+        service.resolve_model_name_for_request("specified-model")
+    assert specified_exc.value.status_code == 400
+    assert specified_exc.value.detail == "invalid runtime setup"
+
+    with pytest.raises(HTTPException) as default_exc:
+        service.resolve_model_name_for_request("   ")
+    assert default_exc.value.status_code == 503
+    assert default_exc.value.detail == "invalid runtime setup"
+
+
+def test_bind_conversation_runtime_updates_repository() -> None:
+    repo = FakeConversationRepo()
+
+    def fake_ensure_runtime():
+        return FakeRuntimeInstance(
+            runtime_profile_id="profile-1",
+            runtime_instance_id="instance-1",
+        )
+
+    service = RuntimeSupportService(
+        conversation_repo=repo,  # type: ignore[arg-type]
+        ensure_default_runtime_instance_fn=fake_ensure_runtime,
+    )
+
+    runtime_instance, thread_id = service.bind_conversation_runtime("conv-1")
+
+    assert runtime_instance.runtime_profile_id == "profile-1"
+    assert runtime_instance.runtime_instance_id == "instance-1"
+    assert thread_id == "conv-1"
+    assert repo.update_calls == [("conv-1", "profile-1", "instance-1", "conv-1")]
+
+
+def test_resolve_runtime_options_behavior() -> None:
+    repo = FakeConversationRepo()
+
+    def fake_resolve_model_for_subject(**_kwargs):
+        return FakeModelSelection(name="resolved-default")
+
+    service = RuntimeSupportService(
+        conversation_repo=repo,  # type: ignore[arg-type]
+        resolve_model_for_subject_fn=fake_resolve_model_for_subject,
+    )
+
+    flash = service.resolve_runtime_options(
+        SendMessageRequest(content="hello", reasoning=False, mode=None, model_name=None),
+    )
+    assert flash.mode == ConversationMode.FLASH
+    assert flash.model_name == "resolved-default"
+    assert flash.thinking_enabled is False
+    assert flash.plan_mode is False
+    assert flash.subagent_enabled is False
+
+    thinking = service.resolve_runtime_options(
+        SendMessageRequest(content="hello", reasoning=True, mode=None, model_name=None),
+    )
+    assert thinking.mode == ConversationMode.THINKING
+    assert thinking.thinking_enabled is True
+    assert thinking.plan_mode is False
+    assert thinking.subagent_enabled is False
+
+    ultra = service.resolve_runtime_options(
+        SendMessageRequest(content="hello", mode=ConversationMode.ULTRA, model_name="x"),
+    )
+    assert ultra.mode == ConversationMode.ULTRA
+    assert ultra.thinking_enabled is True
+    assert ultra.plan_mode is True
+    assert ultra.subagent_enabled is True

--- a/tests/test_shared_memory.py
+++ b/tests/test_shared_memory.py
@@ -9,7 +9,7 @@ from swarmmind.shared_memory import SharedMemory
 @pytest.fixture(autouse=True)
 def setup_db(tmp_path, monkeypatch):
     db_path = str(tmp_path / "test.db")
-    monkeypatch.setenv("SWARMMIND_DB_PATH", db_path)
+    monkeypatch.setenv("SWARMMIND_DATABASE_URL", f"sqlite:///{db_path}")
     init_db()
     seed_default_agents()
     yield

--- a/tests/test_stream_events.py
+++ b/tests/test_stream_events.py
@@ -1,0 +1,183 @@
+"""Unit tests for stream event translation helpers."""
+
+from __future__ import annotations
+
+import json
+
+from swarmmind.models import ConversationMode, ConversationRuntimeOptions
+from swarmmind.services.stream_events import (
+    general_agent_status_labels,
+    serialize_stream_event,
+    task_card_title,
+    task_status_from_result,
+    tool_activity_label,
+    translate_general_agent_event,
+)
+
+
+def _opts(mode: ConversationMode, *, thinking: bool, subagent: bool, plan_mode: bool = False) -> ConversationRuntimeOptions:
+    return ConversationRuntimeOptions(
+        mode=mode,
+        model_name="test-model",
+        thinking_enabled=thinking,
+        plan_mode=plan_mode,
+        subagent_enabled=subagent,
+    )
+
+
+def test_serialize_stream_event_outputs_ndjson_line():
+    line = serialize_stream_event("assistant_message", message_id="m1", content="hello")
+    assert line.endswith("\n")
+    assert json.loads(line) == {"type": "assistant_message", "message_id": "m1", "content": "hello"}
+
+
+def test_tool_activity_label_and_task_helpers_match_existing_behavior():
+    assert tool_activity_label("search", {"query": "  abc  "}) == "检索资料：abc"
+    assert tool_activity_label("search", {}) == "检索外部资料"
+    assert tool_activity_label("unknown_tool") == "执行工具：unknown_tool"
+
+    assert task_card_title({"description": "  收集信息  "}) == "收集信息"
+    assert task_card_title({"prompt": "第一行\n第二行"}) == "第一行"
+    assert task_card_title(None) == "新的协作分工"
+
+    assert task_status_from_result("Task Succeeded. Result: done") == ("completed", "done")
+    assert task_status_from_result("Task failed. reason") == ("failed", "reason")
+    assert task_status_from_result("Task timed out after 60s") == ("failed", "Task timed out after 60s")
+    assert task_status_from_result("keep running") == ("running", "keep running")
+
+
+def test_general_agent_status_labels_by_mode():
+    assert general_agent_status_labels(_opts(ConversationMode.ULTRA, thinking=True, subagent=True)) == (
+        "Agent Team 正在判断这轮探索需要怎样的协作方式",
+        "Agent Team 正在协作处理你的问题",
+    )
+    assert general_agent_status_labels(_opts(ConversationMode.PRO, thinking=True, subagent=False)) == (
+        "正在规划这轮任务的执行方式",
+        "正在按规划生成结果",
+    )
+    assert general_agent_status_labels(_opts(ConversationMode.THINKING, thinking=True, subagent=False)) == (
+        "正在分析你的问题",
+        "正在整理深入回复",
+    )
+    assert general_agent_status_labels(_opts(ConversationMode.FLASH, thinking=False, subagent=False)) == (
+        "正在准备快速回复",
+        "正在快速生成结果",
+    )
+
+
+def test_translate_reasoning_and_assistant_message_respects_runtime_flags():
+    flash = _opts(ConversationMode.FLASH, thinking=False, subagent=False)
+    thinking = _opts(ConversationMode.THINKING, thinking=True, subagent=False)
+
+    assert (
+        translate_general_agent_event(
+            {"type": "assistant_reasoning", "message_id": "r1", "content": "thinking..."},
+            flash,
+        )
+        == []
+    )
+
+    reasoning_lines = translate_general_agent_event(
+        {"type": "assistant_reasoning", "message_id": "r1", "content": "thinking..."},
+        thinking,
+    )
+    assert json.loads(reasoning_lines[0]) == {"type": "thinking", "message_id": "r1", "content": "thinking..."}
+
+    assistant_lines = translate_general_agent_event(
+        {"type": "assistant_message", "message_id": "a1", "content": "answer"},
+        flash,
+    )
+    assert json.loads(assistant_lines[0]) == {"type": "assistant_message", "message_id": "a1", "content": "answer"}
+
+
+def test_translate_tool_calls_and_tool_results_for_ultra_mode():
+    ultra = _opts(ConversationMode.ULTRA, thinking=True, subagent=True, plan_mode=True)
+
+    tool_call_lines = translate_general_agent_event(
+        {
+            "type": "assistant_tool_calls",
+            "tool_calls": [
+                {"name": "task", "args": {"description": "收集竞品资料"}, "id": "task-1"},
+                {"name": "search", "args": {"query": "crm mvp"}, "id": "search-1"},
+            ],
+        },
+        ultra,
+    )
+    task_line = json.loads(tool_call_lines[0])
+    activity_line = json.loads(tool_call_lines[1])
+    assert task_line["type"] == "team_task"
+    assert task_line["task"]["id"] == "task-1"
+    assert task_line["task"]["status"] == "running"
+    assert activity_line["type"] == "team_activity"
+    assert activity_line["activity"]["id"] == "search-1"
+    assert activity_line["activity"]["status"] == "running"
+
+    task_result = translate_general_agent_event(
+        {
+            "type": "tool_result",
+            "tool_name": "task",
+            "tool_call_id": "task-1",
+            "content": "Task Succeeded. Result: 已完成",
+        },
+        ultra,
+    )
+    parsed_task_result = json.loads(task_result[0])
+    assert parsed_task_result["type"] == "team_task"
+    assert parsed_task_result["task"]["status"] == "completed"
+    assert parsed_task_result["task"]["detail"] == "已完成"
+
+    activity_result = translate_general_agent_event(
+        {
+            "type": "tool_result",
+            "tool_name": "search",
+            "tool_call_id": "search-1",
+            "content": "找到了 5 个相关来源",
+        },
+        ultra,
+    )
+    parsed_activity_result = json.loads(activity_result[0])
+    assert parsed_activity_result["type"] == "team_activity"
+    assert parsed_activity_result["activity"]["id"] == "search-1"
+    assert parsed_activity_result["activity"]["status"] == "completed"
+    assert parsed_activity_result["activity"]["detail"] == "找到了 5 个相关来源"
+
+
+def test_translate_clarification_and_custom_events():
+    flash = _opts(ConversationMode.FLASH, thinking=False, subagent=False)
+    ultra = _opts(ConversationMode.ULTRA, thinking=True, subagent=True, plan_mode=True)
+
+    clarification_lines = translate_general_agent_event(
+        {
+            "type": "tool_result",
+            "tool_name": "ask_clarification",
+            "tool_call_id": "clarify-1",
+            "content": "请提供目标用户信息",
+        },
+        flash,
+    )
+    assert json.loads(clarification_lines[0]) == {
+        "type": "clarification_request",
+        "clarification": {"id": "clarify-1", "content": "请提供目标用户信息"},
+    }
+
+    started = translate_general_agent_event(
+        {"type": "custom_event", "event_type": "task_started", "task_id": "t1", "description": "desc"},
+        ultra,
+    )
+    running = translate_general_agent_event(
+        {"type": "custom_event", "event_type": "task_running", "task_id": "t1", "message": "working"},
+        ultra,
+    )
+    completed = translate_general_agent_event(
+        {"type": "custom_event", "event_type": "task_completed", "task_id": "t1", "result": "ok"},
+        ultra,
+    )
+    failed = translate_general_agent_event(
+        {"type": "custom_event", "event_type": "task_failed", "task_id": "t1", "error": "boom"},
+        ultra,
+    )
+
+    assert json.loads(started[0])["type"] == "task_started"
+    assert json.loads(running[0])["type"] == "task_running"
+    assert json.loads(completed[0])["type"] == "task_completed"
+    assert json.loads(failed[0])["type"] == "task_failed"

--- a/tests/test_trace_service.py
+++ b/tests/test_trace_service.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from swarmmind.services.trace_service import TraceService
+from swarmmind.services.trace_service import LEGACY_DEFAULT_CHECKPOINTER_PATH, TraceService
 
 
 @pytest.fixture
@@ -135,10 +135,35 @@ def temp_checkpointer_db():
 class TestTraceService:
     """Test TraceService collaboration trace reconstruction."""
 
-    def test_service_initialization(self):
-        """Test TraceService can be initialized with default path."""
+    def test_service_initialization_uses_legacy_default_without_runtime_env(self, monkeypatch):
+        """Test TraceService keeps the legacy repo-local fallback without runtime env."""
+        monkeypatch.delenv("DEER_FLOW_HOME", raising=False)
         service = TraceService()
-        assert service.checkpointer_path is not None
+
+        assert service.checkpointer_path == LEGACY_DEFAULT_CHECKPOINTER_PATH
+
+    def test_service_initialization_uses_runtime_home_parent_checkpoint_path(self, monkeypatch, tmp_path):
+        """Test TraceService follows SwarmMind runtime bundle layout under DEER_FLOW_HOME/home."""
+        runtime_root = tmp_path / "runtime-instance"
+        runtime_home = runtime_root / "home"
+        runtime_home.mkdir(parents=True)
+        monkeypatch.setenv("DEER_FLOW_HOME", str(runtime_home))
+
+        service = TraceService()
+
+        assert service.checkpointer_path == runtime_root / "checkpoints.db"
+
+    def test_service_initialization_prefers_existing_runtime_home_checkpoint(self, monkeypatch, tmp_path):
+        """Test TraceService uses an existing checkpoints.db inside DEER_FLOW_HOME."""
+        runtime_home = tmp_path / "custom-home"
+        runtime_home.mkdir(parents=True)
+        expected_path = runtime_home / "checkpoints.db"
+        expected_path.touch()
+        monkeypatch.setenv("DEER_FLOW_HOME", str(runtime_home))
+
+        service = TraceService()
+
+        assert service.checkpointer_path == expected_path
 
     def test_service_initialization_with_custom_path(self):
         """Test TraceService can be initialized with custom path."""

--- a/tests/test_working_memory_repository.py
+++ b/tests/test_working_memory_repository.py
@@ -1,0 +1,52 @@
+"""Tests for WorkingMemoryRepository compatibility behavior."""
+
+import pytest
+
+from swarmmind.db import init_db, seed_default_agents
+from swarmmind.repositories.working_memory import WorkingMemoryRepository
+
+
+@pytest.fixture(autouse=True)
+def setup_db(tmp_path, monkeypatch):
+    db_path = str(tmp_path / "test.db")
+    monkeypatch.setenv("SWARMMIND_DATABASE_URL", f"sqlite:///{db_path}")
+    init_db()
+    seed_default_agents()
+    yield
+
+
+class TestWorkingMemoryRepository:
+    def test_write_and_read_match_shared_memory_semantics(self):
+        repo = WorkingMemoryRepository()
+
+        repo.write("test_key", "test_value", "finance,q3", "finance")
+        result = repo.read("test_key")
+
+        assert result is not None
+        assert result["value"] == "test_value"
+        assert result["last_writer_agent_id"] == "finance"
+        assert "q3" in result["domain_tags"]
+
+    def test_write_preserves_existing_tags_when_domain_tags_is_none(self):
+        repo = WorkingMemoryRepository()
+
+        repo.write("tagged_key", "value1", "finance,q3", "finance")
+        repo.write("tagged_key", "value2", None, "code_review")
+        result = repo.read("tagged_key")
+
+        assert result is not None
+        assert result["value"] == "value2"
+        assert result["domain_tags"] == "finance,q3"
+        assert result["last_writer_agent_id"] == "code_review"
+
+    def test_read_all_by_tag_and_read_all_delegate_consistently(self):
+        repo = WorkingMemoryRepository()
+
+        repo.write("finance_key", "value1", "finance", "finance")
+        repo.write("revenue_key", "value2", "revenue", "finance")
+
+        finance_results = repo.read_all_by_tag("finance")
+        all_results = repo.read_all()
+
+        assert any(item["key"] == "finance_key" for item in finance_results)
+        assert {item["key"] for item in all_results} >= {"finance_key", "revenue_key"}


### PR DESCRIPTION
## Summary
- split supervisor responsibilities into focused services and formalize message tool fields in ORM + Alembic
- make database/bootstrap and trace paths more runtime-configurable instead of relying on fixed local assumptions
- retire duplicate working-memory behavior by routing the repository through SharedMemory as the single implementation truth
- replace clarification middleware stdout debugging with structured logging and add focused runtime/middleware regression tests

## Validation
- uv run ruff check swarmmind tests
- make test

## Notes
- branch contains three commits so docs and code debt paydown stay reviewable
- final merge will be followed by syncing local main to remote main exactly