### PR TITLE
Further reduce supervisor and runtime debt

### DIFF
--- a/swarmmind/agents/general_agent.py
+++ b/swarmmind/agents/general_agent.py
@@ -9,12 +9,11 @@ import json
 import logging
 import uuid
 from collections.abc import AsyncGenerator, Generator
-from dataclasses import dataclass, field
 from typing import Any
 
 import deerflow.client as deerflow_client_module
 from deerflow.client import DeerFlowClient, StreamEvent
-from langchain_core.messages import AIMessage, AIMessageChunk, HumanMessage, ToolMessage
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 
 from swarmmind.agents.base import BaseAgent
 from swarmmind.context_broker import update_proposal_result
@@ -23,20 +22,15 @@ from swarmmind.prompting import rewrite_swarmmind_identity_prompt
 from swarmmind.runtime import RuntimeExecutionError, ensure_default_runtime_instance
 from swarmmind.runtime.models import RuntimeInstance
 from swarmmind.services.runtime_bridge import iter_async_generator_in_thread, run_coroutine_blocking
+from swarmmind.services.runtime_event_processing import (
+    StreamCaptureState,
+    iter_new_turn_messages,
+    process_custom_mode_chunk,
+    process_messages_mode_chunk,
+    process_values_mode_message,
+)
 
 logger = logging.getLogger(__name__)
-
-
-@dataclass
-class _StreamCaptureState:
-    """Mutable capture state for a single async DeerFlow turn."""
-
-    current_chunk_msg_id: str | None = None
-    accumulated_reasoning: str = ""
-    accumulated_content: str = ""
-    final_text: str = ""
-    tool_results: list[str] = field(default_factory=list)
-    seen_ids: set[str] = field(default_factory=set)
 
 
 class SwarmMindDeerFlowClient(DeerFlowClient):
@@ -377,7 +371,7 @@ class DeerFlowRuntimeAdapter(BaseAgent):
         state: dict[str, Any] = {"messages": [HumanMessage(content=goal, id=current_user_message_id)]}
         runtime_context = {"thread_id": thread_id}
 
-        capture_state = _StreamCaptureState()
+        capture_state = StreamCaptureState()
 
         async for mode_tag, chunk in self._client._agent.astream(
             state,
@@ -387,18 +381,18 @@ class DeerFlowRuntimeAdapter(BaseAgent):
         ):
             if mode_tag == "messages":
                 msg_chunk, _metadata = chunk
-                for event in self._process_messages_mode_chunk(msg_chunk, capture_state):
+                for event in process_messages_mode_chunk(msg_chunk, capture_state):
                     yield event
 
             elif mode_tag == "custom":
-                event = self._process_custom_mode_chunk(chunk)
+                event = process_custom_mode_chunk(chunk)
                 if event is not None:
                     yield event
 
             elif mode_tag == "values":
                 messages = chunk.get("messages", [])
-                for msg in self._iter_new_turn_messages(messages, current_user_message_id, capture_state.seen_ids):
-                    for event in self._process_values_mode_message(msg, capture_state):
+                for msg in iter_new_turn_messages(messages, current_user_message_id, capture_state.seen_ids):
+                    for event in process_values_mode_message(msg, capture_state, self._client._extract_text):
                         yield event
 
         # Fallback: if messages mode captured content but values mode didn't
@@ -456,157 +450,6 @@ class DeerFlowRuntimeAdapter(BaseAgent):
             pass
         return self._last_final_text, self._last_tool_results
 
