### PR TITLE
chore: auto-merge owner PRs once CI passes

### DIFF
--- a/.github/workflows/auto-merge-owner.yml
+++ b/.github/workflows/auto-merge-owner.yml
@@ -1,0 +1,34 @@
+name: Auto-merge owner PRs
+
+# 当 owner (hawkli-1994) 提交 PR 时，自动开启 GitHub auto-merge：
+# 所有必需的 status check 通过后，PR 会被自动 squash-merge 并删除来源分支。
+# 草稿 (draft) PR 不触发；其他贡献者的 PR 不触发（仍走正常 review 流程）。
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review, synchronize]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  enable-auto-merge:
+    name: Enable auto-merge for owner
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.pull_request.user.login == 'hawkli-1994'
+      && github.event.pull_request.draft == false
+    steps:
+      - name: Enable auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          echo "Enabling auto-merge on PR #${PR_NUMBER}"
+          gh pr merge "${PR_NUMBER}" \
+            --repo "${REPO}" \
+            --auto \
+            --squash \
+            --delete-branch


### PR DESCRIPTION
## 变更摘要 / Summary

- 新增 [.github/workflows/auto-merge-owner.yml](.github/workflows/auto-merge-owner.yml)
- 当 owner (\`hawkli-1994\`) 提交非 draft PR 时，自动调用 \`gh pr merge --auto --squash --delete-branch\`
- GitHub 会在所有必需 status check 通过后自动 squash-merge 并删除来源分支

## 动机与背景 / Why

单人维护项目的 PR 流程已经简化为 "CI 绿 → bypass merge"。这一步把"敲一条命令"也省掉：push 完代码就不用再管，CI 一过自动合并。

非 owner 的 PR 不受影响，仍走标准 review 流程。Draft PR 被跳过，owner 可以挂 WIP 而不被自动合。

## 影响范围 / Impact

- 数据库迁移：否
- API 变更：否
- Breaking change：否
- 仅影响 owner 自己的 PR 工作流

## Reviewer Notes

- 使用 \`pull_request_target\` 触发器：在 base 分支上下文运行，拥有完整 \`GITHUB_TOKEN\`，且不会执行 PR 分支的代码（无需检出 PR 源码，所以无 supply-chain 风险）
- 工作流仅调用 \`gh pr merge\`，不接触 PR 代码
- \`if:\` 双重过滤：必须是 owner + 非 draft
- 即使工作流被触发多次（synchronize 事件），\`gh pr merge --auto\` 是幂等的

## Test Plan

- [x] YAML 语法本地通过
- [ ] 合并后下一个 owner PR 验证：开 PR → 自动启用 auto-merge → CI 通过后自动合并
- [ ] 验证 draft PR 不触发（开个 draft PR 看 Actions 标签页应显示 skipped）
- [ ] 验证非 owner PR 不触发（如有外部贡献者）

## 后续微调

如未来添加协同维护者，把 \`if:\` 里的 \`'hawkli-1994'\` 改成 \`contains(fromJSON('["hawkli-1994","其他人"]'), github.event.pull_request.user.login)\` 即可。