### PR TITLE
test: harden renderer and proposal repository behavior

### DIFF
--- a/swarmmind/renderer.py
+++ b/swarmmind/renderer.py
@@ -30,7 +30,7 @@ def render_status(goal: str, ctx: MemoryContext | None = None, reasoning: bool =
     if not entries:
         return f"当前还没有与“{_collapse_whitespace(goal)}”相关的共享上下文。"
 
-    latest_entries = entries[-5:]
+    latest_entries = entries[:5]
     fragments = [f"{entry.key}: {_collapse_whitespace(entry.value)[:120]}" for entry in latest_entries]
     return (
         f"围绕“{_collapse_whitespace(goal)}”当前已沉淀 {len(entries)} 条共享上下文。"

--- a/swarmmind/services/trace_service.py
+++ b/swarmmind/services/trace_service.py
@@ -123,16 +123,20 @@ class TraceService:
         try:
             cursor = conn.cursor()
             # 复用 SqliteSaver 的查询模式
-            cursor.execute(
-                """
-                SELECT thread_id, checkpoint_id, parent_checkpoint_id, type, 
-                       checkpoint, metadata
-                FROM checkpoints 
-                WHERE thread_id = ? AND checkpoint_ns = ''
-                ORDER BY checkpoint_id ASC
-                """,
-                (thread_id,),
-            )
+            try:
+                cursor.execute(
+                    """
+                    SELECT thread_id, checkpoint_id, parent_checkpoint_id, type, 
+                           checkpoint, metadata
+                    FROM checkpoints 
+                    WHERE thread_id = ? AND checkpoint_ns = ''
+                    ORDER BY checkpoint_id ASC
+                    """,
+                    (thread_id,),
+                )
+            except sqlite3.OperationalError as exc:
+                logger.warning("Checkpoint query failed for thread %s at %s: %s", thread_id, self.checkpointer_path, exc)
+                return []
 
             checkpoints = []
             for row in cursor.fetchall():

--- a/tests/test_action_proposal_repository.py
+++ b/tests/test_action_proposal_repository.py
@@ -1,0 +1,127 @@
+"""Tests for ActionProposalRepository behavior."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+from fastapi import HTTPException
+
+from swarmmind.db import init_db, seed_default_agents, session_scope
+from swarmmind.db_models import ActionProposalDB
+from swarmmind.models import ProposalStatus
+from swarmmind.repositories.action_proposal import ActionProposalRepository
+from swarmmind.time_utils import utc_now
+
+
+@pytest.fixture
+def action_repo(tmp_path, monkeypatch) -> ActionProposalRepository:
+    db_path = tmp_path / "action-proposals.db"
+    monkeypatch.setenv("SWARMMIND_DATABASE_URL", f"sqlite:///{db_path}")
+    init_db()
+    seed_default_agents()
+    return ActionProposalRepository()
+
+
+def test_create_and_get_roundtrip_serializes_conditions(action_repo: ActionProposalRepository) -> None:
+    proposal = action_repo.create(
+        agent_id="general",
+        description="analyze q3 report",
+        target_resource="report.md",
+        preconditions={"source": "uploaded_csv"},
+        postconditions={"artifact": "summary.md"},
+        confidence=0.9,
+    )
+
+    loaded = action_repo.get(proposal.id)
+
+    assert loaded is not None
+    assert loaded.description == "analyze q3 report"
+    assert loaded.target_resource == "report.md"
+    assert loaded.preconditions == {"source": "uploaded_csv"}
+    assert loaded.postconditions == {"artifact": "summary.md"}
+    assert loaded.confidence == 0.9
+    assert loaded.status == ProposalStatus.PENDING
+
+
+def test_update_result_persists_description_target_and_confidence(action_repo: ActionProposalRepository) -> None:
+    proposal = action_repo.create(agent_id="general", description="draft")
+
+    action_repo.update_result(
+        proposal.id,
+        description="final summary",
+        target_resource="output.md",
+        confidence=0.75,
+    )
+
+    loaded = action_repo.get(proposal.id)
+    assert loaded is not None
+    assert loaded.description == "final summary"
+    assert loaded.target_resource == "output.md"
+    assert loaded.confidence == 0.75
+    assert loaded.status == ProposalStatus.PENDING
+
+
+def test_approve_and_reject_proposal_enforce_pending_state(action_repo: ActionProposalRepository) -> None:
+    approved = action_repo.create(agent_id="general", description="approve me")
+    rejected = action_repo.create(agent_id="general", description="reject me")
+
+    action_repo.approve(approved.id)
+    action_repo.reject_proposal(rejected.id)
+
+    assert action_repo.get(approved.id).status == ProposalStatus.APPROVED
+    assert action_repo.get(rejected.id).status == ProposalStatus.REJECTED
+
+    with pytest.raises(HTTPException) as approved_exc:
+        action_repo.approve(approved.id)
+    assert approved_exc.value.status_code == 409
+
+    with pytest.raises(HTTPException) as rejected_exc:
+        action_repo.reject_proposal(rejected.id)
+    assert rejected_exc.value.status_code == 409
+
+
+def test_approve_missing_proposal_raises_404(action_repo: ActionProposalRepository) -> None:
+    with pytest.raises(HTTPException) as exc:
+        action_repo.approve("missing")
+
+    assert exc.value.status_code == 404
+
+
+def test_list_pending_and_list_stale_filter_by_status_and_age(action_repo: ActionProposalRepository) -> None:
+    oldest = action_repo.create(agent_id="general", description="oldest")
+    middle = action_repo.create(agent_id="general", description="middle")
+    newest = action_repo.create(agent_id="general", description="newest")
+    approved = action_repo.create(agent_id="general", description="approved")
+    action_repo.approve(approved.id)
+
+    stale_time = utc_now() - timedelta(seconds=120)
+    less_stale_time = utc_now() - timedelta(seconds=61)
+
+    with session_scope() as session:
+        oldest_db = session.get(ActionProposalDB, oldest.id)
+        middle_db = session.get(ActionProposalDB, middle.id)
+        newest_db = session.get(ActionProposalDB, newest.id)
+        assert oldest_db and middle_db and newest_db
+        oldest_db.created_at = stale_time
+        middle_db.created_at = less_stale_time
+        newest_db.created_at = utc_now()
+
+    page, total = action_repo.list_pending(limit=2, offset=0)
+
+    assert total == 3
+    assert [item.id for item in page] == [oldest.id, middle.id]
+
+    stale = action_repo.list_stale(timeout_seconds=60)
+    assert [item.id for item in stale] == [oldest.id, middle.id]
+
+
+def test_reject_sets_description(action_repo: ActionProposalRepository) -> None:
+    proposal = action_repo.create(agent_id="general", description="initial")
+
+    action_repo.reject(proposal.id, "runtime failed")
+
+    loaded = action_repo.get(proposal.id)
+    assert loaded is not None
+    assert loaded.status == ProposalStatus.REJECTED
+    assert loaded.description == "runtime failed"

--- a/tests/test_clarification_middleware.py
+++ b/tests/test_clarification_middleware.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-import logging
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 from langchain_core.messages import ToolMessage
@@ -28,7 +27,7 @@ def _build_request(*, name: str, args: dict | None = None, tool_call_id: str = "
     )
 
 
-def test_wrap_tool_call_intercepts_ask_clarification(caplog: pytest.LogCaptureFixture) -> None:
+def test_wrap_tool_call_intercepts_ask_clarification() -> None:
     middleware = ClarificationMiddleware()
     request = _build_request(
         name="ask_clarification",
@@ -42,7 +41,7 @@ def test_wrap_tool_call_intercepts_ask_clarification(caplog: pytest.LogCaptureFi
     )
     handler = Mock(side_effect=AssertionError("clarification requests should be intercepted"))
 
-    with caplog.at_level(logging.INFO):
+    with patch("swarmmind.agents.middlewares.clarification_middleware.logger") as mock_logger:
         result = middleware.wrap_tool_call(request, handler)
 
     assert isinstance(result, Command)
@@ -54,8 +53,11 @@ def test_wrap_tool_call_intercepts_ask_clarification(caplog: pytest.LogCaptureFi
     assert message.name == "ask_clarification"
     assert message.content == "❓ 当前需求缺少核心用户画像。\n\n请确认目标用户是谁？\n\n  1. 企业销售\n  2. 运营团队"
     handler.assert_not_called()
-    assert "tool_call_id=clarify-sync" in caplog.text
-    assert "clarification_type=missing_info" in caplog.text
+    mock_logger.info.assert_called_once()
+    log_args = mock_logger.info.call_args[0]
+    assert "Intercepted clarification request:" in log_args[0]
+    assert log_args[1] == "clarify-sync"
+    assert log_args[2] == "missing_info"
 
 
 @pytest.mark.asyncio

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -1,0 +1,69 @@
+"""Tests for deterministic render helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+
+from swarmmind.models import MemoryContext
+from swarmmind.renderer import (
+    generate_conversation_title,
+    generate_conversation_title_from_exchange,
+    render_status,
+)
+
+
+def test_render_status_returns_empty_context_message(monkeypatch) -> None:
+    class FakeMemory:
+        def __init__(self, agent_id: str) -> None:
+            assert agent_id == "status_renderer"
+
+        def read_all(self, ctx=None):
+            return []
+
+    monkeypatch.setattr("swarmmind.renderer.LayeredMemory", FakeMemory)
+
+    summary = render_status("  分析   本周   销售  ", ctx=MemoryContext(user_id="u-1", session_id="s-1"))
+
+    assert summary == "当前还没有与“分析 本周 销售”相关的共享上下文。"
+
+
+def test_render_status_uses_latest_five_entries_in_desc_order(monkeypatch) -> None:
+    entries = [
+        SimpleNamespace(key=f"k{i}", value=f"value {i}", created_at=datetime(2026, 1, i + 1, 0, 0, 0))
+        for i in range(7, 0, -1)
+    ]
+
+    class FakeMemory:
+        def __init__(self, agent_id: str) -> None:
+            assert agent_id == "status_renderer"
+
+        def read_all(self, ctx=None):
+            return entries
+
+    monkeypatch.setattr("swarmmind.renderer.LayeredMemory", FakeMemory)
+
+    summary = render_status("季度复盘", ctx=MemoryContext(user_id="u-1", session_id="s-1"))
+
+    assert "当前已沉淀 7 条共享上下文" in summary
+    for key in ("k7", "k6", "k5", "k4", "k3"):
+        assert key in summary
+    for key in ("k2", "k1"):
+        assert key not in summary
+
+
+def test_generate_conversation_title_trims_and_truncates() -> None:
+    title = generate_conversation_title(
+        "   这是一个   很长很长很长很长很长很长很长很长很长很长很长很长很长很长很长很长 的问题，需要被整理成标题，并且要继续补充更多背景信息   "
+    )
+
+    assert title.endswith("...")
+    assert len(title) <= 50
+    assert "  " not in title
+
+
+def test_generate_conversation_title_from_exchange_is_deterministic_fallback() -> None:
+    title, source = generate_conversation_title_from_exchange("  帮我总结今天的 standup  ", "好的")
+
+    assert title == "帮我总结今天的 standup"
+    assert source == "fallback"

--- a/tests/test_trace_service.py
+++ b/tests/test_trace_service.py
@@ -180,6 +180,21 @@ class TestTraceService:
         assert trace["events"] == []
         assert trace["checkpoint_count"] == 0
 
+    def test_get_trace_returns_empty_when_checkpoints_table_is_missing(self, tmp_path):
+        """Test get_conversation_trace degrades gracefully if upstream schema is absent."""
+        db_path = tmp_path / "missing-table.db"
+        conn = sqlite3.connect(db_path)
+        conn.execute("CREATE TABLE unrelated (id INTEGER PRIMARY KEY)")
+        conn.commit()
+        conn.close()
+
+        service = TraceService(str(db_path))
+        trace = service.get_conversation_trace("any-thread")
+
+        assert trace["status"] == "empty"
+        assert trace["events"] == []
+        assert trace["checkpoint_count"] == 0
+
     def test_get_trace_reconstructs_events(self, temp_checkpointer_db):
         """Test get_conversation_trace correctly reconstructs events from checkpoints."""
         service = TraceService(temp_checkpointer_db)


### PR DESCRIPTION
## Summary
- fix renderer status rendering so it summarizes the newest five memory entries instead of older ones
- add focused repository coverage for action proposal create/update/approve/reject/pending/stale behavior
- make trace service degrade cleanly when the upstream checkpoints table is missing
- harden clarification middleware logging assertions so full-suite logging config does not make tests flaky

## Validation
- uv run ruff check swarmmind tests
- make test