### PR TITLE
Repay trace and chat workspace tech debt

### DIFF
--- a/swarmmind/agents/general_agent.py
+++ b/swarmmind/agents/general_agent.py
@@ -22,7 +22,7 @@ from swarmmind.models import ActionProposal, ConversationRuntimeOptions, MemoryC
 from swarmmind.prompting import rewrite_swarmmind_identity_prompt
 from swarmmind.runtime import RuntimeExecutionError, ensure_default_runtime_instance
 from swarmmind.runtime.models import RuntimeInstance
-from swarmmind.services.runtime_bridge import iter_async_generator_in_thread
+from swarmmind.services.runtime_bridge import iter_async_generator_in_thread, run_coroutine_blocking
 
 logger = logging.getLogger(__name__)
 
@@ -439,18 +439,22 @@ class DeerFlowRuntimeAdapter(BaseAgent):
         ctx: MemoryContext | None = None,
         runtime_options: ConversationRuntimeOptions | None = None,
     ) -> tuple[str, list[str]]:
-        final_text = ""
-        tool_results: list[str] = []
+        return run_coroutine_blocking(
+            lambda: self._acollect_turn(goal, ctx=ctx, runtime_options=runtime_options),
+            thread_name="deerflow-act",
+            join_timeout=5.0,
+            bridge_logger=logger,
+        )
 
