### PR TITLE
Fix CI formatting and frontend lint failure

### DIFF
--- a/swarmmind/agents/general_agent.py
+++ b/swarmmind/agents/general_agent.py
@@ -487,6 +487,7 @@ class DeerFlowRuntimeAdapter(BaseAgent):
 
         return None
 
+
 # Backward-compatible alias retained while call sites migrate away from the
 # misleading "GeneralAgent" name.
 GeneralAgent = DeerFlowRuntimeAdapter

--- a/swarmmind/repositories/memory.py
+++ b/swarmmind/repositories/memory.py
@@ -201,7 +201,9 @@ class MemoryRepository:
             results = session.exec(select(MemoryEntryDB).where(MemoryEntryDB.ttl.is_not(None))).all()
             count = 0
             for row in results:
-                created_at = datetime.fromisoformat(row.created_at) if isinstance(row.created_at, str) else row.created_at
+                created_at = (
+                    datetime.fromisoformat(row.created_at) if isinstance(row.created_at, str) else row.created_at
+                )
                 if created_at is None or row.ttl is None:
                     continue
                 if created_at + timedelta(seconds=row.ttl) <= now:

--- a/swarmmind/services/trace_provider.py
+++ b/swarmmind/services/trace_provider.py
@@ -38,7 +38,9 @@ class SqliteTraceCheckpointProvider:
         storage: TraceCheckpointStorage | None = None,
         provider_logger: logging.Logger = logger,
     ) -> None:
-        self._storage = storage or SqliteTraceCheckpointStorage(checkpointer_path=checkpointer_path, storage_logger=provider_logger)
+        self._storage = storage or SqliteTraceCheckpointStorage(
+            checkpointer_path=checkpointer_path, storage_logger=provider_logger
+        )
         self.checkpointer_path = self._storage.checkpointer_path
         self._logger = provider_logger
 

--- a/tests/test_conversation_trace_service.py
+++ b/tests/test_conversation_trace_service.py
@@ -24,7 +24,13 @@ class FakeConversationRepo:
 
 class FakeTraceReader:
     def __init__(self, response: dict | None = None, error: Exception | None = None) -> None:
-        self._response = response or {"thread_id": "resolved-thread", "status": "completed", "events": [], "summary": "ok", "checkpoint_count": 1}
+        self._response = response or {
+            "thread_id": "resolved-thread",
+            "status": "completed",
+            "events": [],
+            "summary": "ok",
+            "checkpoint_count": 1,
+        }
         self._error = error
         self.calls: list[str] = []
 
@@ -52,7 +58,15 @@ def test_get_trace_prefers_conversation_thread_id() -> None:
 
 def test_get_trace_falls_back_to_conversation_id_when_thread_missing() -> None:
     repo = FakeConversationRepo(FakeConversation(thread_id=None))
-    reader = FakeTraceReader(response={"thread_id": "conversation-2", "status": "empty", "events": [], "summary": "暂无执行记录", "checkpoint_count": 0})
+    reader = FakeTraceReader(
+        response={
+            "thread_id": "conversation-2",
+            "status": "empty",
+            "events": [],
+            "summary": "暂无执行记录",
+            "checkpoint_count": 0,
+        }
+    )
     service = ConversationTraceService(conversation_repo=repo, trace_reader=reader)
 
     trace = service.get_trace("conversation-2")

--- a/tests/test_general_agent_stream_bridge.py
+++ b/tests/test_general_agent_stream_bridge.py
@@ -22,7 +22,9 @@ def test_stream_events_yields_async_events_and_returns_final_result() -> None:
 
     agent._astream_events = fake_astream_events
 
-    stream = agent.stream_events("investigate", ctx=SimpleNamespace(session_id="conv-1"), runtime_options=SimpleNamespace())
+    stream = agent.stream_events(
+        "investigate", ctx=SimpleNamespace(session_id="conv-1"), runtime_options=SimpleNamespace()
+    )
     events: list[dict] = []
     while True:
         try:
@@ -45,7 +47,9 @@ def test_stream_events_reraises_async_failure() -> None:
 
     agent._astream_events = fake_astream_events
 
-    stream = agent.stream_events("investigate", ctx=SimpleNamespace(session_id="conv-1"), runtime_options=SimpleNamespace())
+    stream = agent.stream_events(
+        "investigate", ctx=SimpleNamespace(session_id="conv-1"), runtime_options=SimpleNamespace()
+    )
 
     try:
         next(stream)

--- a/tests/test_lifecycle_service.py
+++ b/tests/test_lifecycle_service.py
@@ -90,7 +90,10 @@ def test_startup_lifecycle_runs_bootstrap_and_starts_cleanup_thread() -> None:
 
 def test_run_cleanup_once_matches_supervisor_cleanup_behavior() -> None:
     action_repo = FakeActionProposalRepo(
-        stale=[FakeProposal(id="p-1", created_at=datetime(2026, 1, 1, 0, 0, 0)), FakeProposal(id="p-2", created_at=datetime(2026, 1, 1, 0, 1, 0))]
+        stale=[
+            FakeProposal(id="p-1", created_at=datetime(2026, 1, 1, 0, 0, 0)),
+            FakeProposal(id="p-2", created_at=datetime(2026, 1, 1, 0, 1, 0)),
+        ]
     )
     memory_repo = FakeMemoryRepo(deleted=3)
     decisions: list[tuple[str, str]] = []

--- a/tests/test_stream_events.py
+++ b/tests/test_stream_events.py
@@ -15,7 +15,9 @@ from swarmmind.services.stream_events import (
 )
 
 
-def _opts(mode: ConversationMode, *, thinking: bool, subagent: bool, plan_mode: bool = False) -> ConversationRuntimeOptions:
+def _opts(
+    mode: ConversationMode, *, thinking: bool, subagent: bool, plan_mode: bool = False
+) -> ConversationRuntimeOptions:
     return ConversationRuntimeOptions(
         mode=mode,
         model_name="test-model",

--- a/ui/src/components/workspace/chat-empty-state.tsx
+++ b/ui/src/components/workspace/chat-empty-state.tsx
@@ -3,10 +3,10 @@ import { Brain, Lightbulb, Rocket, Sparkles, type LucideIcon } from "lucide-reac
 
 import { cn } from "@/lib/utils";
 
-const QUICK_PROMPT_ITEMS: Array<{
+const QUICK_PROMPT_ITEMS: {
   icon: LucideIcon;
   prompt: string;
-}> = [
+}[] = [
   { icon: Rocket, prompt: "帮我整理本周项目进展，输出 3 条重点结论。" },
   { icon: Lightbulb, prompt: "生成一版 CRM MVP 范围说明，控制在一页内。" },
   { icon: Brain, prompt: "把下面的会议讨论改写成正式纪要。" },


### PR DESCRIPTION
## Summary
- fix the frontend ESLint failure in \
- apply Ruff formatting to files failing the backend format job
- validate backend and frontend CI commands locally

## Validation
- uv run ruff format --check swarmmind tests
- uv run ruff check swarmmind tests
- make test
- cd ui && pnpm exec eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 50
- cd ui && pnpm exec tsc --noEmit
- cd ui && pnpm build