-    def _process_messages_mode_chunk(
-        self,
-        msg_chunk: object,
-        capture_state: _StreamCaptureState,
-    ) -> list[dict[str, Any]]:
-        """Convert a streaming AI chunk into accumulated reasoning/content events."""
-        if not isinstance(msg_chunk, AIMessageChunk):
-            return []
-
-        chunk_id = getattr(msg_chunk, "id", None)
-        if chunk_id and chunk_id != capture_state.current_chunk_msg_id:
-            capture_state.current_chunk_msg_id = chunk_id
-            capture_state.accumulated_reasoning = ""
-            capture_state.accumulated_content = ""
-
-        if not capture_state.current_chunk_msg_id:
-            capture_state.current_chunk_msg_id = str(uuid.uuid4())
-
-        events: list[dict[str, Any]] = []
-        reasoning_delta = self._extract_reasoning_delta(msg_chunk)
-        if reasoning_delta:
-            capture_state.accumulated_reasoning += reasoning_delta
-            events.append(
-                {
-                    "type": "assistant_reasoning",
-                    "message_id": capture_state.current_chunk_msg_id,
-                    "content": capture_state.accumulated_reasoning,
-                }
-            )
-
-        content_delta = self._extract_content_delta(msg_chunk)
-        if content_delta:
-            capture_state.accumulated_content += content_delta
-            events.append(
-                {
-                    "type": "assistant_message",
-                    "message_id": capture_state.current_chunk_msg_id,
-                    "content": capture_state.accumulated_content,
-                }
-            )
-
-        return events
-
-    @staticmethod
-    def _process_custom_mode_chunk(event: object) -> dict[str, Any] | None:
-        """Normalize supported custom task events from DeerFlow."""
-        logger.debug("Custom event received: %s", event)
-        if not isinstance(event, dict) or event.get("type") not in {
-            "task_started",
-            "task_running",
-            "task_completed",
-            "task_failed",
-        }:
-            return None
-
-        logger.info("Task event: type=%s, task_id=%s", event.get("type"), event.get("task_id"))
-        return {
-            "type": "custom_event",
-            "event_type": event["type"],
-            "task_id": event.get("task_id"),
-            "description": event.get("description"),
-            "message": event.get("message"),
-            "result": event.get("result"),
-            "error": event.get("error"),
-        }
-
-    @staticmethod
-    def _iter_new_turn_messages(
-        messages: list[object],
-        current_user_message_id: str,
-        seen_ids: set[str],
-    ) -> Generator[object, None, None]:
-        """Yield unseen non-user messages after the current turn anchor."""
-        turn_anchor_index = next(
-            (
-                index
-                for index, message in enumerate(messages)
-                if isinstance(message, HumanMessage) and getattr(message, "id", None) == current_user_message_id
-            ),
-            -1,
-        )
-        if turn_anchor_index == -1:
-            return
-
-        for msg in messages[turn_anchor_index + 1 :]:
-            if isinstance(msg, HumanMessage):
-                continue
-
-            msg_id = getattr(msg, "id", None)
-            if msg_id and msg_id in seen_ids:
-                continue
-            if msg_id:
-                seen_ids.add(msg_id)
-            yield msg
-
-    def _process_values_mode_message(
-        self,
-        msg: object,
-        capture_state: _StreamCaptureState,
-    ) -> list[dict[str, Any]]:
-        """Convert full values-mode messages into runtime events and summaries."""
-        msg_id = getattr(msg, "id", None)
-
-        if isinstance(msg, AIMessage):
-            events: list[dict[str, Any]] = []
-            if msg.tool_calls:
-                tool_names = [tc.get("name") for tc in msg.tool_calls]
-                logger.info("AI tool calls: %s", tool_names)
-                events.append(
-                    {
-                        "type": "assistant_tool_calls",
-                        "message_id": msg_id,
-                        "tool_calls": [
-                            {
-                                "name": tool_call.get("name"),
-                                "args": tool_call.get("args", {}),
-                                "id": tool_call.get("id"),
-                            }
-                            for tool_call in msg.tool_calls
-                        ],
-                    }
-                )
-
-            content = self._client._extract_text(msg.content)
-            if content:
-                capture_state.final_text = content
-            return events
-
-        if isinstance(msg, ToolMessage):
-            tool_name = getattr(msg, "name", None) or "unknown"
-            tool_content = self._client._extract_text(msg.content)
-            logger.info(
-                "Tool result: name=%s, content_preview=%s",
-                tool_name,
-                tool_content[:100] if tool_content else "(empty)",
-            )
-            if tool_content:
-                capture_state.tool_results.append(f"[{tool_name}]: {tool_content[:200]}")
-
-            return [
-                {
-                    "type": "tool_result",
-                    "message_id": msg_id,
-                    "tool_name": tool_name,
-                    "tool_call_id": getattr(msg, "tool_call_id", None),
-                    "content": tool_content,
-                }
-            ]
-
-        return []
-
     def _resolve_runtime_options(
         self,
         runtime_options: ConversationRuntimeOptions | None = None,
@@ -643,41 +486,6 @@ class DeerFlowRuntimeAdapter(BaseAgent):
                 return "\n\n".join(reasoning_parts)
 
         return None
-
-    @staticmethod
-    def _extract_reasoning_delta(chunk: AIMessageChunk) -> str | None:
-        """Extract incremental reasoning content from a streaming chunk."""
-        additional_kwargs = getattr(chunk, "additional_kwargs", None) or {}
-        reasoning = additional_kwargs.get("reasoning_content")
-        if isinstance(reasoning, str) and reasoning:
-            return reasoning
-
-        content = getattr(chunk, "content", None)
-        if isinstance(content, list):
-            for block in content:
-                if isinstance(block, dict) and block.get("type") == "thinking":
-                    thinking = block.get("thinking", "")
-                    if thinking:
-                        return thinking
-
-        return None
-
-    @staticmethod
-    def _extract_content_delta(chunk: AIMessageChunk) -> str | None:
-        """Extract incremental text content from a streaming chunk."""
-        content = getattr(chunk, "content", None)
-        if isinstance(content, str) and content:
-            return content
-        if isinstance(content, list):
-            parts = []
-            for block in content:
-                if isinstance(block, dict) and block.get("type") == "text":
-                    text = block.get("text", "")
-                    if text:
-                        parts.append(text)
-            return "".join(parts) if parts else None
-        return None
-
 
 # Backward-compatible alias retained while call sites migrate away from the
 # misleading "GeneralAgent" name.

--- a/swarmmind/api/conversation_routes.py
+++ b/swarmmind/api/conversation_routes.py
@@ -1,0 +1,132 @@
+"""Conversation route registration helpers for the supervisor API."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from fastapi import APIRouter
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel
+
+from swarmmind.models import (
+    Conversation,
+    ConversationListResponse,
+    GoalRequest,
+    Message,
+    MessageListResponse,
+    SendMessageRequest,
+)
+
+
+class ClarificationResponseRequest(BaseModel):
+    """Request to respond to a clarification prompt."""
+
+    tool_call_id: str
+    response: str
+
+
+@dataclass(frozen=True)
+class ConversationRouteHandlers:
+    """Direct-call handlers re-exported by supervisor for compatibility."""
+
+    list_conversations: Callable[[], ConversationListResponse]
+    create_conversation: Callable[[GoalRequest], Conversation]
+    get_conversation: Callable[[str], Conversation]
+    get_conversation_messages: Callable[[str], MessageListResponse]
+    send_message: Callable[[str, SendMessageRequest], object]
+    delete_conversation: Callable[[str], dict]
+    get_conversation_trace: Callable[[str], dict]
+    stream_conversation_message: Callable[[str, SendMessageRequest], object]
+    send_message_stream: Callable[[str, SendMessageRequest], StreamingResponse]
+    respond_to_clarification: Callable[[str, ClarificationResponseRequest], Message]
+
+
+@dataclass(frozen=True)
+class ConversationRouteDeps:
+    """Injected dependencies for the conversation router."""
+
+    list_conversations: Callable[[], ConversationListResponse]
+    create_conversation: Callable[[GoalRequest], Conversation]
+    get_conversation: Callable[[str], Conversation]
+    get_conversation_messages: Callable[[str], MessageListResponse]
+    send_message: Callable[[str, SendMessageRequest], object]
+    delete_conversation: Callable[[str], dict]
+    get_conversation_trace: Callable[[str], dict]
+    stream_conversation_message: Callable[[str, SendMessageRequest], object]
+    respond_to_clarification: Callable[[str, str, str], Message]
+
+
+def build_conversation_router(*, deps: ConversationRouteDeps) -> tuple[APIRouter, ConversationRouteHandlers]:
+    """Build the conversation router from injected supervisor dependencies."""
+    router = APIRouter()
+
+    @router.get("/conversations")
+    def list_conversations() -> ConversationListResponse:
+        """List all conversations ordered by updated_at descending."""
+        return deps.list_conversations()
+
+    @router.post("/conversations")
+    def create_conversation(body: GoalRequest) -> Conversation:
+        """Create a new conversation with the first user message."""
+        return deps.create_conversation(body)
+
+    @router.get("/conversations/{conversation_id}")
+    def get_conversation(conversation_id: str) -> Conversation:
+        """Get a single conversation by ID."""
+        return deps.get_conversation(conversation_id)
+
+    @router.get("/conversations/{conversation_id}/messages")
+    def get_conversation_messages(conversation_id: str) -> MessageListResponse:
+        """Get all messages for a conversation."""
+        return deps.get_conversation_messages(conversation_id)
+
+    @router.post("/conversations/{conversation_id}/messages", include_in_schema=False)
+    def send_message(conversation_id: str, body: SendMessageRequest):
+        """Internal compatibility endpoint for non-streaming conversation turns."""
+        return deps.send_message(conversation_id, body)
+
+    @router.delete("/conversations/{conversation_id}")
+    def delete_conversation(conversation_id: str) -> dict:
+        """Delete a conversation and all its messages."""
+        return deps.delete_conversation(conversation_id)
+
+    @router.get("/conversations/{conversation_id}/trace")
+    def get_conversation_trace(conversation_id: str) -> dict:
+        """Return the collaboration trace for a conversation."""
+        return deps.get_conversation_trace(conversation_id)
+
+    def _stream_conversation_message(conversation_id: str, body: SendMessageRequest):
+        """Stream a ChatSession turn with SwarmMind runtime semantics."""
+        yield from deps.stream_conversation_message(conversation_id, body)
+
+    @router.post("/conversations/{conversation_id}/messages/stream")
+    def send_message_stream(conversation_id: str, body: SendMessageRequest) -> StreamingResponse:
+        """Stream a ChatSession turn with runtime state and final persistence."""
+        get_conversation(conversation_id)
+        return StreamingResponse(
+            _stream_conversation_message(conversation_id, body),
+            media_type="application/x-ndjson",
+        )
+
+    @router.post("/conversations/{conversation_id}/clarification")
+    def respond_to_clarification(conversation_id: str, body: ClarificationResponseRequest) -> Message:
+        """Resume the conversation from a clarification response."""
+        return deps.respond_to_clarification(
+            conversation_id,
+            body.tool_call_id,
+            body.response,
+        )
+
+    return router, ConversationRouteHandlers(
+        list_conversations=list_conversations,
+        create_conversation=create_conversation,
+        get_conversation=get_conversation,
+        get_conversation_messages=get_conversation_messages,
+        send_message=send_message,
+        delete_conversation=delete_conversation,
+        get_conversation_trace=get_conversation_trace,
+        stream_conversation_message=_stream_conversation_message,
+        send_message_stream=send_message_stream,
+        respond_to_clarification=respond_to_clarification,
+    )

--- a/swarmmind/api/supervisor.py
+++ b/swarmmind/api/supervisor.py
@@ -7,9 +7,15 @@ from datetime import UTC, datetime
 
 from fastapi import FastAPI, HTTPException, Query
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
+from swarmmind.api.conversation_routes import (
+    ClarificationResponseRequest as ConversationClarificationResponseRequest,
+)
+from swarmmind.api.conversation_routes import (
+    ConversationRouteDeps,
+    build_conversation_router,
+)
 from swarmmind.config import ACTION_TIMEOUT_SECONDS, API_HOST, API_PORT
 from swarmmind.context_broker import (
     derive_situation_tag,
@@ -383,49 +389,34 @@ def _conversation_execution_service() -> ConversationExecutionService:
     )
 
 
-@app.get("/conversations")
-def list_conversations() -> ConversationListResponse:
-    """List all conversations ordered by updated_at descending."""
+def _list_conversations() -> ConversationListResponse:
     rows = conversation_repo.list_all()
     items = [_db_to_conversation(row) for row in rows]
     return ConversationListResponse(items=items, total=len(items))
 
 
-@app.post("/conversations")
-def create_conversation(body: GoalRequest) -> Conversation:
-    """Create a new conversation with the first user message."""
+def _create_conversation(body: GoalRequest) -> Conversation:
     conv = conversation_repo.create(NEW_CONVERSATION_TITLE, "pending")
     return _db_to_conversation(conv)
 
 
-@app.get("/conversations/{conversation_id}")
-def get_conversation(conversation_id: str) -> Conversation:
-    """Get a single conversation by ID."""
+def _get_conversation(conversation_id: str) -> Conversation:
     conv = conversation_repo.get_by_id(conversation_id)
     return _db_to_conversation(conv)
 
 
-@app.get("/conversations/{conversation_id}/messages")
-def get_conversation_messages(conversation_id: str) -> MessageListResponse:
-    """Get all messages for a conversation."""
+def _get_conversation_messages(conversation_id: str) -> MessageListResponse:
     conversation_repo.get_by_id(conversation_id)
     rows = message_repo.list_by_conversation(conversation_id)
     items = [_db_to_message(row) for row in rows]
     return MessageListResponse(items=items, total=len(items))
 
 
-@app.post("/conversations/{conversation_id}/messages", include_in_schema=False)
-def send_message(conversation_id: str, body: SendMessageRequest):
-    """Internal compatibility endpoint for non-streaming conversation turns.
-
-    All execution flows through the single DeerFlow Runtime Instance.
-    """
+def _send_message(conversation_id: str, body: SendMessageRequest):
     return _conversation_execution_service().send_message(conversation_id, body)
 
 
-@app.delete("/conversations/{conversation_id}")
-def delete_conversation(conversation_id: str) -> dict:
-    """Delete a conversation and all its messages."""
+def _delete_conversation(conversation_id: str) -> dict:
     conversation_repo.get_by_id(conversation_id)
     conversation_repo.delete(conversation_id)
     return {"status": "deleted", "id": conversation_id}
@@ -434,21 +425,7 @@ def delete_conversation(conversation_id: str) -> dict:
 # ---- Collaboration Trace Endpoints ----
 
 
-@app.get("/conversations/{conversation_id}/trace")
-def get_conversation_trace(conversation_id: str) -> dict:
-    """获取会话的协作轨迹（回放用）。
-
-    复用 deer-flow checkpointer 数据，零侵入设计：
-    1. 从 conversations 表读取 thread_id
-    2. 从 deer-flow SqliteSaver 读取 checkpoints
-    3. 解析 ThreadState 转换为协作轨迹
-
-    Args:
-        conversation_id: SwarmMind conversation ID (maps to deer-flow thread_id)
-
-    Returns:
-        Collaboration trace with events, status, and summary.
-    """
+def _get_conversation_trace(conversation_id: str) -> dict:
     return conversation_trace_service.get_trace(conversation_id)
 
 
@@ -457,37 +434,41 @@ def _stream_conversation_message(conversation_id: str, body: SendMessageRequest)
     yield from _conversation_execution_service().stream_message(conversation_id, body)
 
 
-@app.post("/conversations/{conversation_id}/messages/stream")
-def send_message_stream(conversation_id: str, body: SendMessageRequest) -> StreamingResponse:
-    """Stream a ChatSession turn with runtime state and final persistence."""
-    # Validate before opening the streaming response so 404 is returned normally.
-    get_conversation(conversation_id)
-    return StreamingResponse(
-        _stream_conversation_message(conversation_id, body),
-        media_type="application/x-ndjson",
-    )
-
-
-class ClarificationResponseRequest(BaseModel):
-    """Request to respond to a clarification prompt."""
-
-    tool_call_id: str
-    response: str
-
-
-@app.post("/conversations/{conversation_id}/clarification")
-def respond_to_clarification(conversation_id: str, body: ClarificationResponseRequest) -> Message:
-    """Respond to a clarification request from the AI.
-
-    This endpoint is called when the user responds to an ask_clarification tool call.
-    The response is added as a ToolMessage to the conversation history, and the
-    conversation is resumed.
-    """
+def _respond_to_clarification(conversation_id: str, tool_call_id: str, response: str) -> Message:
     return _conversation_execution_service().respond_to_clarification(
         conversation_id,
-        body.tool_call_id,
-        body.response,
+        tool_call_id,
+        response,
     )
+
+
+conversation_router, conversation_handlers = build_conversation_router(
+    deps=ConversationRouteDeps(
+        list_conversations=_list_conversations,
+        create_conversation=_create_conversation,
+        get_conversation=_get_conversation,
+        get_conversation_messages=_get_conversation_messages,
+        send_message=_send_message,
+        delete_conversation=_delete_conversation,
+        get_conversation_trace=_get_conversation_trace,
+        stream_conversation_message=_stream_conversation_message,
+        respond_to_clarification=_respond_to_clarification,
+    ),
+)
+
+ClarificationResponseRequest = ConversationClarificationResponseRequest
+list_conversations = conversation_handlers.list_conversations
+create_conversation = conversation_handlers.create_conversation
+get_conversation = conversation_handlers.get_conversation
+get_conversation_messages = conversation_handlers.get_conversation_messages
+send_message = conversation_handlers.send_message
+delete_conversation = conversation_handlers.delete_conversation
+get_conversation_trace = conversation_handlers.get_conversation_trace
+_stream_conversation_message = conversation_handlers.stream_conversation_message
+send_message_stream = conversation_handlers.send_message_stream
+respond_to_clarification = conversation_handlers.respond_to_clarification
+
+app.include_router(conversation_router)
 
 
 # ---- Run ----

--- a/swarmmind/services/runtime_event_processing.py
+++ b/swarmmind/services/runtime_event_processing.py
@@ -1,0 +1,211 @@
+"""Helpers for DeerFlow runtime stream capture and event normalization."""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from collections.abc import Callable, Generator
+from dataclasses import dataclass, field
+from typing import Any
+
+from langchain_core.messages import AIMessage, AIMessageChunk, HumanMessage, ToolMessage
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class StreamCaptureState:
+    """Mutable capture state for a single async DeerFlow turn."""
+
+    current_chunk_msg_id: str | None = None
+    accumulated_reasoning: str = ""
+    accumulated_content: str = ""
+    final_text: str = ""
+    tool_results: list[str] = field(default_factory=list)
+    seen_ids: set[str] = field(default_factory=set)
+
+
+def process_messages_mode_chunk(
+    msg_chunk: object,
+    capture_state: StreamCaptureState,
+) -> list[dict[str, Any]]:
+    """Convert a streaming AI chunk into accumulated reasoning/content events."""
+    if not isinstance(msg_chunk, AIMessageChunk):
+        return []
+
+    chunk_id = getattr(msg_chunk, "id", None)
+    if chunk_id and chunk_id != capture_state.current_chunk_msg_id:
+        capture_state.current_chunk_msg_id = chunk_id
+        capture_state.accumulated_reasoning = ""
+        capture_state.accumulated_content = ""
+
+    if not capture_state.current_chunk_msg_id:
+        capture_state.current_chunk_msg_id = str(uuid.uuid4())
+
+    events: list[dict[str, Any]] = []
+    reasoning_delta = extract_reasoning_delta(msg_chunk)
+    if reasoning_delta:
+        capture_state.accumulated_reasoning += reasoning_delta
+        events.append(
+            {
+                "type": "assistant_reasoning",
+                "message_id": capture_state.current_chunk_msg_id,
+                "content": capture_state.accumulated_reasoning,
+            }
+        )
+
+    content_delta = extract_content_delta(msg_chunk)
+    if content_delta:
+        capture_state.accumulated_content += content_delta
+        events.append(
+            {
+                "type": "assistant_message",
+                "message_id": capture_state.current_chunk_msg_id,
+                "content": capture_state.accumulated_content,
+            }
+        )
+
+    return events
+
+
+def process_custom_mode_chunk(event: object) -> dict[str, Any] | None:
+    """Normalize supported custom task events from DeerFlow."""
+    logger.debug("Custom event received: %s", event)
+    if not isinstance(event, dict) or event.get("type") not in {
+        "task_started",
+        "task_running",
+        "task_completed",
+        "task_failed",
+    }:
+        return None
+
+    logger.info("Task event: type=%s, task_id=%s", event.get("type"), event.get("task_id"))
+    return {
+        "type": "custom_event",
+        "event_type": event["type"],
+        "task_id": event.get("task_id"),
+        "description": event.get("description"),
+        "message": event.get("message"),
+        "result": event.get("result"),
+        "error": event.get("error"),
+    }
+
+
+def iter_new_turn_messages(
+    messages: list[object],
+    current_user_message_id: str,
+    seen_ids: set[str],
+) -> Generator[object, None, None]:
+    """Yield unseen non-user messages after the current turn anchor."""
+    turn_anchor_index = next(
+        (
+            index
+            for index, message in enumerate(messages)
+            if isinstance(message, HumanMessage) and getattr(message, "id", None) == current_user_message_id
+        ),
+        -1,
+    )
+    if turn_anchor_index == -1:
+        return
+
+    for msg in messages[turn_anchor_index + 1 :]:
+        if isinstance(msg, HumanMessage):
+            continue
+
+        msg_id = getattr(msg, "id", None)
+        if msg_id and msg_id in seen_ids:
+            continue
+        if msg_id:
+            seen_ids.add(msg_id)
+        yield msg
+
+
+def process_values_mode_message(
+    msg: object,
+    capture_state: StreamCaptureState,
+    extract_text: Callable[[object], str],
+) -> list[dict[str, Any]]:
+    """Convert full values-mode messages into runtime events and summaries."""
+    msg_id = getattr(msg, "id", None)
+
+    if isinstance(msg, AIMessage):
+        events: list[dict[str, Any]] = []
+        if msg.tool_calls:
+            tool_names = [tc.get("name") for tc in msg.tool_calls]
+            logger.info("AI tool calls: %s", tool_names)
+            events.append(
+                {
+                    "type": "assistant_tool_calls",
+                    "message_id": msg_id,
+                    "tool_calls": [
+                        {
+                            "name": tool_call.get("name"),
+                            "args": tool_call.get("args", {}),
+                            "id": tool_call.get("id"),
+                        }
+                        for tool_call in msg.tool_calls
+                    ],
+                }
+            )
+
+        content = extract_text(msg.content)
+        if content:
+            capture_state.final_text = content
+        return events
+
+    if isinstance(msg, ToolMessage):
+        tool_name = getattr(msg, "name", None) or "unknown"
+        tool_content = extract_text(msg.content)
+        logger.info(
+            "Tool result: name=%s, content_preview=%s",
+            tool_name,
+            tool_content[:100] if tool_content else "(empty)",
+        )
+        if tool_content:
+            capture_state.tool_results.append(f"[{tool_name}]: {tool_content[:200]}")
+
+        return [
+            {
+                "type": "tool_result",
+                "message_id": msg_id,
+                "tool_name": tool_name,
+                "tool_call_id": getattr(msg, "tool_call_id", None),
+                "content": tool_content,
+            }
+        ]
+
+    return []
+
+
+def extract_reasoning_delta(chunk: AIMessageChunk) -> str | None:
+    """Extract incremental reasoning content from a streaming chunk."""
+    additional_kwargs = getattr(chunk, "additional_kwargs", None) or {}
+    reasoning = additional_kwargs.get("reasoning_content")
+    if isinstance(reasoning, str) and reasoning:
+        return reasoning
+
+    content = getattr(chunk, "content", None)
+    if isinstance(content, list):
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "thinking":
+                thinking = block.get("thinking", "")
+                if thinking:
+                    return thinking
+
+    return None
+
+
+def extract_content_delta(chunk: AIMessageChunk) -> str | None:
+    """Extract incremental text content from a streaming chunk."""
+    content = getattr(chunk, "content", None)
+    if isinstance(content, str) and content:
+        return content
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "text":
+                text = block.get("text", "")
+                if text:
+                    parts.append(text)
+        return "".join(parts) if parts else None
+    return None

--- a/tests/test_general_agent_stream_bridge.py
+++ b/tests/test_general_agent_stream_bridge.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 from langchain_core.messages import AIMessage, AIMessageChunk
 
 from swarmmind.agents.general_agent import DeerFlowRuntimeAdapter
+from swarmmind.services.runtime_event_processing import extract_content_delta, extract_reasoning_delta
 
 
 def test_stream_events_yields_async_events_and_returns_final_result() -> None:
@@ -79,19 +80,19 @@ def test_run_deerflow_turn_collects_async_result_without_stream_wrapper() -> Non
 def test_extract_reasoning_delta_prefers_additional_kwargs() -> None:
     chunk = AIMessageChunk(content="", additional_kwargs={"reasoning_content": "step by step"})
 
-    assert DeerFlowRuntimeAdapter._extract_reasoning_delta(chunk) == "step by step"
+    assert extract_reasoning_delta(chunk) == "step by step"
 
 
 def test_extract_reasoning_delta_falls_back_to_thinking_blocks() -> None:
     chunk = AIMessageChunk(content=[{"type": "thinking", "thinking": "consider option A"}])
 
-    assert DeerFlowRuntimeAdapter._extract_reasoning_delta(chunk) == "consider option A"
+    assert extract_reasoning_delta(chunk) == "consider option A"
 
 
 def test_extract_content_delta_handles_text_blocks() -> None:
     chunk = AIMessageChunk(content=[{"type": "text", "text": "hello"}, {"type": "text", "text": " world"}])
 
-    assert DeerFlowRuntimeAdapter._extract_content_delta(chunk) == "hello world"
+    assert extract_content_delta(chunk) == "hello world"
 
 
 def test_extract_reasoning_collects_multiple_blocks() -> None:

--- a/tests/test_general_agent_stream_events.py
+++ b/tests/test_general_agent_stream_events.py
@@ -6,7 +6,14 @@ from types import SimpleNamespace
 
 from langchain_core.messages import AIMessage, AIMessageChunk, HumanMessage, ToolMessage
 
-from swarmmind.agents.general_agent import DeerFlowRuntimeAdapter, _StreamCaptureState
+from swarmmind.agents.general_agent import DeerFlowRuntimeAdapter
+from swarmmind.services.runtime_event_processing import (
+    StreamCaptureState,
+    iter_new_turn_messages,
+    process_custom_mode_chunk,
+    process_messages_mode_chunk,
+    process_values_mode_message,
+)
 
 
 class FakeStreamingAgent:
@@ -98,10 +105,9 @@ def test_stream_events_skips_history_messages_before_current_turn(monkeypatch):
 
 
 def test_process_messages_mode_chunk_accumulates_reasoning_and_content() -> None:
-    agent = DeerFlowRuntimeAdapter.__new__(DeerFlowRuntimeAdapter)
-    capture_state = _StreamCaptureState()
+    capture_state = StreamCaptureState()
 
-    first_events = agent._process_messages_mode_chunk(
+    first_events = process_messages_mode_chunk(
         AIMessageChunk(
             id="chunk-1",
             content="hello",
@@ -109,7 +115,7 @@ def test_process_messages_mode_chunk_accumulates_reasoning_and_content() -> None
         ),
         capture_state,
     )
-    second_events = agent._process_messages_mode_chunk(
+    second_events = process_messages_mode_chunk(
         AIMessageChunk(
             id="chunk-1",
             content=" world",
@@ -131,14 +137,13 @@ def test_process_messages_mode_chunk_accumulates_reasoning_and_content() -> None
 
 
 def test_process_messages_mode_chunk_resets_accumulators_for_new_message_id() -> None:
-    agent = DeerFlowRuntimeAdapter.__new__(DeerFlowRuntimeAdapter)
-    capture_state = _StreamCaptureState(
+    capture_state = StreamCaptureState(
         current_chunk_msg_id="chunk-1",
         accumulated_reasoning="previous reasoning",
         accumulated_content="previous content",
     )
 
-    events = agent._process_messages_mode_chunk(
+    events = process_messages_mode_chunk(
         AIMessageChunk(
             id="chunk-2",
             content="fresh",
@@ -157,9 +162,9 @@ def test_process_messages_mode_chunk_resets_accumulators_for_new_message_id() ->
 
 
 def test_process_custom_mode_chunk_filters_and_normalizes_task_events() -> None:
-    assert DeerFlowRuntimeAdapter._process_custom_mode_chunk("ignored") is None
-    assert DeerFlowRuntimeAdapter._process_custom_mode_chunk({"type": "other"}) is None
-    assert DeerFlowRuntimeAdapter._process_custom_mode_chunk(
+    assert process_custom_mode_chunk("ignored") is None
+    assert process_custom_mode_chunk({"type": "other"}) is None
+    assert process_custom_mode_chunk(
         {
             "type": "task_running",
             "task_id": "task-1",
@@ -185,7 +190,7 @@ def test_iter_new_turn_messages_skips_pre_turn_user_and_seen_messages() -> None:
     seen_ids = {"tool-1"}
 
     yielded = list(
-        DeerFlowRuntimeAdapter._iter_new_turn_messages(
+        iter_new_turn_messages(
             [
                 HumanMessage(content="history user", id="history-user"),
                 history_assistant,
@@ -205,17 +210,16 @@ def test_iter_new_turn_messages_skips_pre_turn_user_and_seen_messages() -> None:
 
 
 def test_process_values_mode_message_emits_tool_calls_and_tracks_final_text() -> None:
-    agent = DeerFlowRuntimeAdapter.__new__(DeerFlowRuntimeAdapter)
-    agent._client = SimpleNamespace(_extract_text=lambda content: content if isinstance(content, str) else "")
-    capture_state = _StreamCaptureState()
+    capture_state = StreamCaptureState()
 
-    events = agent._process_values_mode_message(
+    events = process_values_mode_message(
         AIMessage(
             content="final answer",
             id="assistant-1",
             tool_calls=[{"name": "search_docs", "args": {"q": "streaming"}, "id": "call-1"}],
         ),
         capture_state,
+        lambda content: content if isinstance(content, str) else "",
     )
 
     assert events == [
@@ -229,11 +233,9 @@ def test_process_values_mode_message_emits_tool_calls_and_tracks_final_text() ->
 
 
 def test_process_values_mode_message_emits_tool_result_and_summarizes_tool_output() -> None:
-    agent = DeerFlowRuntimeAdapter.__new__(DeerFlowRuntimeAdapter)
-    agent._client = SimpleNamespace(_extract_text=lambda content: content if isinstance(content, str) else "")
-    capture_state = _StreamCaptureState()
+    capture_state = StreamCaptureState()
 
-    events = agent._process_values_mode_message(
+    events = process_values_mode_message(
         ToolMessage(
             content="tool output",
             tool_call_id="call-1",
@@ -241,6 +243,7 @@ def test_process_values_mode_message_emits_tool_result_and_summarizes_tool_outpu
             id="tool-1",
         ),
         capture_state,
+        lambda content: content if isinstance(content, str) else "",
     )
 
     assert events == [

--- a/ui/src/components/ui/v0-ai-chat.tsx
+++ b/ui/src/components/ui/v0-ai-chat.tsx
@@ -13,6 +13,8 @@ import { ChatLayout } from "@/components/workspace/chat-layout";
 import { MessageListSkeleton } from "@/components/workspace/chat-message-ui";
 import { ChatMessageArea } from "@/components/workspace/chat-message-area";
 import { SubtasksProvider, useUpdateSubtask, useSubtaskContext } from "@/core/tasks/context";
+import { isNearBottom, scrollContainerToLatest } from "@/core/chat/scroll";
+import { consumeNdjsonStream } from "@/core/chat/stream";
 import type {
   ChatMessage,
   ConversationMode,
@@ -173,11 +175,9 @@ function V0ChatInner({
       return;
     }
 
-    const distanceToBottom =
-      container.scrollHeight - container.scrollTop - container.clientHeight;
-    const isNearBottom = distanceToBottom <= 72;
-    shouldStickToBottomRef.current = isNearBottom;
-    setShowScrollToLatest(!isNearBottom);
+    const nextIsNearBottom = isNearBottom(container);
+    shouldStickToBottomRef.current = nextIsNearBottom;
+    setShowScrollToLatest(!nextIsNearBottom);
   }, []);
 
   const scrollToLatest = useCallback((behavior: ScrollBehavior = "smooth") => {
@@ -185,11 +185,7 @@ function V0ChatInner({
     if (!container) {
       return;
     }
-
-    container.scrollTo({
-      top: container.scrollHeight,
-      behavior,
-    });
+    scrollContainerToLatest(container, behavior);
     shouldStickToBottomRef.current = true;
     setShowScrollToLatest(false);
   }, []);
@@ -729,46 +725,18 @@ function V0ChatInner({
         throw new Error(`HTTP ${response.status}`);
       }
 
-      const reader = response.body.getReader();
-      const decoder = new TextDecoder();
-      let buffer = "";
-
       const timeoutId = setTimeout(() => {
         abortController.abort();
       }, 30_000);
 
       try {
-        // eslint-disable-next-line no-constant-condition
-        while (true) {
-          const { value, done } = await reader.read();
-          if (done) break;
-
-          buffer += decoder.decode(value, { stream: true });
-          let lineBreakIndex = buffer.indexOf("\n");
-          while (lineBreakIndex >= 0) {
-            const rawLine = buffer.slice(0, lineBreakIndex).trim();
-            buffer = buffer.slice(lineBreakIndex + 1);
-
-            if (rawLine) {
-              try {
-                handleStreamEvent(JSON.parse(rawLine) as StreamEvent);
-              } catch (e) {
-                console.warn("[stream] Failed to parse line:", rawLine, e);
-              }
-            }
-
-            lineBreakIndex = buffer.indexOf("\n");
-          }
-        }
-
-        const lastLine = buffer.trim();
-        if (lastLine) {
-          try {
-            handleStreamEvent(JSON.parse(lastLine) as StreamEvent);
-          } catch (e) {
-            console.warn("[stream] Failed to parse line:", lastLine, e);
-          }
-        }
+        await consumeNdjsonStream<StreamEvent>(
+          response.body,
+          handleStreamEvent,
+          (rawLine, error) => {
+            console.warn("[stream] Failed to parse line:", rawLine, error);
+          },
+        );
       } finally {
         clearTimeout(timeoutId);
       }

--- a/ui/src/core/chat/scroll.ts
+++ b/ui/src/core/chat/scroll.ts
@@ -1,0 +1,18 @@
+export function isNearBottom(
+  container: Pick<HTMLElement, "scrollHeight" | "scrollTop" | "clientHeight">,
+  threshold = 72,
+) {
+  const distanceToBottom =
+    container.scrollHeight - container.scrollTop - container.clientHeight;
+  return distanceToBottom <= threshold;
+}
+
+export function scrollContainerToLatest(
+  container: Pick<HTMLElement, "scrollHeight" | "scrollTo">,
+  behavior: ScrollBehavior = "smooth",
+) {
+  container.scrollTo({
+    top: container.scrollHeight,
+    behavior,
+  });
+}

--- a/ui/src/core/chat/stream.ts
+++ b/ui/src/core/chat/stream.ts
@@ -1,0 +1,43 @@
+export async function consumeNdjsonStream<T>(
+  stream: ReadableStream<Uint8Array>,
+  onEvent: (event: T) => void,
+  onParseError?: (rawLine: string, error: unknown) => void,
+) {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) {
+      break;
+    }
+
+    buffer += decoder.decode(value, { stream: true });
+    let lineBreakIndex = buffer.indexOf("\n");
+    while (lineBreakIndex >= 0) {
+      const rawLine = buffer.slice(0, lineBreakIndex).trim();
+      buffer = buffer.slice(lineBreakIndex + 1);
+
+      if (rawLine) {
+        try {
+          onEvent(JSON.parse(rawLine) as T);
+        } catch (error) {
+          onParseError?.(rawLine, error);
+        }
+      }
+
+      lineBreakIndex = buffer.indexOf("\n");
+    }
+  }
+
+  const lastLine = buffer.trim();
+  if (lastLine) {
+    try {
+      onEvent(JSON.parse(lastLine) as T);
+    } catch (error) {
+      onParseError?.(lastLine, error);
+    }
+  }
+}


### PR DESCRIPTION
Summary
- extract conversation route registration out of supervisor.py into a dedicated router module
- move DeerFlow runtime event processing helpers out of general_agent.py
- extract front-end NDJSON stream parsing and scroll helpers from v0-ai-chat.tsx

Validation
- uv run ruff check swarmmind tests
- cd ui && pnpm exec tsc --noEmit
- make test