-        stream = self.stream_events(goal, ctx=ctx, runtime_options=runtime_options)
-        while True:
-            try:
-                next(stream)
-            except StopIteration as stop:
-                final_text, tool_results = stop.value
-                break
-
-        return final_text, tool_results
+    async def _acollect_turn(
+        self,
+        goal: str,
+        ctx: MemoryContext | None = None,
+        runtime_options: ConversationRuntimeOptions | None = None,
+    ) -> tuple[str, list[str]]:
+        async for _ in self._astream_events(goal, ctx=ctx, runtime_options=runtime_options):
+            pass
+        return self._last_final_text, self._last_tool_results
 
     def _process_messages_mode_chunk(
         self,

--- a/swarmmind/api/supervisor.py
+++ b/swarmmind/api/supervisor.py
@@ -47,6 +47,7 @@ from swarmmind.services.conversation_support import (
     ConversationSupportService,
     generate_title_with_deerflow,
 )
+from swarmmind.services.conversation_trace_service import ConversationTraceService
 from swarmmind.services.lifecycle import run_cleanup_scanner, startup_lifecycle
 from swarmmind.services.runtime_support import RuntimeSupportService
 from swarmmind.services.stream_events import (
@@ -79,6 +80,7 @@ conversation_support = ConversationSupportService(
     title_generator=generate_title_with_deerflow,
 )
 runtime_support = RuntimeSupportService(conversation_repo=conversation_repo)
+conversation_trace_service = ConversationTraceService(conversation_repo=conversation_repo)
 
 
 def _generate_title_with_deerflow(user_msg: str, assistant_msg: str) -> tuple[str, str]:
@@ -447,27 +449,7 @@ def get_conversation_trace(conversation_id: str) -> dict:
     Returns:
         Collaboration trace with events, status, and summary.
     """
-    # 延迟导入，避免循环依赖
-    from swarmmind.services.trace_service import trace_service
-
-    conv = conversation_repo.get_by_id(conversation_id)
-    # 优先使用 thread_id，否则用 conversation_id 作为 fallback
-    thread_id = conv.thread_id or conversation_id
-
-    # 从 deer-flow checkpointer 读取轨迹
-    try:
-        trace = trace_service.get_conversation_trace(thread_id)
-        return trace
-    except Exception as e:
-        logger.error("Failed to get trace for thread %s: %s", thread_id, e)
-        # 降级返回空轨迹，不阻断主流程
-        return {
-            "thread_id": thread_id,
-            "status": "error",
-            "events": [],
-            "summary": f"读取轨迹失败: {e!s}",
-            "checkpoint_count": 0,
-        }
+    return conversation_trace_service.get_trace(conversation_id)
 
 
 def _stream_conversation_message(conversation_id: str, body: SendMessageRequest):

--- a/swarmmind/services/conversation_trace_service.py
+++ b/swarmmind/services/conversation_trace_service.py
@@ -1,0 +1,34 @@
+"""Conversation-scoped trace orchestration helpers."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from swarmmind.services.trace_service import TraceService, trace_service
+
+logger = logging.getLogger(__name__)
+
+
+class ConversationTraceService:
+    """Resolve conversation identity and delegate trace reconstruction."""
+
+    def __init__(self, conversation_repo: Any, trace_reader: TraceService = trace_service) -> None:
+        self._conversation_repo = conversation_repo
+        self._trace_reader = trace_reader
+
+    def get_trace(self, conversation_id: str) -> dict[str, Any]:
+        """Load trace for a SwarmMind conversation, degrading gracefully on trace read errors."""
+        conversation = self._conversation_repo.get_by_id(conversation_id)
+        thread_id = self._resolve_thread_id(conversation, conversation_id)
+
+        try:
+            return self._trace_reader.get_conversation_trace(thread_id)
+        except Exception as exc:
+            logger.error("Failed to get trace for thread %s: %s", thread_id, exc)
+            return self._trace_reader.build_error_trace(thread_id, f"读取轨迹失败: {exc!s}")
+
+    @staticmethod
+    def _resolve_thread_id(conversation: Any, conversation_id: str) -> str:
+        """Prefer the bound runtime thread id, falling back to the conversation id."""
+        return getattr(conversation, "thread_id", None) or conversation_id

--- a/swarmmind/services/runtime_bridge.py
+++ b/swarmmind/services/runtime_bridge.py
@@ -1,4 +1,4 @@
-"""Helpers for bridging async runtime streams into sync iterators."""
+"""Helpers for bridging async runtime execution into sync call sites."""
 
 from __future__ import annotations
 
@@ -12,6 +12,7 @@ from typing import TypeVar
 logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
+R = TypeVar("R")
 
 
 def iter_async_generator_in_thread[T](
@@ -73,3 +74,58 @@ def iter_async_generator_in_thread[T](
 
     if exception_container:
         raise exception_container[0]
+
+
+def run_coroutine_blocking[R](
+    async_factory: Callable[[], asyncio.Future[R] | asyncio.Awaitable[R]],
+    *,
+    thread_name: str = "runtime-call",
+    join_timeout: float = 5.0,
+    bridge_logger: logging.Logger = logger,
+) -> R:
+    """Run a coroutine to completion from synchronous code.
+
+    If the caller is not already inside an event loop, the coroutine runs
+    directly via ``asyncio.run``. When a loop is already active in the current
+    thread, execution is isolated in a dedicated worker thread with its own
+    event loop.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(async_factory())
+
+    result_queue: queue.Queue[tuple[str, R | BaseException]] = queue.Queue()
+
+    def _run_in_thread() -> None:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            result_queue.put(("result", loop.run_until_complete(async_factory())))
+        except BaseException as exc:
+            result_queue.put(("error", exc))
+        finally:
+            try:
+                pending = asyncio.all_tasks(loop)
+                if pending:
+                    for task in pending:
+                        task.cancel()
+                    loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+            except Exception:  # nosec: B110 - cleanup code, safe to ignore
+                pass
+            loop.close()
+
+    thread = threading.Thread(target=_run_in_thread, name=thread_name, daemon=True)
+    thread.start()
+
+    try:
+        item_type, payload = result_queue.get()
+    finally:
+        thread.join(timeout=join_timeout)
+        if thread.is_alive():
+            bridge_logger.warning("Async bridge thread %s did not terminate within timeout", thread_name)
+
+    if item_type == "error":
+        raise payload
+
+    return payload

--- a/swarmmind/services/trace_checkpoint_storage.py
+++ b/swarmmind/services/trace_checkpoint_storage.py
@@ -1,0 +1,94 @@
+"""Storage adapters for raw trace checkpoint rows."""
+
+from __future__ import annotations
+
+import logging
+import os
+import sqlite3
+from collections.abc import Callable, Mapping
+from pathlib import Path
+from typing import Any, Protocol
+
+logger = logging.getLogger(__name__)
+
+LEGACY_DEFAULT_CHECKPOINTER_PATH = (
+    Path(__file__).resolve().parents[2] / ".runtime" / "deerflow" / "local-default" / "checkpoints.db"
+)
+DEFAULT_CHECKPOINTER_FILENAME = "checkpoints.db"
+
+CHECKPOINT_SELECT_SQL = """
+SELECT thread_id, checkpoint_id, parent_checkpoint_id, type,
+       checkpoint, metadata
+FROM checkpoints
+WHERE thread_id = ? AND checkpoint_ns = ''
+ORDER BY checkpoint_id ASC
+"""
+
+
+def resolve_default_checkpointer_path() -> Path:
+    """Resolve the default SqliteSaver path from runtime env when available."""
+    deer_flow_home = os.environ.get("DEER_FLOW_HOME")
+    if not deer_flow_home:
+        return LEGACY_DEFAULT_CHECKPOINTER_PATH
+
+    runtime_home = Path(deer_flow_home).expanduser()
+    direct_candidate = runtime_home / DEFAULT_CHECKPOINTER_FILENAME
+    sibling_candidate = runtime_home.parent / DEFAULT_CHECKPOINTER_FILENAME
+
+    for candidate in (direct_candidate, sibling_candidate):
+        if candidate.exists():
+            return candidate
+
+    if runtime_home.name == "home":
+        return sibling_candidate
+
+    return direct_candidate
+
+
+class TraceCheckpointStorage(Protocol):
+    """Loads raw checkpoint rows for a conversation thread."""
+
+    checkpointer_path: Path | None
+
+    def fetch_checkpoint_rows(self, thread_id: str) -> list[Mapping[str, Any]]:
+        """Fetch raw checkpoint rows for a thread."""
+
+
+class SqliteTraceCheckpointStorage:
+    """SQLite-backed storage for langgraph/deer-flow checkpoint rows."""
+
+    def __init__(
+        self,
+        checkpointer_path: Path | str | None = None,
+        connect_fn: Callable[..., sqlite3.Connection] = sqlite3.connect,
+        storage_logger: logging.Logger = logger,
+    ) -> None:
+        self.checkpointer_path = Path(checkpointer_path) if checkpointer_path else resolve_default_checkpointer_path()
+        self._connect_fn = connect_fn
+        self._logger = storage_logger
+
+    def fetch_checkpoint_rows(self, thread_id: str) -> list[Mapping[str, Any]]:
+        """Fetch raw rows from the upstream checkpoints table."""
+        if not self.checkpointer_path.exists():
+            self._logger.warning("Checkpointer database not found at %s", self.checkpointer_path)
+            return []
+
+        conn = self._connect_fn(self.checkpointer_path, check_same_thread=False)
+        conn.row_factory = sqlite3.Row
+
+        try:
+            cursor = conn.cursor()
+            try:
+                cursor.execute(CHECKPOINT_SELECT_SQL, (thread_id,))
+            except sqlite3.OperationalError as exc:
+                self._logger.warning(
+                    "Checkpoint query failed for thread %s at %s: %s",
+                    thread_id,
+                    self.checkpointer_path,
+                    exc,
+                )
+                return []
+
+            return list(cursor.fetchall())
+        finally:
+            conn.close()

--- a/swarmmind/services/trace_provider.py
+++ b/swarmmind/services/trace_provider.py
@@ -4,39 +4,20 @@ from __future__ import annotations
 
 import json
 import logging
-import os
-import sqlite3
-from collections.abc import Callable
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, Protocol
 
-logger = logging.getLogger(__name__)
-
-
-LEGACY_DEFAULT_CHECKPOINTER_PATH = (
-    Path(__file__).resolve().parents[2] / ".runtime" / "deerflow" / "local-default" / "checkpoints.db"
+from swarmmind.services.trace_checkpoint_storage import (
+    LEGACY_DEFAULT_CHECKPOINTER_PATH as STORAGE_LEGACY_DEFAULT_CHECKPOINTER_PATH,
 )
-DEFAULT_CHECKPOINTER_FILENAME = "checkpoints.db"
+from swarmmind.services.trace_checkpoint_storage import (
+    SqliteTraceCheckpointStorage,
+    TraceCheckpointStorage,
+)
 
-
-def resolve_default_checkpointer_path() -> Path:
-    """Resolve the default SqliteSaver path from runtime env when available."""
-    deer_flow_home = os.environ.get("DEER_FLOW_HOME")
-    if not deer_flow_home:
-        return LEGACY_DEFAULT_CHECKPOINTER_PATH
-
-    runtime_home = Path(deer_flow_home).expanduser()
-    direct_candidate = runtime_home / DEFAULT_CHECKPOINTER_FILENAME
-    sibling_candidate = runtime_home.parent / DEFAULT_CHECKPOINTER_FILENAME
-
-    for candidate in (direct_candidate, sibling_candidate):
-        if candidate.exists():
-            return candidate
-
-    if runtime_home.name == "home":
-        return sibling_candidate
-
-    return direct_candidate
+logger = logging.getLogger(__name__)
+LEGACY_DEFAULT_CHECKPOINTER_PATH = STORAGE_LEGACY_DEFAULT_CHECKPOINTER_PATH
 
 
 class TraceCheckpointProvider(Protocol):
@@ -54,64 +35,40 @@ class SqliteTraceCheckpointProvider:
     def __init__(
         self,
         checkpointer_path: Path | str | None = None,
-        connect_fn: Callable[..., sqlite3.Connection] = sqlite3.connect,
+        storage: TraceCheckpointStorage | None = None,
         provider_logger: logging.Logger = logger,
     ) -> None:
-        self.checkpointer_path = Path(checkpointer_path) if checkpointer_path else resolve_default_checkpointer_path()
-        self._connect_fn = connect_fn
+        self._storage = storage or SqliteTraceCheckpointStorage(checkpointer_path=checkpointer_path, storage_logger=provider_logger)
+        self.checkpointer_path = self._storage.checkpointer_path
         self._logger = provider_logger
 
     def load_checkpoints(self, thread_id: str) -> list[dict[str, Any]]:
-        """Load checkpoints from a SqliteSaver database."""
-        if not self.checkpointer_path.exists():
-            self._logger.warning("Checkpointer database not found at %s", self.checkpointer_path)
-            return []
+        """Load parsed checkpoints from upstream storage."""
+        checkpoints: list[dict[str, Any]] = []
+        for row in self._storage.fetch_checkpoint_rows(thread_id):
+            parsed_row = self._parse_checkpoint_row(row)
+            if parsed_row is not None:
+                checkpoints.append(parsed_row)
+        return checkpoints
 
-        conn = self._connect_fn(self.checkpointer_path, check_same_thread=False)
-        conn.row_factory = sqlite3.Row
+    def _parse_checkpoint_row(self, row: Mapping[str, Any]) -> dict[str, Any] | None:
+        """Decode one raw storage row into the trace checkpoint shape."""
+        checkpoint_id = row["checkpoint_id"]
+        checkpoint_payload = row["checkpoint"]
+        metadata_payload = row["metadata"]
 
         try:
-            cursor = conn.cursor()
-            try:
-                cursor.execute(
-                    """
-                    SELECT thread_id, checkpoint_id, parent_checkpoint_id, type,
-                           checkpoint, metadata
-                    FROM checkpoints
-                    WHERE thread_id = ? AND checkpoint_ns = ''
-                    ORDER BY checkpoint_id ASC
-                    """,
-                    (thread_id,),
-                )
-            except sqlite3.OperationalError as exc:
-                self._logger.warning(
-                    "Checkpoint query failed for thread %s at %s: %s",
-                    thread_id,
-                    self.checkpointer_path,
-                    exc,
-                )
-                return []
+            checkpoint_data = json.loads(checkpoint_payload) if checkpoint_payload else {}
+            metadata = json.loads(metadata_payload) if metadata_payload else {}
+        except json.JSONDecodeError as exc:
+            self._logger.warning("Failed to parse checkpoint %s: %s", checkpoint_id, exc)
+            return None
 
-            checkpoints: list[dict[str, Any]] = []
-            for row in cursor.fetchall():
-                try:
-                    checkpoint_data = json.loads(row["checkpoint"]) if row["checkpoint"] else {}
-                    metadata = json.loads(row["metadata"]) if row["metadata"] else {}
-                except json.JSONDecodeError as exc:
-                    self._logger.warning("Failed to parse checkpoint %s: %s", row["checkpoint_id"], exc)
-                    continue
-
-                checkpoints.append(
-                    {
-                        "thread_id": row["thread_id"],
-                        "checkpoint_id": row["checkpoint_id"],
-                        "parent_checkpoint_id": row["parent_checkpoint_id"],
-                        "type": row["type"],
-                        "checkpoint": checkpoint_data,
-                        "metadata": metadata,
-                    }
-                )
-
-            return checkpoints
-        finally:
-            conn.close()
+        return {
+            "thread_id": row["thread_id"],
+            "checkpoint_id": checkpoint_id,
+            "parent_checkpoint_id": row["parent_checkpoint_id"],
+            "type": row["type"],
+            "checkpoint": checkpoint_data,
+            "metadata": metadata,
+        }

--- a/swarmmind/services/trace_service.py
+++ b/swarmmind/services/trace_service.py
@@ -65,6 +65,16 @@ class TraceService:
             "checkpoint_count": len(checkpoints),
         }
 
+    def build_error_trace(self, thread_id: str, summary: str) -> dict[str, Any]:
+        """Return a degraded trace payload for provider/service failures."""
+        return {
+            "thread_id": thread_id,
+            "status": "error",
+            "events": [],
+            "summary": summary,
+            "checkpoint_count": 0,
+        }
+
     def _build_trace_events(self, checkpoints: list[dict]) -> list[dict[str, Any]]:
         """Build trace events from checkpoints.
 

--- a/tests/test_conversation_trace_service.py
+++ b/tests/test_conversation_trace_service.py
@@ -1,0 +1,78 @@
+"""Tests for conversation-scoped trace orchestration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from swarmmind.services.conversation_trace_service import ConversationTraceService
+
+
+@dataclass
+class FakeConversation:
+    thread_id: str | None = None
+
+
+class FakeConversationRepo:
+    def __init__(self, conversation: FakeConversation) -> None:
+        self._conversation = conversation
+        self.calls: list[str] = []
+
+    def get_by_id(self, conversation_id: str) -> FakeConversation:
+        self.calls.append(conversation_id)
+        return self._conversation
+
+
+class FakeTraceReader:
+    def __init__(self, response: dict | None = None, error: Exception | None = None) -> None:
+        self._response = response or {"thread_id": "resolved-thread", "status": "completed", "events": [], "summary": "ok", "checkpoint_count": 1}
+        self._error = error
+        self.calls: list[str] = []
+
+    def get_conversation_trace(self, thread_id: str) -> dict:
+        self.calls.append(thread_id)
+        if self._error is not None:
+            raise self._error
+        return self._response
+
+    def build_error_trace(self, thread_id: str, summary: str) -> dict:
+        return {"thread_id": thread_id, "status": "error", "events": [], "summary": summary, "checkpoint_count": 0}
+
+
+def test_get_trace_prefers_conversation_thread_id() -> None:
+    repo = FakeConversationRepo(FakeConversation(thread_id="runtime-thread"))
+    reader = FakeTraceReader()
+    service = ConversationTraceService(conversation_repo=repo, trace_reader=reader)
+
+    trace = service.get_trace("conversation-1")
+
+    assert repo.calls == ["conversation-1"]
+    assert reader.calls == ["runtime-thread"]
+    assert trace["status"] == "completed"
+
+
+def test_get_trace_falls_back_to_conversation_id_when_thread_missing() -> None:
+    repo = FakeConversationRepo(FakeConversation(thread_id=None))
+    reader = FakeTraceReader(response={"thread_id": "conversation-2", "status": "empty", "events": [], "summary": "暂无执行记录", "checkpoint_count": 0})
+    service = ConversationTraceService(conversation_repo=repo, trace_reader=reader)
+
+    trace = service.get_trace("conversation-2")
+
+    assert reader.calls == ["conversation-2"]
+    assert trace["thread_id"] == "conversation-2"
+
+
+def test_get_trace_returns_error_payload_on_trace_failure() -> None:
+    repo = FakeConversationRepo(FakeConversation(thread_id="runtime-thread"))
+    reader = FakeTraceReader(error=RuntimeError("checkpoint store offline"))
+    service = ConversationTraceService(conversation_repo=repo, trace_reader=reader)
+
+    trace = service.get_trace("conversation-3")
+
+    assert reader.calls == ["runtime-thread"]
+    assert trace == {
+        "thread_id": "runtime-thread",
+        "status": "error",
+        "events": [],
+        "summary": "读取轨迹失败: checkpoint store offline",
+        "checkpoint_count": 0,
+    }

--- a/tests/test_general_agent_stream_bridge.py
+++ b/tests/test_general_agent_stream_bridge.py
@@ -54,6 +54,28 @@ def test_stream_events_reraises_async_failure() -> None:
         raise AssertionError("RuntimeError was not re-raised")
 
 
+def test_run_deerflow_turn_collects_async_result_without_stream_wrapper() -> None:
+    agent = DeerFlowRuntimeAdapter.__new__(DeerFlowRuntimeAdapter)
+
+    async def fake_astream_events(goal, ctx=None, runtime_options=None):
+        assert goal == "investigate"
+        assert ctx.session_id == "conv-1"
+        yield {"type": "assistant_message", "content": "partial"}
+        agent._last_final_text = "final answer"
+        agent._last_tool_results = ["tool:done"]
+
+    agent._astream_events = fake_astream_events
+
+    final_text, tool_results = agent._run_deerflow_turn(
+        "investigate",
+        ctx=SimpleNamespace(session_id="conv-1"),
+        runtime_options=SimpleNamespace(),
+    )
+
+    assert final_text == "final answer"
+    assert tool_results == ["tool:done"]
+
+
 def test_extract_reasoning_delta_prefers_additional_kwargs() -> None:
     chunk = AIMessageChunk(content="", additional_kwargs={"reasoning_content": "step by step"})
 

--- a/tests/test_runtime_bridge.py
+++ b/tests/test_runtime_bridge.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from swarmmind.services.runtime_bridge import iter_async_generator_in_thread
+import asyncio
+
+from swarmmind.services.runtime_bridge import iter_async_generator_in_thread, run_coroutine_blocking
 
 
 def test_iter_async_generator_in_thread_yields_items_in_order() -> None:
@@ -26,3 +28,21 @@ def test_iter_async_generator_in_thread_reraises_async_errors() -> None:
         assert str(exc) == "bridge failed"
     else:  # pragma: no cover
         raise AssertionError("RuntimeError was not re-raised")
+
+
+def test_run_coroutine_blocking_returns_result_without_existing_loop() -> None:
+    async def factory() -> str:
+        return "done"
+
+    assert run_coroutine_blocking(factory, thread_name="bridge-call") == "done"
+
+
+def test_run_coroutine_blocking_uses_worker_thread_when_loop_is_active() -> None:
+    async def exercise() -> str:
+        async def factory() -> str:
+            await asyncio.sleep(0)
+            return "done"
+
+        return run_coroutine_blocking(factory, thread_name="bridge-call")
+
+    assert asyncio.run(exercise()) == "done"

--- a/ui/src/components/ui/v0-ai-chat.tsx
+++ b/ui/src/components/ui/v0-ai-chat.tsx
@@ -1,34 +1,31 @@
 "use client";
 
+import type { ChangeEvent, KeyboardEvent } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
-import {
-  ArrowDown,
-  ArrowUp,
-  Brain,
-  Check,
-  Copy,
-  Lightbulb,
-  Loader2,
-  Paperclip,
-  Rocket,
-  Sparkles,
-} from "lucide-react";
+import { ArrowDown } from "lucide-react";
 
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Textarea } from "@/components/ui/textarea";
 import { ArtifactsProvider } from "@/components/workspace/artifacts/context";
+import { ChatComposerPanel } from "@/components/workspace/chat-composer-panel";
+import { ChatEmptyState } from "@/components/workspace/chat-empty-state";
 import { ChatLayout } from "@/components/workspace/chat-layout";
-import { MessageBubble, MessageListSkeleton, StreamingDots } from "@/components/workspace/chat-message-ui";
-import { ClarificationCard } from "@/components/workspace/messages/clarification-card";
-import { ModePicker, ModelPicker } from "@/components/workspace/chat-controls";
+import { MessageListSkeleton } from "@/components/workspace/chat-message-ui";
+import { ChatMessageArea } from "@/components/workspace/chat-message-area";
 import { SubtasksProvider, useUpdateSubtask, useSubtaskContext } from "@/core/tasks/context";
-import { SubtaskCard } from "@/components/workspace/messages/subtask-card";
-import { parseClarificationContent } from "@/core/messages/clarification";
-import { cn } from "@/lib/utils";
-import { XIcon } from "lucide-react";
-import { toast } from "sonner";
+import type {
+  ChatMessage,
+  ConversationMode,
+  ConversationRecord,
+  RuntimeActivity,
+  RuntimeModelCatalogResponse,
+  RuntimeModelOption,
+  RuntimeState,
+  StoredMessage,
+  StreamEvent,
+} from "@/core/chat/types";
+
+export type { ConversationRecord } from "@/core/chat/types";
 
 interface V0ChatProps {
   conversationId?: string;
@@ -36,108 +33,6 @@ interface V0ChatProps {
   onConversationCreated?: (id: string) => void;
   onConversationsChange?: (items: ConversationRecord[]) => void;
 }
-
-export interface ConversationRecord {
-  id: string;
-  title: string;
-  title_status: "pending" | "generated" | "fallback" | "manual";
-  updated_at: string;
-  created_at: string;
-}
-
-interface StoredMessage {
-  id: string;
-  role: "user" | "assistant";
-  content: string;
-  created_at?: string;
-}
-
-interface RuntimeModelOption {
-  name: string;
-  provider: string;
-  model: string;
-  display_name?: string | null;
-  description?: string | null;
-  supports_vision: boolean;
-  is_default: boolean;
-}
-
-interface RuntimeModelCatalogResponse {
-  models: RuntimeModelOption[];
-  default_model?: string | null;
-}
-
-interface RuntimeActivity {
-  id: string;
-  label: string;
-  status: "running" | "completed";
-  detail?: string;
-}
-
-interface RuntimeState {
-  phase: "idle" | "accepted" | "routing" | "running" | "completed" | "error";
-  label: string;
-  activities: RuntimeActivity[];
-}
-
-interface StreamEventUserMessage {
-  id: string;
-  role: "user";
-  content: string;
-  created_at?: string;
-}
-
-interface StreamEventAssistantMessage {
-  id: string;
-  role: "assistant";
-  content: string;
-  created_at?: string;
-}
-
-type StreamEvent =
-  | { type: "status"; phase: RuntimeState["phase"]; label: string }
-  | { type: "user_message"; message: StreamEventUserMessage }
-  | { type: "thinking"; message_id: string; content: string }
-  | { type: "assistant_message"; message_id: string; content: string }
-  | { type: "assistant_final"; message: StreamEventAssistantMessage }
-  | {
-      type: "team_activity";
-      activity: {
-        id: string;
-        label: string;
-        status: RuntimeActivity["status"];
-        detail?: string | null;
-      };
-    }
-  // Task events for SubtaskCard (DeerFlow compatible)
-  | { type: "task_started"; task: { id: string; description: string; status: "in_progress" } }
-  | { type: "task_running"; task: { id: string; message?: unknown } }
-  | { type: "task_completed"; task: { id: string; result?: string; status: "completed" } }
-  | { type: "task_failed"; task: { id: string; error?: string; status: "failed" } }
-  // Clarification request from AI
-  | { type: "clarification_request"; clarification: { id: string; content: string } }
-  | { type: "artifact"; path: string; filename?: string }
-  | {
-      type: "title";
-      conversation: ConversationRecord;
-    }
-  | { type: "done" };
-
-type ChatMessage = StoredMessage & {
-  pendingPersist?: boolean;
-  isStreaming?: boolean;
-  thinking?: string;
-  isReasoningStreaming?: boolean;
-};
-
-type ConversationMode = "flash" | "thinking" | "pro" | "ultra";
-
-const QUICK_PROMPTS = [
-  "帮我整理本周项目进展，输出 3 条重点结论。",
-  "生成一版 CRM MVP 范围说明，控制在一页内。",
-  "把下面的会议讨论改写成正式纪要。",
-  "总结当前续费风险，并给出 3 条行动建议。",
-];
 
 const MODEL_FETCH_RETRY_COUNT = 3;
 const MODEL_FETCH_RETRY_DELAY_MS = 400;
@@ -208,22 +103,6 @@ function upsertActivity(
     ...patch,
   };
   return next;
-}
-
-function statusTone(phase: RuntimeState["phase"]) {
-  if (phase === "error") return "status-pill-blocked";
-  if (phase === "completed") return "status-pill-done";
-  if (phase === "routing" || phase === "running" || phase === "accepted")
-    return "status-pill-running";
-  return "status-pill-draft";
-}
-
-function statusLabel(phase: RuntimeState["phase"]) {
-  if (phase === "accepted") return "已提交";
-  if (phase === "routing" || phase === "running") return "生成中";
-  if (phase === "completed") return "已完成";
-  if (phase === "error") return "失败";
-  return "待开始";
 }
 
 // Internal component that uses useUpdateSubtask (must be inside SubtasksProvider)
@@ -897,7 +776,7 @@ function V0ChatInner({
     [handleStreamEvent],
   );
 
-  const handleFileSelect = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleFileSelect = useCallback((e: ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(e.target.files ?? []);
     if (files.length === 0) return;
     setAttachedFiles((prev) => {
@@ -1065,210 +944,23 @@ function V0ChatInner({
           {isConversationLoading ? (
             <MessageListSkeleton />
           ) : isEmpty ? (
-            <div className="flex flex-1 flex-col px-6 pt-14">
-              <div className="mx-auto w-full max-w-[560px]">
-                <motion.div
-                  initial={{ opacity: 0, y: 12 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ duration: 0.3, ease: [0.16, 1, 0.3, 1] }}
-                  className="mb-7"
-                >
-                  <div className="inline-flex size-10 items-center justify-center rounded-xl border bg-[var(--warm-ivory)] text-[var(--neutral-600)]"
-                    style={{ boxShadow: 'var(--shadow-whisper)' }}
-                  >
-                    <Sparkles className="size-4" />
-                  </div>
-                  <p className="mt-5 text-[11px] uppercase tracking-[0.08em] text-muted-foreground">
-                    Exploratory Session
-                  </p>
-                  <h2 className="mt-2 text-[28px] leading-[36px] font-semibold tracking-[-0.02em] text-foreground">
-                    临时会话
-                  </h2>
-                  <p className="mt-2 max-w-[440px] text-[14px] leading-[22px] text-muted-foreground">
-                    用一个明确任务开始探索。首次发送成功后，系统才会创建正式会话记录。
-                  </p>
-                </motion.div>
-
-                <motion.div
-                  initial={{ opacity: 0 }}
-                  animate={{ opacity: 1 }}
-                  transition={{ delay: 0.15, duration: 0.2 }}
-                  className="mb-3 flex items-center gap-2"
-                >
-                  <p className="text-[12px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
-                    快速开始
-                  </p>
-                  <span className="h-px flex-1 bg-border/50" />
-                </motion.div>
-                <div className="grid gap-2.5 sm:grid-cols-2">
-                  {[
-                    { icon: Rocket, prompt: QUICK_PROMPTS[0] },
-                    { icon: Lightbulb, prompt: QUICK_PROMPTS[1] },
-                    { icon: Brain, prompt: QUICK_PROMPTS[2] },
-                    { icon: Sparkles, prompt: QUICK_PROMPTS[3] },
-                  ].map(({ icon: Icon, prompt }, i) => (
-                    <motion.button
-                      key={prompt}
-                      initial={{ opacity: 0, y: 12 }}
-                      animate={{ opacity: 1, y: 0 }}
-                      transition={{
-                        delay: 0.2 + i * 0.06,
-                        duration: 0.25,
-                        ease: [0.16, 1, 0.3, 1],
-                      }}
-                      onClick={() => {
-                        setInput(prompt);
-                        void handleSubmit(prompt);
-                      }}
-                      className="group flex items-start gap-3 rounded-xl border bg-[var(--warm-ivory)] px-4 py-3.5 text-left transition-all duration-200 hover:border-[var(--warm-ring)] hover:bg-[var(--neutral-150)]"
-                    >
-                      <span
-                        className={cn(
-                          "mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-md border border-black/5 transition-colors",
-                          i === 0
-                            ? "bg-[#e2e8ee] text-[#49617a]"
-                            : i === 1
-                              ? "bg-[#ece3d6] text-[#756046]"
-                              : i === 2
-                                ? "bg-[#eae6ef] text-[#66597c]"
-                                : "bg-[#e4ebe4] text-[#4c6554]",
-                        )}
-                      >
-                        <Icon className="size-4" />
-                      </span>
-                      <span className="text-[13px] leading-[20px] text-muted-foreground group-hover:text-foreground">
-                        {prompt}
-                      </span>
-                    </motion.button>
-                  ))}
-                </div>
-              </div>
-            </div>
+            <ChatEmptyState
+              onPromptSelect={(prompt) => {
+                setInput(prompt);
+                void handleSubmit(prompt);
+              }}
+            />
           ) : (
-            <div className="mx-auto flex w-full max-w-[760px] flex-col gap-5 px-6 py-6">
-              <AnimatePresence initial={false}>
-                {messages.map((message) => {
-                  // Check if this is a clarification message from tool
-                  // Try to parse as clarification if message looks like it
-                  if (
-                    message.role === "assistant" &&
-                    (message.content.includes("需要") ||
-                     message.content.includes("?") ||
-                     message.content.includes("选择") ||
-                     message.content.includes("确认"))
-                  ) {
-                    // Try to parse as clarification
-                    try {
-                      const parsed = parseClarificationContent(message.content);
-                      // Only render as clarification if it has the expected format
-                      if (parsed.question && parsed.clarificationType) {
-                        return (
-                          <ClarificationCard
-                            key={message.id}
-                            question={parsed.question}
-                            context={parsed.context}
-                            options={parsed.options}
-                            clarificationType={parsed.clarificationType}
-                            onRespond={(response) => {
-                              // Use message.id as tool_call_id fallback
-                              handleClarificationRespond(response, message.id);
-                            }}
-                          />
-                        );
-                      }
-                    } catch (e) {
-                      toast.error("AI 澄清请求解析失败，请查看原始消息");
-                      console.warn("[clarification] parse failed:", e);
-                      // Fall through to normal rendering
-                    }
-                  }
-                  
-                  return (
-                    <motion.div
-                      key={message.id}
-                      initial={{ opacity: 0, y: 12 }}
-                      animate={{ opacity: 1, y: 0 }}
-                      transition={{ duration: 0.25, ease: [0.16, 1, 0.3, 1] }}
-                    >
-                      <MessageBubble
-                        key={message.id}
-                        message={message}
-                        isMessageStreaming={
-                          message.isStreaming || message.isReasoningStreaming
-                        }
-                      />
-                    </motion.div>
-                  );
-                })}
-              </AnimatePresence>
-              
-              {/* Render ClarificationCard if there's a pending clarification */}
-              {pendingClarification && (
-                <motion.div
-                  initial={{ opacity: 0, y: 12 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ duration: 0.25, ease: [0.16, 1, 0.3, 1] }}
-                  className="mt-4"
-                >
-                  {(() => {
-                    try {
-                      const parsed = parseClarificationContent(pendingClarification.content);
-                      return (
-                        <ClarificationCard
-                          question={parsed.question}
-                          context={parsed.context}
-                          options={parsed.options}
-                          clarificationType={parsed.clarificationType}
-                          onRespond={(response) => {
-                            handleClarificationRespond(response, pendingClarification.id);
-                            setPendingClarification(null); // Clear after response
-                          }}
-                        />
-                      );
-                    } catch (e) {
-                      toast.error("AI 澄清请求解析失败，请查看原始消息");
-                      console.warn("[clarification] parse failed:", e);
-                      return null;
-                    }
-                  })()}
-                </motion.div>
-              )}
-              
-              {/* Render SubtaskCards for active tasks */}
-              {Object.values(tasks).length > 0 && (
-                <div className="flex flex-col gap-3 mt-4">
-                  <div className="text-muted-foreground text-sm">
-                    正在执行 {Object.values(tasks).length} 个子任务...
-                  </div>
-                  {Object.values(tasks).map((task) => (
-                    <SubtaskCard
-                      key={task.id}
-                      taskId={task.id}
-                      isLoading={isLoading}
-                    />
-                  ))}
-                </div>
-              )}
-              
-              {isLoading &&
-                !messages.some(
-                  (m) => m.content.trim().length > 0 && m.role === "assistant",
-                ) && (
-                  <motion.div
-                    initial={{ opacity: 0, y: 8 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    transition={{ duration: 0.2 }}
-                    className="flex justify-start"
-                  >
-                    <div className="flex items-center gap-2 rounded-xl border border-[var(--warm-border)] bg-[var(--neutral-150)] px-4 py-2">
-                      <StreamingDots />
-                      <span className="text-[13px] text-muted-foreground">
-                        正在生成回复
-                      </span>
-                    </div>
-                  </motion.div>
-                )}
-            </div>
+            <ChatMessageArea
+              isLoading={isLoading}
+              messages={messages}
+              pendingClarification={pendingClarification}
+              tasks={tasks}
+              onClarificationRespond={handleClarificationRespond}
+              onPendingClarificationHandled={() => {
+                setPendingClarification(null);
+              }}
+            />
           )}
         </div>
 
@@ -1298,199 +990,38 @@ function V0ChatInner({
         </AnimatePresence>
       </div>
 
-      {/* Pinned bottom: status + composer as unified container */}
-      <div className="sticky bottom-0 z-20"
-        style={{
-          background: 'linear-gradient(to top, var(--warm-paper) 0%, var(--warm-paper) 85%, transparent 100%)',
+      <ChatComposerPanel
+        attachedFiles={attachedFiles}
+        error={error}
+        fetchModels={() => {
+          void fetchModels();
         }}
-      >
-        <div className="relative border-t border-[var(--warm-border)]/50 bg-[var(--warm-paper)]">
-          <div className="mx-auto w-full max-w-[760px] px-6 pb-5 pt-2.5">
-            <div
-              className="rounded-2xl border border-[var(--warm-border)] bg-[var(--warm-ivory)] transition-all duration-200 focus-within:border-[var(--warm-ring)]"
-              style={{
-                boxShadow: 'var(--shadow-whisper)',
-              }}
-            >
-              {(runtime.phase !== "idle" || error) && (
-                <div
-                  className="border-b border-[var(--warm-border)] bg-[var(--neutral-150)] px-5 py-2.5"
-                  aria-live="polite"
-                >
-                  <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-                    <p className="text-[13px] text-muted-foreground">
-                      {error || runtime.label}
-                    </p>
-                    <Badge
-                      variant="outline"
-                      className={cn("text-[11px]", statusTone(runtime.phase))}
-                    >
-                      {statusLabel(runtime.phase)}
-                    </Badge>
-                  </div>
-                </div>
-              )}
-
-              <AnimatePresence>
-                {runtime.activities.length > 0 && (
-                  <motion.div
-                    key="activities"
-                    initial={{ opacity: 0, height: 0 }}
-                    animate={{ opacity: 1, height: "auto" }}
-                    exit={{ opacity: 0, height: 0 }}
-                    transition={{ duration: 0.2, ease: [0.16, 1, 0.3, 1] }}
-                    className="overflow-hidden"
-                  >
-                    <div className="flex flex-col gap-1 border-b border-[var(--warm-border)] px-4 py-2">
-                      {runtime.activities.slice(0, 5).map((activity) => (
-                        <div
-                          key={activity.id}
-                          className="flex items-center gap-2 text-xs"
-                        >
-                          {activity.status === "running" ? (
-                            <Loader2 className="size-3 shrink-0 animate-spin text-[var(--status-running)]" />
-                          ) : (
-                            <Check className="size-3 shrink-0 text-[var(--status-done)]" />
-                          )}
-                          <span
-                            className={cn(
-                              "truncate",
-                              activity.status === "running"
-                                ? "text-[var(--neutral-700)]"
-                                : "text-[var(--neutral-500)]"
-                            )}
-                          >
-                            {activity.label}
-                          </span>
-                          {activity.detail && (
-                            <span className="ml-auto shrink-0 text-[var(--neutral-400)] max-w-[120px] truncate">
-                              {activity.detail}
-                            </span>
-                          )}
-                        </div>
-                      ))}
-                      {runtime.activities.length > 5 && (
-                        <p className="text-xs text-[var(--neutral-400)] pl-5">
-                          +{runtime.activities.length - 5} 个任务...
-                        </p>
-                      )}
-                    </div>
-                  </motion.div>
-                )}
-              </AnimatePresence>
-
-              <div>
-                {attachedFiles.length > 0 && (
-                  <div className="flex flex-wrap gap-2 px-5 pt-3">
-                    {attachedFiles.map((file, index) => (
-                      <div
-                        key={`${file.name}-${index}`}
-                        className="flex items-center gap-1.5 rounded-md border border-[var(--warm-border)] bg-[var(--warm-ivory)] px-2.5 py-1 text-xs text-[var(--neutral-700)]"
-                      >
-                        <Paperclip className="size-3 shrink-0 text-[var(--neutral-500)]" />
-                        <span className="max-w-[120px] truncate">{file.name}</span>
-                        <button
-                          type="button"
-                          onClick={() => handleRemoveFile(index)}
-                          className="ml-0.5 text-[var(--neutral-400)] hover:text-[var(--neutral-700)]"
-                          aria-label={`移除 ${file.name}`}
-                        >
-                          <XIcon className="size-3" />
-                        </button>
-                      </div>
-                    ))}
-                  </div>
-                )}
-                <Textarea
-                  value={input}
-                  onChange={(e) => { setInput(e.target.value); }}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter" && !e.shiftKey) {
-                      e.preventDefault();
-                      void handleSubmit();
-                    }
-                  }}
-                  placeholder={
-                    isModelsLoading
-                      ? "正在加载模型..."
-                      : selectedModel
-                        ? "输入问题或任务..."
-                        : "当前没有可用模型，暂时无法开始会话"
-                  }
-                  className="min-h-[100px] resize-none border-none bg-card px-5 py-4 text-[15px] leading-[24px] tracking-[-0.003em] focus-visible:ring-0"
-                  disabled={isComposerDisabled}
-                />
-                <div className="flex flex-col gap-2 border-t border-[var(--warm-border)] bg-[var(--neutral-150)]/70 px-4 py-2.5 sm:flex-row sm:items-center sm:justify-between">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <ModePicker
-                      selected={selectedMode}
-                      onSelect={setSelectedMode}
-                    />
-                    <>
-                      <input
-                        ref={fileInputRef}
-                        type="file"
-                        multiple
-                        className="hidden"
-                        onChange={handleFileSelect}
-                        accept="image/*,.pdf,.txt,.md,.csv,.json,.py,.ts,.tsx,.js,.jsx"
-                      />
-                      <Button
-                        variant="ghost"
-                        size="icon-sm"
-                        onClick={() => fileInputRef.current?.click()}
-                        className="size-10 rounded-lg border border-transparent text-[var(--neutral-600)] hover:border-[var(--warm-border)] hover:bg-[var(--warm-ivory)]"
-                        title="上传附件"
-                      >
-                        <Paperclip className="size-4" />
-                      </Button>
-                    </>
-                    {lastAssistantMessage && (
-                      <Button
-                        variant="ghost"
-                        size="icon-sm"
-                        className="size-10 rounded-lg border border-transparent text-[var(--neutral-600)] hover:border-[var(--warm-border)] hover:bg-[var(--warm-ivory)]"
-                        onClick={() =>
-                          navigator.clipboard.writeText(
-                            lastAssistantMessage.content,
-                          )
-                        }
-                        title="复制回复"
-                      >
-                        <Copy className="size-4" />
-                      </Button>
-                    )}
-                  </div>
-                  <div className="flex flex-wrap items-center justify-between gap-2 sm:justify-end">
-                    <ModelPicker
-                      models={modelOptions}
-                      selected={selectedModel}
-                      onSelect={setSelectedModel}
-                      isLoading={isModelsLoading}
-                      loadError={modelLoadError}
-                      onRetry={() => {
-                        void fetchModels();
-                      }}
-                    />
-                    <Button
-                      onClick={() => void handleSubmit()}
-                      disabled={!input.trim() || isComposerDisabled}
-                      size="icon-sm"
-                      className="size-10 rounded-md shadow-none"
-                    >
-                      {isLoading ? (
-                        <Loader2 className="size-4 animate-spin" />
-                      ) : (
-                        <ArrowUp className="size-4" />
-                      )}
-                    </Button>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
+        fileInputRef={fileInputRef}
+        handleFileSelect={handleFileSelect}
+        handleRemoveFile={handleRemoveFile}
+        handleSubmit={() => {
+          void handleSubmit();
+        }}
+        input={input}
+        isComposerDisabled={isComposerDisabled}
+        isLoading={isLoading}
+        isModelsLoading={isModelsLoading}
+        lastAssistantMessage={lastAssistantMessage}
+        modelLoadError={modelLoadError}
+        modelOptions={modelOptions}
+        onInputChange={setInput}
+        onKeyDown={(e: KeyboardEvent<HTMLTextAreaElement>) => {
+          if (e.key === "Enter" && !e.shiftKey) {
+            e.preventDefault();
+            void handleSubmit();
+          }
+        }}
+        runtime={runtime}
+        selectedMode={selectedMode}
+        selectedModel={selectedModel}
+        setSelectedMode={setSelectedMode}
+        setSelectedModel={setSelectedModel}
+      />
     </div>
     </ChatLayout>
     </ArtifactsProvider>

--- a/ui/src/components/workspace/chat-composer-panel.tsx
+++ b/ui/src/components/workspace/chat-composer-panel.tsx
@@ -1,0 +1,247 @@
+import type { ChangeEvent, KeyboardEvent, RefObject } from "react";
+import React from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { ArrowUp, Check, Copy, Loader2, Paperclip, XIcon } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { ModePicker, ModelPicker } from "@/components/workspace/chat-controls";
+import type { ChatMessage, ConversationMode, RuntimeModelOption, RuntimeState } from "@/core/chat/types";
+import { cn } from "@/lib/utils";
+
+interface ChatComposerPanelProps {
+  attachedFiles: File[];
+  error: string | null;
+  fetchModels: () => void;
+  fileInputRef: RefObject<HTMLInputElement | null>;
+  handleFileSelect: (event: ChangeEvent<HTMLInputElement>) => void;
+  handleRemoveFile: (index: number) => void;
+  handleSubmit: () => void;
+  input: string;
+  isComposerDisabled: boolean;
+  isLoading: boolean;
+  isModelsLoading: boolean;
+  lastAssistantMessage?: ChatMessage;
+  modelLoadError: string | null;
+  modelOptions: RuntimeModelOption[];
+  onInputChange: (value: string) => void;
+  onKeyDown: (event: KeyboardEvent<HTMLTextAreaElement>) => void;
+  runtime: RuntimeState;
+  selectedMode: ConversationMode;
+  selectedModel: string;
+  setSelectedMode: (mode: ConversationMode) => void;
+  setSelectedModel: (model: string) => void;
+}
+
+function statusTone(phase: RuntimeState["phase"]) {
+  if (phase === "error") return "status-pill-blocked";
+  if (phase === "completed") return "status-pill-done";
+  if (phase === "routing" || phase === "running" || phase === "accepted") {
+    return "status-pill-running";
+  }
+  return "status-pill-draft";
+}
+
+function statusLabel(phase: RuntimeState["phase"]) {
+  if (phase === "accepted") return "已提交";
+  if (phase === "routing" || phase === "running") return "生成中";
+  if (phase === "completed") return "已完成";
+  if (phase === "error") return "失败";
+  return "待开始";
+}
+
+export function ChatComposerPanel({
+  attachedFiles,
+  error,
+  fetchModels,
+  fileInputRef,
+  handleFileSelect,
+  handleRemoveFile,
+  handleSubmit,
+  input,
+  isComposerDisabled,
+  isLoading,
+  isModelsLoading,
+  lastAssistantMessage,
+  modelLoadError,
+  modelOptions,
+  onInputChange,
+  onKeyDown,
+  runtime,
+  selectedMode,
+  selectedModel,
+  setSelectedMode,
+  setSelectedModel,
+}: ChatComposerPanelProps) {
+  return (
+    <div
+      className="sticky bottom-0 z-20"
+      style={{
+        background:
+          "linear-gradient(to top, var(--warm-paper) 0%, var(--warm-paper) 85%, transparent 100%)",
+      }}
+    >
+      <div className="relative border-t border-[var(--warm-border)]/50 bg-[var(--warm-paper)]">
+        <div className="mx-auto w-full max-w-[760px] px-6 pb-5 pt-2.5">
+          <div
+            className="rounded-2xl border border-[var(--warm-border)] bg-[var(--warm-ivory)] transition-all duration-200 focus-within:border-[var(--warm-ring)]"
+            style={{ boxShadow: "var(--shadow-whisper)" }}
+          >
+            {(runtime.phase !== "idle" || error) && (
+              <div
+                className="border-b border-[var(--warm-border)] bg-[var(--neutral-150)] px-5 py-2.5"
+                aria-live="polite"
+              >
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                  <p className="text-[13px] text-muted-foreground">{error || runtime.label}</p>
+                  <Badge variant="outline" className={cn("text-[11px]", statusTone(runtime.phase))}>
+                    {statusLabel(runtime.phase)}
+                  </Badge>
+                </div>
+              </div>
+            )}
+
+            <AnimatePresence>
+              {runtime.activities.length > 0 && (
+                <motion.div
+                  key="activities"
+                  initial={{ opacity: 0, height: 0 }}
+                  animate={{ opacity: 1, height: "auto" }}
+                  exit={{ opacity: 0, height: 0 }}
+                  transition={{ duration: 0.2, ease: [0.16, 1, 0.3, 1] }}
+                  className="overflow-hidden"
+                >
+                  <div className="flex flex-col gap-1 border-b border-[var(--warm-border)] px-4 py-2">
+                    {runtime.activities.slice(0, 5).map((activity) => (
+                      <div key={activity.id} className="flex items-center gap-2 text-xs">
+                        {activity.status === "running" ? (
+                          <Loader2 className="size-3 shrink-0 animate-spin text-[var(--status-running)]" />
+                        ) : (
+                          <Check className="size-3 shrink-0 text-[var(--status-done)]" />
+                        )}
+                        <span
+                          className={cn(
+                            "truncate",
+                            activity.status === "running"
+                              ? "text-[var(--neutral-700)]"
+                              : "text-[var(--neutral-500)]",
+                          )}
+                        >
+                          {activity.label}
+                        </span>
+                        {activity.detail ? (
+                          <span className="ml-auto max-w-[120px] shrink-0 truncate text-[var(--neutral-400)]">
+                            {activity.detail}
+                          </span>
+                        ) : null}
+                      </div>
+                    ))}
+                    {runtime.activities.length > 5 ? (
+                      <p className="pl-5 text-xs text-[var(--neutral-400)]">
+                        +{runtime.activities.length - 5} 个任务...
+                      </p>
+                    ) : null}
+                  </div>
+                </motion.div>
+              )}
+            </AnimatePresence>
+
+            <div>
+              {attachedFiles.length > 0 ? (
+                <div className="flex flex-wrap gap-2 px-5 pt-3">
+                  {attachedFiles.map((file, index) => (
+                    <div
+                      key={`${file.name}-${index}`}
+                      className="flex items-center gap-1.5 rounded-md border border-[var(--warm-border)] bg-[var(--warm-ivory)] px-2.5 py-1 text-xs text-[var(--neutral-700)]"
+                    >
+                      <Paperclip className="size-3 shrink-0 text-[var(--neutral-500)]" />
+                      <span className="max-w-[120px] truncate">{file.name}</span>
+                      <button
+                        type="button"
+                        onClick={() => handleRemoveFile(index)}
+                        className="ml-0.5 text-[var(--neutral-400)] hover:text-[var(--neutral-700)]"
+                        aria-label={`移除 ${file.name}`}
+                      >
+                        <XIcon className="size-3" />
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              ) : null}
+              <Textarea
+                value={input}
+                onChange={(event) => {
+                  onInputChange(event.target.value);
+                }}
+                onKeyDown={onKeyDown}
+                placeholder={
+                  isModelsLoading
+                    ? "正在加载模型..."
+                    : selectedModel
+                      ? "输入问题或任务..."
+                      : "当前没有可用模型，暂时无法开始会话"
+                }
+                className="min-h-[100px] resize-none border-none bg-card px-5 py-4 text-[15px] leading-[24px] tracking-[-0.003em] focus-visible:ring-0"
+                disabled={isComposerDisabled}
+              />
+              <div className="flex flex-col gap-2 border-t border-[var(--warm-border)] bg-[var(--neutral-150)]/70 px-4 py-2.5 sm:flex-row sm:items-center sm:justify-between">
+                <div className="flex flex-wrap items-center gap-2">
+                  <ModePicker selected={selectedMode} onSelect={setSelectedMode} />
+                  <>
+                    <input
+                      ref={fileInputRef as React.RefObject<HTMLInputElement>}
+                      type="file"
+                      multiple
+                      className="hidden"
+                      onChange={handleFileSelect}
+                      accept="image/*,.pdf,.txt,.md,.csv,.json,.py,.ts,.tsx,.js,.jsx"
+                    />
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      onClick={() => fileInputRef.current?.click()}
+                      className="size-10 rounded-lg border border-transparent text-[var(--neutral-600)] hover:border-[var(--warm-border)] hover:bg-[var(--warm-ivory)]"
+                      title="上传附件"
+                    >
+                      <Paperclip className="size-4" />
+                    </Button>
+                  </>
+                  {lastAssistantMessage ? (
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      className="size-10 rounded-lg border border-transparent text-[var(--neutral-600)] hover:border-[var(--warm-border)] hover:bg-[var(--warm-ivory)]"
+                      onClick={() => navigator.clipboard.writeText(lastAssistantMessage.content)}
+                      title="复制回复"
+                    >
+                      <Copy className="size-4" />
+                    </Button>
+                  ) : null}
+                </div>
+                <div className="flex flex-wrap items-center justify-between gap-2 sm:justify-end">
+                  <ModelPicker
+                    models={modelOptions}
+                    selected={selectedModel}
+                    onSelect={setSelectedModel}
+                    isLoading={isModelsLoading}
+                    loadError={modelLoadError}
+                    onRetry={fetchModels}
+                  />
+                  <Button
+                    onClick={handleSubmit}
+                    disabled={!input.trim() || isComposerDisabled}
+                    size="icon-sm"
+                    className="size-10 rounded-md shadow-none"
+                  >
+                    {isLoading ? <Loader2 className="size-4 animate-spin" /> : <ArrowUp className="size-4" />}
+                  </Button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/workspace/chat-empty-state.tsx
+++ b/ui/src/components/workspace/chat-empty-state.tsx
@@ -1,0 +1,97 @@
+import { motion } from "framer-motion";
+import { Brain, Lightbulb, Rocket, Sparkles, type LucideIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+const QUICK_PROMPT_ITEMS: Array<{
+  icon: LucideIcon;
+  prompt: string;
+}> = [
+  { icon: Rocket, prompt: "帮我整理本周项目进展，输出 3 条重点结论。" },
+  { icon: Lightbulb, prompt: "生成一版 CRM MVP 范围说明，控制在一页内。" },
+  { icon: Brain, prompt: "把下面的会议讨论改写成正式纪要。" },
+  { icon: Sparkles, prompt: "总结当前续费风险，并给出 3 条行动建议。" },
+];
+
+interface ChatEmptyStateProps {
+  onPromptSelect: (prompt: string) => void;
+}
+
+export function ChatEmptyState({ onPromptSelect }: ChatEmptyStateProps) {
+  return (
+    <div className="flex flex-1 flex-col px-6 pt-14">
+      <div className="mx-auto w-full max-w-[560px]">
+        <motion.div
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.3, ease: [0.16, 1, 0.3, 1] }}
+          className="mb-7"
+        >
+          <div
+            className="inline-flex size-10 items-center justify-center rounded-xl border bg-[var(--warm-ivory)] text-[var(--neutral-600)]"
+            style={{ boxShadow: "var(--shadow-whisper)" }}
+          >
+            <Sparkles className="size-4" />
+          </div>
+          <p className="mt-5 text-[11px] uppercase tracking-[0.08em] text-muted-foreground">
+            Exploratory Session
+          </p>
+          <h2 className="mt-2 text-[28px] leading-[36px] font-semibold tracking-[-0.02em] text-foreground">
+            临时会话
+          </h2>
+          <p className="mt-2 max-w-[440px] text-[14px] leading-[22px] text-muted-foreground">
+            用一个明确任务开始探索。首次发送成功后，系统才会创建正式会话记录。
+          </p>
+        </motion.div>
+
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ delay: 0.15, duration: 0.2 }}
+          className="mb-3 flex items-center gap-2"
+        >
+          <p className="text-[12px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
+            快速开始
+          </p>
+          <span className="h-px flex-1 bg-border/50" />
+        </motion.div>
+        <div className="grid gap-2.5 sm:grid-cols-2">
+          {QUICK_PROMPT_ITEMS.map(({ icon: Icon, prompt }, i) => (
+            <motion.button
+              key={prompt}
+              initial={{ opacity: 0, y: 12 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{
+                delay: 0.2 + i * 0.06,
+                duration: 0.25,
+                ease: [0.16, 1, 0.3, 1],
+              }}
+              onClick={() => {
+                onPromptSelect(prompt);
+              }}
+              className="group flex items-start gap-3 rounded-xl border bg-[var(--warm-ivory)] px-4 py-3.5 text-left transition-all duration-200 hover:border-[var(--warm-ring)] hover:bg-[var(--neutral-150)]"
+            >
+              <span
+                className={cn(
+                  "mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-md border border-black/5 transition-colors",
+                  i === 0
+                    ? "bg-[#e2e8ee] text-[#49617a]"
+                    : i === 1
+                      ? "bg-[#ece3d6] text-[#756046]"
+                      : i === 2
+                        ? "bg-[#eae6ef] text-[#66597c]"
+                        : "bg-[#e4ebe4] text-[#4c6554]",
+                )}
+              >
+                <Icon className="size-4" />
+              </span>
+              <span className="text-[13px] leading-[20px] text-muted-foreground group-hover:text-foreground">
+                {prompt}
+              </span>
+            </motion.button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/workspace/chat-message-area.tsx
+++ b/ui/src/components/workspace/chat-message-area.tsx
@@ -1,0 +1,143 @@
+import { AnimatePresence, motion } from "framer-motion";
+import { toast } from "sonner";
+
+import { MessageBubble, StreamingDots } from "@/components/workspace/chat-message-ui";
+import { ClarificationCard } from "@/components/workspace/messages/clarification-card";
+import { SubtaskCard } from "@/components/workspace/messages/subtask-card";
+import { parseClarificationContent } from "@/core/messages/clarification";
+import type { ChatMessage } from "@/core/chat/types";
+import type { Subtask } from "@/core/tasks/types";
+
+interface PendingClarification {
+  id: string;
+  content: string;
+}
+
+interface ChatMessageAreaProps {
+  isLoading: boolean;
+  messages: ChatMessage[];
+  pendingClarification: PendingClarification | null;
+  tasks: Record<string, Subtask>;
+  onClarificationRespond: (response: string, toolCallId: string) => void;
+  onPendingClarificationHandled: () => void;
+}
+
+export function ChatMessageArea({
+  isLoading,
+  messages,
+  pendingClarification,
+  tasks,
+  onClarificationRespond,
+  onPendingClarificationHandled,
+}: ChatMessageAreaProps) {
+  const taskList = Object.values(tasks);
+
+  return (
+    <div className="mx-auto flex w-full max-w-[760px] flex-col gap-5 px-6 py-6">
+      <AnimatePresence initial={false}>
+        {messages.map((message) => {
+          if (
+            message.role === "assistant" &&
+            (message.content.includes("需要") ||
+              message.content.includes("?") ||
+              message.content.includes("选择") ||
+              message.content.includes("确认"))
+          ) {
+            try {
+              const parsed = parseClarificationContent(message.content);
+              if (parsed.question && parsed.clarificationType) {
+                return (
+                  <ClarificationCard
+                    key={message.id}
+                    question={parsed.question}
+                    context={parsed.context}
+                    options={parsed.options}
+                    clarificationType={parsed.clarificationType}
+                    onRespond={(response) => {
+                      onClarificationRespond(response, message.id);
+                    }}
+                  />
+                );
+              }
+            } catch (e) {
+              toast.error("AI 澄清请求解析失败，请查看原始消息");
+              console.warn("[clarification] parse failed:", e);
+            }
+          }
+
+          return (
+            <motion.div
+              key={message.id}
+              initial={{ opacity: 0, y: 12 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.25, ease: [0.16, 1, 0.3, 1] }}
+            >
+              <MessageBubble
+                key={message.id}
+                message={message}
+                isMessageStreaming={message.isStreaming || message.isReasoningStreaming}
+              />
+            </motion.div>
+          );
+        })}
+      </AnimatePresence>
+
+      {pendingClarification ? (
+        <motion.div
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.25, ease: [0.16, 1, 0.3, 1] }}
+          className="mt-4"
+        >
+          {(() => {
+            try {
+              const parsed = parseClarificationContent(pendingClarification.content);
+              return (
+                <ClarificationCard
+                  question={parsed.question}
+                  context={parsed.context}
+                  options={parsed.options}
+                  clarificationType={parsed.clarificationType}
+                  onRespond={(response) => {
+                    onClarificationRespond(response, pendingClarification.id);
+                    onPendingClarificationHandled();
+                  }}
+                />
+              );
+            } catch (e) {
+              toast.error("AI 澄清请求解析失败，请查看原始消息");
+              console.warn("[clarification] parse failed:", e);
+              return null;
+            }
+          })()}
+        </motion.div>
+      ) : null}
+
+      {taskList.length > 0 ? (
+        <div className="mt-4 flex flex-col gap-3">
+          <div className="text-sm text-muted-foreground">
+            正在执行 {taskList.length} 个子任务...
+          </div>
+          {taskList.map((task) => (
+            <SubtaskCard key={task.id} taskId={task.id} isLoading={isLoading} />
+          ))}
+        </div>
+      ) : null}
+
+      {isLoading &&
+        !messages.some((message) => message.content.trim().length > 0 && message.role === "assistant") && (
+          <motion.div
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.2 }}
+            className="flex justify-start"
+          >
+            <div className="flex items-center gap-2 rounded-xl border border-[var(--warm-border)] bg-[var(--neutral-150)] px-4 py-2">
+              <StreamingDots />
+              <span className="text-[13px] text-muted-foreground">正在生成回复</span>
+            </div>
+          </motion.div>
+        )}
+    </div>
+  );
+}

--- a/ui/src/core/chat/types.ts
+++ b/ui/src/core/chat/types.ts
@@ -1,0 +1,92 @@
+export interface StoredMessage {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  created_at?: string;
+}
+
+export interface RuntimeModelOption {
+  name: string;
+  provider: string;
+  model: string;
+  display_name?: string | null;
+  description?: string | null;
+  supports_vision: boolean;
+  is_default: boolean;
+}
+
+export interface RuntimeModelCatalogResponse {
+  models: RuntimeModelOption[];
+  default_model?: string | null;
+}
+
+export interface RuntimeActivity {
+  id: string;
+  label: string;
+  status: "running" | "completed";
+  detail?: string;
+}
+
+export interface RuntimeState {
+  phase: "idle" | "accepted" | "routing" | "running" | "completed" | "error";
+  label: string;
+  activities: RuntimeActivity[];
+}
+
+export interface StreamEventUserMessage {
+  id: string;
+  role: "user";
+  content: string;
+  created_at?: string;
+}
+
+export interface StreamEventAssistantMessage {
+  id: string;
+  role: "assistant";
+  content: string;
+  created_at?: string;
+}
+
+export type StreamEvent =
+  | { type: "status"; phase: RuntimeState["phase"]; label: string }
+  | { type: "user_message"; message: StreamEventUserMessage }
+  | { type: "thinking"; message_id: string; content: string }
+  | { type: "assistant_message"; message_id: string; content: string }
+  | { type: "assistant_final"; message: StreamEventAssistantMessage }
+  | {
+      type: "team_activity";
+      activity: {
+        id: string;
+        label: string;
+        status: RuntimeActivity["status"];
+        detail?: string | null;
+      };
+    }
+  | { type: "task_started"; task: { id: string; description: string; status: "in_progress" } }
+  | { type: "task_running"; task: { id: string; message?: unknown } }
+  | { type: "task_completed"; task: { id: string; result?: string; status: "completed" } }
+  | { type: "task_failed"; task: { id: string; error?: string; status: "failed" } }
+  | { type: "clarification_request"; clarification: { id: string; content: string } }
+  | { type: "artifact"; path: string; filename?: string }
+  | {
+      type: "title";
+      conversation: ConversationRecord;
+    }
+  | { type: "done" };
+
+export type ChatMessage = StoredMessage & {
+  pendingPersist?: boolean;
+  isStreaming?: boolean;
+  thinking?: string;
+  isReasoningStreaming?: boolean;
+};
+
+export type ConversationMode = "flash" | "thinking" | "pro" | "ultra";
+
+export interface ConversationRecord {
+  id: string;
+  title: string;
+  title_status: "pending" | "generated" | "fallback" | "manual";
+  updated_at: string;
+  created_at: string;
+}


### PR DESCRIPTION
Summary
- extract conversation-scoped trace orchestration out of supervisor.py
- split sqlite checkpoint access from trace parsing and add trace service coverage
- reduce non-streaming DeerFlow bridge coupling by running act() via coroutine execution
- split v0-ai-chat.tsx into empty-state, message-area, and composer panel components

Validation
- uv run ruff check swarmmind tests
- cd ui && pnpm exec tsc --noEmit
- make test