### PR TITLE
feat: modularize supervisor API + Project page + trace summary (issue #62)

### DIFF
--- a/swarmmind/api/routers/__init__.py
+++ b/swarmmind/api/routers/__init__.py
@@ -1,0 +1,1 @@
+"""Per-domain FastAPI routers for the SwarmMind Supervisor API."""

--- a/swarmmind/api/routers/agent_teams.py
+++ b/swarmmind/api/routers/agent_teams.py
@@ -17,10 +17,13 @@ from swarmmind.models import (
 
 @dataclass(frozen=True)
 class AgentTeamsRouterDeps:
+    """Dependencies for the agent-teams router."""
+
     agent_team_repo: object
 
 
 def build_agent_teams_router(deps: AgentTeamsRouterDeps) -> APIRouter:
+    """Return an APIRouter with all agent-team template CRUD endpoints."""
     router = APIRouter()
 
     @router.get("/agent-teams", tags=["agent-teams"])
@@ -29,7 +32,9 @@ def build_agent_teams_router(deps: AgentTeamsRouterDeps) -> APIRouter:
         rows = deps.agent_team_repo.list_all(include_disabled=False)
         return AgentTeamTemplateListResponse(items=[db_to_team_template(r) for r in rows], total=len(rows))
 
-    @router.get("/agent-teams/{team_id}", tags=["agent-teams"], responses={404: {"description": "Team template not found"}})
+    @router.get(
+        "/agent-teams/{team_id}", tags=["agent-teams"], responses={404: {"description": "Team template not found"}}
+    )
     def get_agent_team(team_id: str) -> AgentTeamTemplate:
         """Get a single agent team template by ID."""
         return db_to_team_template(deps.agent_team_repo.get_by_id(team_id))
@@ -48,7 +53,9 @@ def build_agent_teams_router(deps: AgentTeamsRouterDeps) -> APIRouter:
         )
         return db_to_team_template(team)
 
-    @router.patch("/agent-teams/{team_id}", tags=["agent-teams"], responses={404: {"description": "Team template not found"}})
+    @router.patch(
+        "/agent-teams/{team_id}", tags=["agent-teams"], responses={404: {"description": "Team template not found"}}
+    )
     def update_agent_team(team_id: str, body: AgentTeamTemplateUpdateRequest) -> AgentTeamTemplate:
         """Update an agent team template."""
         roles = [r.model_dump() for r in body.roles] if body.roles is not None else None

--- a/swarmmind/api/routers/agent_teams.py
+++ b/swarmmind/api/routers/agent_teams.py
@@ -1,0 +1,72 @@
+"""Agent team template domain routes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from fastapi import APIRouter
+
+from swarmmind.api.routers.mappers import db_to_team_template
+from swarmmind.models import (
+    AgentTeamTemplate,
+    AgentTeamTemplateCreateRequest,
+    AgentTeamTemplateListResponse,
+    AgentTeamTemplateUpdateRequest,
+)
+
+
+@dataclass(frozen=True)
+class AgentTeamsRouterDeps:
+    agent_team_repo: object
+
+
+def build_agent_teams_router(deps: AgentTeamsRouterDeps) -> APIRouter:
+    router = APIRouter()
+
+    @router.get("/agent-teams", tags=["agent-teams"])
+    def list_agent_teams() -> AgentTeamTemplateListResponse:
+        """List all enabled agent team templates."""
+        rows = deps.agent_team_repo.list_all(include_disabled=False)
+        return AgentTeamTemplateListResponse(items=[db_to_team_template(r) for r in rows], total=len(rows))
+
+    @router.get("/agent-teams/{team_id}", tags=["agent-teams"], responses={404: {"description": "Team template not found"}})
+    def get_agent_team(team_id: str) -> AgentTeamTemplate:
+        """Get a single agent team template by ID."""
+        return db_to_team_template(deps.agent_team_repo.get_by_id(team_id))
+
+    @router.post("/agent-teams", tags=["agent-teams"], status_code=201)
+    def create_agent_team(body: AgentTeamTemplateCreateRequest) -> AgentTeamTemplate:
+        """Create a new custom agent team template."""
+        team = deps.agent_team_repo.create(
+            name=body.name,
+            description=body.description,
+            icon=body.icon,
+            roles=[r.model_dump() for r in body.roles],
+            default_skills=body.default_skills,
+            runtime_profile_prefs=body.runtime_profile_prefs,
+            is_builtin=False,
+        )
+        return db_to_team_template(team)
+
+    @router.patch("/agent-teams/{team_id}", tags=["agent-teams"], responses={404: {"description": "Team template not found"}})
+    def update_agent_team(team_id: str, body: AgentTeamTemplateUpdateRequest) -> AgentTeamTemplate:
+        """Update an agent team template."""
+        roles = [r.model_dump() for r in body.roles] if body.roles is not None else None
+        team = deps.agent_team_repo.update(
+            team_id=team_id,
+            name=body.name,
+            description=body.description,
+            icon=body.icon,
+            roles=roles,
+            default_skills=body.default_skills,
+            runtime_profile_prefs=body.runtime_profile_prefs,
+            is_enabled=body.is_enabled,
+        )
+        return db_to_team_template(team)
+
+    @router.delete("/agent-teams/{team_id}", tags=["agent-teams"], status_code=204)
+    def delete_agent_team(team_id: str) -> None:
+        """Disable an agent team template."""
+        deps.agent_team_repo.delete(team_id)
+
+    return router

--- a/swarmmind/api/routers/approvals.py
+++ b/swarmmind/api/routers/approvals.py
@@ -19,12 +19,15 @@ from swarmmind.models import (
 
 @dataclass(frozen=True)
 class ApprovalsRouterDeps:
+    """Dependencies for the approvals router."""
+
     approval_request_repo: object
     project_repo: object
     run_repo: object
 
 
 def build_approvals_router(deps: ApprovalsRouterDeps) -> APIRouter:
+    """Return an APIRouter with all approval-request CRUD endpoints."""
     router = APIRouter()
 
     @router.get("/approvals", tags=["approvals"])
@@ -64,7 +67,9 @@ def build_approvals_router(deps: ApprovalsRouterDeps) -> APIRouter:
         )
         return db_to_approval_request(ar)
 
-    @router.get("/approvals/{approval_id}", tags=["approvals"], responses={404: {"description": "Approval request not found"}})
+    @router.get(
+        "/approvals/{approval_id}", tags=["approvals"], responses={404: {"description": "Approval request not found"}}
+    )
     def get_approval(approval_id: str) -> ApprovalRequest:
         """Get a single approval request by ID."""
         return db_to_approval_request(deps.approval_request_repo.get(approval_id))
@@ -72,7 +77,10 @@ def build_approvals_router(deps: ApprovalsRouterDeps) -> APIRouter:
     @router.patch(
         "/approvals/{approval_id}",
         tags=["approvals"],
-        responses={404: {"description": "Approval request not found"}, 409: {"description": "Invalid status transition"}},
+        responses={
+            404: {"description": "Approval request not found"},
+            409: {"description": "Invalid status transition"},
+        },
     )
     def update_approval(approval_id: str, body: UpdateApprovalRequest) -> ApprovalRequest:
         """Update an approval request. Only provided fields are changed."""
@@ -98,7 +106,9 @@ def build_approvals_router(deps: ApprovalsRouterDeps) -> APIRouter:
             return db_to_approval_request(ar)
         return db_to_approval_request(deps.approval_request_repo.update(approval_id, **fields))
 
-    @router.delete("/approvals/{approval_id}", tags=["approvals"], responses={404: {"description": "Approval request not found"}})
+    @router.delete(
+        "/approvals/{approval_id}", tags=["approvals"], responses={404: {"description": "Approval request not found"}}
+    )
     def delete_approval(approval_id: str) -> DeleteApprovalResponse:
         """Delete an approval request."""
         deps.approval_request_repo.get(approval_id)

--- a/swarmmind/api/routers/approvals.py
+++ b/swarmmind/api/routers/approvals.py
@@ -1,0 +1,108 @@
+"""Approval request domain routes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from fastapi import APIRouter, HTTPException
+
+from swarmmind.api.routers.mappers import db_to_approval_request
+from swarmmind.models import (
+    ApprovalRequest,
+    ApprovalRequestListResponse,
+    ApprovalStatus,
+    CreateApprovalRequest,
+    DeleteApprovalResponse,
+    UpdateApprovalRequest,
+)
+
+
+@dataclass(frozen=True)
+class ApprovalsRouterDeps:
+    approval_request_repo: object
+    project_repo: object
+    run_repo: object
+
+
+def build_approvals_router(deps: ApprovalsRouterDeps) -> APIRouter:
+    router = APIRouter()
+
+    @router.get("/approvals", tags=["approvals"])
+    def list_approvals(
+        project_id: str | None = None,
+        status: str | None = None,
+        risk_tier: str | None = None,
+    ) -> ApprovalRequestListResponse:
+        """List approval requests with optional filters."""
+        rows = deps.approval_request_repo.list_by_filters(
+            project_id=project_id,
+            status=status,
+            risk_tier=risk_tier,
+        )
+        return ApprovalRequestListResponse(
+            items=[db_to_approval_request(r) for r in rows],
+            total=len(rows),
+        )
+
+    @router.post("/approvals", tags=["approvals"], responses={404: {"description": "Project not found"}})
+    def create_approval(body: CreateApprovalRequest) -> ApprovalRequest:
+        """Create a new approval request."""
+        deps.project_repo.get_by_id(body.project_id)
+        if body.run_id:
+            deps.run_repo.get_by_id(body.run_id)
+        ar = deps.approval_request_repo.create(
+            project_id=body.project_id,
+            run_id=body.run_id,
+            title=body.title,
+            description=body.description,
+            risk_tier=body.risk_tier.value,
+            requested_capability=body.requested_capability,
+            evidence=body.evidence,
+            impact=body.impact,
+            approver_role=body.approver_role,
+            recovery_behavior=body.recovery_behavior,
+        )
+        return db_to_approval_request(ar)
+
+    @router.get("/approvals/{approval_id}", tags=["approvals"], responses={404: {"description": "Approval request not found"}})
+    def get_approval(approval_id: str) -> ApprovalRequest:
+        """Get a single approval request by ID."""
+        return db_to_approval_request(deps.approval_request_repo.get(approval_id))
+
+    @router.patch(
+        "/approvals/{approval_id}",
+        tags=["approvals"],
+        responses={404: {"description": "Approval request not found"}, 409: {"description": "Invalid status transition"}},
+    )
+    def update_approval(approval_id: str, body: UpdateApprovalRequest) -> ApprovalRequest:
+        """Update an approval request. Only provided fields are changed."""
+        ar = deps.approval_request_repo.get(approval_id)
+        fields: dict[str, object] = {}
+        if body.status is not None:
+            if body.status in (ApprovalStatus.APPROVED, ApprovalStatus.REJECTED):
+                if ar.status != ApprovalStatus.PENDING.value:
+                    raise HTTPException(
+                        status_code=409,
+                        detail=f"Only pending requests can be approved or rejected. Current status: {ar.status}",
+                    )
+            fields["status"] = body.status.value
+        if body.decision_reason is not None:
+            fields["decision_reason"] = body.decision_reason
+        if body.title is not None:
+            fields["title"] = body.title
+        if body.description is not None:
+            fields["description"] = body.description
+        if body.risk_tier is not None:
+            fields["risk_tier"] = body.risk_tier.value
+        if not fields:
+            return db_to_approval_request(ar)
+        return db_to_approval_request(deps.approval_request_repo.update(approval_id, **fields))
+
+    @router.delete("/approvals/{approval_id}", tags=["approvals"], responses={404: {"description": "Approval request not found"}})
+    def delete_approval(approval_id: str) -> DeleteApprovalResponse:
+        """Delete an approval request."""
+        deps.approval_request_repo.get(approval_id)
+        deps.approval_request_repo.delete(approval_id)
+        return DeleteApprovalResponse(approval_id=approval_id)
+
+    return router

--- a/swarmmind/api/routers/audit_logs.py
+++ b/swarmmind/api/routers/audit_logs.py
@@ -1,0 +1,79 @@
+"""Audit log domain routes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from fastapi import APIRouter
+
+from swarmmind.api.routers.mappers import db_to_audit_log_entry
+from swarmmind.models import (
+    AuditLogEntry,
+    AuditLogListResponse,
+    CreateAuditLogEntry,
+    DeleteAuditLogResponse,
+)
+
+
+@dataclass(frozen=True)
+class AuditLogsRouterDeps:
+    audit_log_repo: object
+    project_repo: object
+    run_repo: object
+    approval_request_repo: object
+
+
+def build_audit_logs_router(deps: AuditLogsRouterDeps) -> APIRouter:
+    router = APIRouter()
+
+    @router.get("/audit-logs", tags=["audit-logs"])
+    def list_audit_logs(
+        project_id: str | None = None,
+        run_id: str | None = None,
+        approval_id: str | None = None,
+    ) -> AuditLogListResponse:
+        """List audit log entries with optional filters."""
+        rows = deps.audit_log_repo.list_by_filters(
+            project_id=project_id,
+            run_id=run_id,
+            approval_id=approval_id,
+        )
+        return AuditLogListResponse(
+            items=[db_to_audit_log_entry(r) for r in rows],
+            total=len(rows),
+        )
+
+    @router.post("/audit-logs", tags=["audit-logs"], responses={404: {"description": "Project not found"}})
+    def create_audit_log(body: CreateAuditLogEntry) -> AuditLogEntry:
+        """Create a new audit log entry."""
+        deps.project_repo.get_by_id(body.project_id)
+        if body.run_id:
+            deps.run_repo.get_by_id(body.run_id)
+        if body.approval_id:
+            deps.approval_request_repo.get(body.approval_id)
+        entry = deps.audit_log_repo.create(
+            audit_type=body.audit_type,
+            project_id=body.project_id,
+            run_id=body.run_id,
+            approval_id=body.approval_id,
+            actor_id=body.actor_id,
+            actor_type=body.actor_type,
+            decision=body.decision,
+            reason=body.reason,
+            extra_data=body.metadata,
+        )
+        return db_to_audit_log_entry(entry)
+
+    @router.get("/audit-logs/{audit_id}", tags=["audit-logs"], responses={404: {"description": "Audit log entry not found"}})
+    def get_audit_log(audit_id: str) -> AuditLogEntry:
+        """Get a single audit log entry by ID."""
+        return db_to_audit_log_entry(deps.audit_log_repo.get(audit_id))
+
+    @router.delete("/audit-logs/{audit_id}", tags=["audit-logs"], responses={404: {"description": "Audit log entry not found"}})
+    def delete_audit_log(audit_id: str) -> DeleteAuditLogResponse:
+        """Delete an audit log entry."""
+        deps.audit_log_repo.get(audit_id)
+        deps.audit_log_repo.delete(audit_id)
+        return DeleteAuditLogResponse(audit_id=audit_id)
+
+    return router

--- a/swarmmind/api/routers/audit_logs.py
+++ b/swarmmind/api/routers/audit_logs.py
@@ -17,6 +17,8 @@ from swarmmind.models import (
 
 @dataclass(frozen=True)
 class AuditLogsRouterDeps:
+    """Dependencies for the audit-logs router."""
+
     audit_log_repo: object
     project_repo: object
     run_repo: object
@@ -24,6 +26,7 @@ class AuditLogsRouterDeps:
 
 
 def build_audit_logs_router(deps: AuditLogsRouterDeps) -> APIRouter:
+    """Return an APIRouter with all audit-log CRUD endpoints."""
     router = APIRouter()
 
     @router.get("/audit-logs", tags=["audit-logs"])
@@ -64,12 +67,16 @@ def build_audit_logs_router(deps: AuditLogsRouterDeps) -> APIRouter:
         )
         return db_to_audit_log_entry(entry)
 
-    @router.get("/audit-logs/{audit_id}", tags=["audit-logs"], responses={404: {"description": "Audit log entry not found"}})
+    @router.get(
+        "/audit-logs/{audit_id}", tags=["audit-logs"], responses={404: {"description": "Audit log entry not found"}}
+    )
     def get_audit_log(audit_id: str) -> AuditLogEntry:
         """Get a single audit log entry by ID."""
         return db_to_audit_log_entry(deps.audit_log_repo.get(audit_id))
 
-    @router.delete("/audit-logs/{audit_id}", tags=["audit-logs"], responses={404: {"description": "Audit log entry not found"}})
+    @router.delete(
+        "/audit-logs/{audit_id}", tags=["audit-logs"], responses={404: {"description": "Audit log entry not found"}}
+    )
     def delete_audit_log(audit_id: str) -> DeleteAuditLogResponse:
         """Delete an audit log entry."""
         deps.audit_log_repo.get(audit_id)

--- a/swarmmind/api/routers/legacy_supervisor.py
+++ b/swarmmind/api/routers/legacy_supervisor.py
@@ -24,6 +24,8 @@ from swarmmind.repositories.action_proposal import _db_to_action_proposal
 
 @dataclass(frozen=True)
 class LegacySupervisorRouterDeps:
+    """Dependencies for the legacy supervisor router."""
+
     action_proposal_repo: object
     strategy_repo: object
     record_supervisor_decision: Callable
@@ -31,6 +33,7 @@ class LegacySupervisorRouterDeps:
 
 
 def build_legacy_supervisor_router(deps: LegacySupervisorRouterDeps) -> APIRouter:
+    """Return an APIRouter for legacy supervisor routes (pending, approve, reject, dispatch, strategy)."""
     router = APIRouter()
 
     @router.get("/pending", tags=["supervisor"])

--- a/swarmmind/api/routers/legacy_supervisor.py
+++ b/swarmmind/api/routers/legacy_supervisor.py
@@ -1,0 +1,82 @@
+"""Legacy supervisor routes: pending proposals, approve, reject, dispatch, strategy."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from fastapi import APIRouter, HTTPException
+
+from swarmmind.models import (
+    ApproveResponse,
+    DispatchResponse,
+    GoalRequest,
+    PendingResponse,
+    RejectRequest,
+    RejectResponse,
+    StrategyEntry,
+    StrategyResponse,
+    SupervisorDecision,
+)
+from swarmmind.repositories.action_proposal import _db_to_action_proposal
+
+
+@dataclass(frozen=True)
+class LegacySupervisorRouterDeps:
+    action_proposal_repo: object
+    strategy_repo: object
+    record_supervisor_decision: Callable
+    dispatch: Callable
+
+
+def build_legacy_supervisor_router(deps: LegacySupervisorRouterDeps) -> APIRouter:
+    router = APIRouter()
+
+    @router.get("/pending", tags=["supervisor"])
+    def get_pending(limit: int = 50, offset: int = 0) -> PendingResponse:
+        """List pending action proposals (paginated)."""
+        rows, total = deps.action_proposal_repo.list_pending(limit=limit, offset=offset)
+        items = [_db_to_action_proposal(row) for row in rows]
+        return PendingResponse(items=items, total=total)
+
+    @router.post("/approve/{proposal_id}", tags=["supervisor"], responses={404: {"description": "Proposal not found"}})
+    def approve(proposal_id: str) -> ApproveResponse:
+        """Approve an action proposal."""
+        deps.action_proposal_repo.approve(proposal_id)
+        deps.record_supervisor_decision(proposal_id, SupervisorDecision.APPROVED)
+        return ApproveResponse(id=proposal_id)
+
+    @router.post("/reject/{proposal_id}", tags=["supervisor"], responses={404: {"description": "Proposal not found"}})
+    def reject(proposal_id: str, body: RejectRequest | None = None) -> RejectResponse:
+        """Reject an action proposal."""
+        deps.action_proposal_repo.reject_proposal(proposal_id)
+        deps.record_supervisor_decision(proposal_id, SupervisorDecision.REJECTED)
+        reason = body.reason if body else None
+        return RejectResponse(id=proposal_id, reason=reason)
+
+    @router.get("/strategy", tags=["supervisor"])
+    def get_strategy() -> StrategyResponse:
+        """View the strategy routing table."""
+        rows = deps.strategy_repo.list_all()
+        entries = [
+            StrategyEntry(
+                situation_tag=row.situation_tag,
+                agent_id=row.agent_id,
+                success_count=row.success_count,
+                failure_count=row.failure_count,
+            )
+            for row in rows
+        ]
+        return StrategyResponse(entries=entries)
+
+    @router.post("/dispatch", tags=["supervisor"])
+    def post_dispatch(body: GoalRequest) -> DispatchResponse:
+        """Submit a new goal for dispatch to an agent."""
+        try:
+            session_id = str(uuid.uuid4())
+            return deps.dispatch(body.goal, user_id="supervisor", session_id=session_id)
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=str(e))
+
+    return router

--- a/swarmmind/api/routers/mappers.py
+++ b/swarmmind/api/routers/mappers.py
@@ -1,0 +1,162 @@
+"""DB row → Pydantic model mappers shared across domain routers."""
+
+from __future__ import annotations
+
+import json
+
+from swarmmind.models import (
+    AgentTeamTemplate,
+    ApprovalRequest,
+    ApprovalStatus,
+    Artifact,
+    AuditLogEntry,
+    Project,
+    ProjectAgentTeamInstance,
+    RiskTier,
+    Run,
+    Task,
+    TeamRole,
+)
+from swarmmind.services.artifact_content import (
+    is_virtual_user_data_path,
+    normalize_virtual_path,
+)
+
+
+def db_to_run(run) -> Run:
+    return Run(
+        run_id=run.run_id,
+        project_id=run.project_id,
+        conversation_id=run.conversation_id,
+        status=run.status,
+        goal=run.goal,
+        summary=run.summary,
+        started_at=run.started_at.isoformat() if run.started_at else "",
+        completed_at=run.completed_at.isoformat() if run.completed_at else None,
+    )
+
+
+def db_to_task(task) -> Task:
+    return Task(
+        task_id=task.task_id,
+        project_id=task.project_id,
+        run_id=task.run_id,
+        title=task.title,
+        description=task.description,
+        status=task.status,
+        assignee_role=task.assignee_role,
+        source_workstream=task.source_workstream,
+        artifact_ids=task.artifact_ids or [],
+        priority=task.priority,
+        created_at=task.created_at.isoformat() if task.created_at else "",
+        updated_at=task.updated_at.isoformat() if task.updated_at else "",
+    )
+
+
+def db_to_artifact(art) -> Artifact:
+    return Artifact(
+        artifact_id=art.artifact_id,
+        conversation_id=art.conversation_id,
+        project_id=art.project_id,
+        message_id=art.message_id,
+        run_id=art.run_id,
+        task_id=art.task_id,
+        author_role=art.author_role,
+        name=art.name,
+        path=art.path or (normalize_virtual_path(art.name) if is_virtual_user_data_path(art.name) else None),
+        storage_uri=art.storage_uri,
+        mime_type=art.mime_type,
+        size_bytes=art.size_bytes,
+        artifact_type=art.artifact_type,
+        created_at=art.created_at.isoformat() if art.created_at else "",
+    )
+
+
+def db_to_approval_request(ar) -> ApprovalRequest:
+    return ApprovalRequest(
+        approval_id=ar.approval_id,
+        project_id=ar.project_id,
+        run_id=ar.run_id,
+        action_proposal_id=ar.action_proposal_id,
+        title=ar.title,
+        description=ar.description,
+        risk_tier=RiskTier(ar.risk_tier),
+        requested_capability=ar.requested_capability,
+        evidence=ar.evidence,
+        impact=ar.impact,
+        approver_role=ar.approver_role,
+        recovery_behavior=ar.recovery_behavior,
+        status=ApprovalStatus(ar.status),
+        decision_reason=ar.decision_reason,
+        created_at=ar.created_at.isoformat() if ar.created_at else "",
+        updated_at=ar.updated_at.isoformat() if ar.updated_at else "",
+    )
+
+
+def db_to_audit_log_entry(entry) -> AuditLogEntry:
+    return AuditLogEntry(
+        audit_id=entry.audit_id,
+        audit_type=entry.audit_type,
+        project_id=entry.project_id,
+        run_id=entry.run_id,
+        approval_id=entry.approval_id,
+        actor_id=entry.actor_id,
+        actor_type=entry.actor_type,
+        decision=entry.decision,
+        reason=entry.reason,
+        metadata=entry.extra_data or {},
+        timestamp=entry.timestamp.isoformat() if entry.timestamp else "",
+    )
+
+
+def db_to_team_template(team) -> AgentTeamTemplate:
+    return AgentTeamTemplate(
+        team_id=team.team_id,
+        name=team.name,
+        description=team.description,
+        icon=team.icon,
+        roles=[TeamRole(**r) for r in json.loads(team.roles)] if team.roles else [],
+        default_skills=json.loads(team.default_skills) if team.default_skills else [],
+        runtime_profile_prefs=json.loads(team.runtime_profile_prefs) if team.runtime_profile_prefs else {},
+        is_builtin=bool(team.is_builtin),
+        is_enabled=bool(team.is_enabled),
+        created_at=team.created_at.isoformat() if team.created_at else "",
+        updated_at=team.updated_at.isoformat() if team.updated_at else "",
+    )
+
+
+def db_to_team_instance(instance, agent_team_repo) -> ProjectAgentTeamInstance:
+    template = agent_team_repo.get_by_id(instance.team_template_id)
+    return ProjectAgentTeamInstance(
+        instance_id=instance.instance_id,
+        project_id=instance.project_id,
+        team_template_id=instance.team_template_id,
+        team_name=template.name,
+        team_description=template.description,
+        roles=[TeamRole(**r) for r in json.loads(template.roles)] if template.roles else [],
+        instance_config=json.loads(instance.instance_config) if instance.instance_config else {},
+        status=instance.status,
+        created_at=instance.created_at.isoformat() if instance.created_at else "",
+        updated_at=instance.updated_at.isoformat() if instance.updated_at else "",
+    )
+
+
+def db_to_project(proj, project_team_repo, agent_team_repo) -> Project:
+    team_instance = project_team_repo.get_by_project(proj.project_id)
+    agent_team = db_to_team_instance(team_instance, agent_team_repo) if team_instance else None
+    return Project(
+        project_id=proj.project_id,
+        title=proj.title,
+        goal=proj.goal,
+        scope=proj.scope,
+        constraints=proj.constraints,
+        source_conversation_id=proj.source_conversation_id,
+        conversation_id=proj.conversation_id,
+        next_step=proj.next_step,
+        phase=proj.phase,
+        risk_level=proj.risk_level,
+        status=proj.status,
+        created_at=proj.created_at.isoformat() if proj.created_at else "",
+        updated_at=proj.updated_at.isoformat() if proj.updated_at else "",
+        agent_team=agent_team,
+    )

--- a/swarmmind/api/routers/mappers.py
+++ b/swarmmind/api/routers/mappers.py
@@ -24,6 +24,7 @@ from swarmmind.services.artifact_content import (
 
 
 def db_to_run(run) -> Run:
+    """Map a RunDB row to a Run Pydantic model."""
     return Run(
         run_id=run.run_id,
         project_id=run.project_id,
@@ -37,6 +38,7 @@ def db_to_run(run) -> Run:
 
 
 def db_to_task(task) -> Task:
+    """Map a TaskDB row to a Task Pydantic model."""
     return Task(
         task_id=task.task_id,
         project_id=task.project_id,
@@ -54,6 +56,7 @@ def db_to_task(task) -> Task:
 
 
 def db_to_artifact(art) -> Artifact:
+    """Map an ArtifactDB row to an Artifact Pydantic model."""
     return Artifact(
         artifact_id=art.artifact_id,
         conversation_id=art.conversation_id,
@@ -73,6 +76,7 @@ def db_to_artifact(art) -> Artifact:
 
 
 def db_to_approval_request(ar) -> ApprovalRequest:
+    """Map an ApprovalRequestDB row to an ApprovalRequest Pydantic model."""
     return ApprovalRequest(
         approval_id=ar.approval_id,
         project_id=ar.project_id,
@@ -94,6 +98,7 @@ def db_to_approval_request(ar) -> ApprovalRequest:
 
 
 def db_to_audit_log_entry(entry) -> AuditLogEntry:
+    """Map an AuditLogDB row to an AuditLogEntry Pydantic model."""
     return AuditLogEntry(
         audit_id=entry.audit_id,
         audit_type=entry.audit_type,
@@ -110,6 +115,7 @@ def db_to_audit_log_entry(entry) -> AuditLogEntry:
 
 
 def db_to_team_template(team) -> AgentTeamTemplate:
+    """Map an AgentTeamDB row to an AgentTeamTemplate Pydantic model."""
     return AgentTeamTemplate(
         team_id=team.team_id,
         name=team.name,
@@ -126,6 +132,7 @@ def db_to_team_template(team) -> AgentTeamTemplate:
 
 
 def db_to_team_instance(instance, agent_team_repo) -> ProjectAgentTeamInstance:
+    """Map a ProjectTeamInstanceDB row to a ProjectAgentTeamInstance Pydantic model."""
     template = agent_team_repo.get_by_id(instance.team_template_id)
     return ProjectAgentTeamInstance(
         instance_id=instance.instance_id,
@@ -142,6 +149,7 @@ def db_to_team_instance(instance, agent_team_repo) -> ProjectAgentTeamInstance:
 
 
 def db_to_project(proj, project_team_repo, agent_team_repo) -> Project:
+    """Map a ProjectDB row to a Project Pydantic model."""
     team_instance = project_team_repo.get_by_project(proj.project_id)
     agent_team = db_to_team_instance(team_instance, agent_team_repo) if team_instance else None
     return Project(

--- a/swarmmind/api/routers/projects.py
+++ b/swarmmind/api/routers/projects.py
@@ -18,8 +18,8 @@ from swarmmind.api.routers.mappers import (
 )
 from swarmmind.models import (
     ArtifactListResponse,
-    AuditLogListResponse,
     AttachTeamRequest,
+    AuditLogListResponse,
     CreateTaskRequest,
     DeleteProjectResponse,
     DeleteTaskResponse,
@@ -40,6 +40,8 @@ from swarmmind.models import (
 
 @dataclass(frozen=True)
 class ProjectsRouterDeps:
+    """Dependencies for the projects router."""
+
     project_repo: object
     task_repo: object
     run_repo: object
@@ -53,6 +55,7 @@ class ProjectsRouterDeps:
 
 
 def build_projects_router(deps: ProjectsRouterDeps) -> APIRouter:
+    """Return an APIRouter with all project domain endpoints."""
     router = APIRouter()
 
     def _db_to_project(proj) -> Project:
@@ -78,6 +81,7 @@ def build_projects_router(deps: ProjectsRouterDeps) -> APIRouter:
 
     def _attach_team(project_id: str, team_template_id: str | None) -> None:
         import logging
+
         _logger = logging.getLogger(__name__)
         if team_template_id:
             try:
@@ -153,7 +157,9 @@ def build_projects_router(deps: ProjectsRouterDeps) -> APIRouter:
 
     # ---- Project overview / audit / artifacts ----
 
-    @router.get("/projects/{project_id}/overview", tags=["projects"], responses={404: {"description": "Project not found"}})
+    @router.get(
+        "/projects/{project_id}/overview", tags=["projects"], responses={404: {"description": "Project not found"}}
+    )
     def get_project_overview(project_id: str) -> ProjectOverviewResponse:
         """Get aggregated project overview with stats and recent items."""
         proj = deps.project_repo.get_by_id(project_id)
@@ -181,7 +187,9 @@ def build_projects_router(deps: ProjectsRouterDeps) -> APIRouter:
             recent_approvals=[db_to_approval_request(a) for a in approvals[:recent_limit]],
         )
 
-    @router.get("/projects/{project_id}/audit", tags=["projects"], responses={404: {"description": "Project not found"}})
+    @router.get(
+        "/projects/{project_id}/audit", tags=["projects"], responses={404: {"description": "Project not found"}}
+    )
     def list_project_audit_logs(project_id: str) -> AuditLogListResponse:
         """List audit log entries for a specific project."""
         deps.project_repo.get_by_id(project_id)
@@ -191,7 +199,9 @@ def build_projects_router(deps: ProjectsRouterDeps) -> APIRouter:
             total=len(rows),
         )
 
-    @router.get("/projects/{project_id}/artifacts", tags=["projects"], responses={404: {"description": "Project not found"}})
+    @router.get(
+        "/projects/{project_id}/artifacts", tags=["projects"], responses={404: {"description": "Project not found"}}
+    )
     def list_project_artifacts(project_id: str) -> ArtifactListResponse:
         """List artifacts for a project."""
         deps.project_repo.get_by_id(project_id)
@@ -207,14 +217,18 @@ def build_projects_router(deps: ProjectsRouterDeps) -> APIRouter:
 
     # ---- Task routes ----
 
-    @router.get("/projects/{project_id}/tasks", tags=["projects"], responses={404: {"description": "Project not found"}})
+    @router.get(
+        "/projects/{project_id}/tasks", tags=["projects"], responses={404: {"description": "Project not found"}}
+    )
     def list_project_tasks(project_id: str) -> TaskListResponse:
         """List tasks for a project."""
         deps.project_repo.get_by_id(project_id)
         rows = deps.task_repo.list_by_project(project_id)
         return TaskListResponse(items=[db_to_task(r) for r in rows], total=len(rows))
 
-    @router.post("/projects/{project_id}/tasks", tags=["projects"], responses={404: {"description": "Project not found"}})
+    @router.post(
+        "/projects/{project_id}/tasks", tags=["projects"], responses={404: {"description": "Project not found"}}
+    )
     def create_task(project_id: str, body: CreateTaskRequest) -> Task:
         """Create a new task for a project."""
         deps.project_repo.get_by_id(project_id)
@@ -308,7 +322,9 @@ def build_projects_router(deps: ProjectsRouterDeps) -> APIRouter:
         )
         return _db_to_team_instance(instance)
 
-    @router.get("/projects/{project_id}/agent-team", tags=["projects"], responses={404: {"description": "Project not found"}})
+    @router.get(
+        "/projects/{project_id}/agent-team", tags=["projects"], responses={404: {"description": "Project not found"}}
+    )
     def get_project_team(project_id: str) -> ProjectAgentTeamInstance:
         """Get the agent team instance attached to a project."""
         deps.project_repo.get_by_id(project_id)

--- a/swarmmind/api/routers/projects.py
+++ b/swarmmind/api/routers/projects.py
@@ -1,0 +1,356 @@
+"""Project domain routes: CRUD, overview, tasks, agent-team, streaming."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import StreamingResponse
+
+from swarmmind.api.routers.mappers import (
+    db_to_approval_request,
+    db_to_artifact,
+    db_to_audit_log_entry,
+    db_to_project,
+    db_to_run,
+    db_to_task,
+    db_to_team_instance,
+)
+from swarmmind.models import (
+    ArtifactListResponse,
+    AuditLogListResponse,
+    AttachTeamRequest,
+    CreateTaskRequest,
+    DeleteProjectResponse,
+    DeleteTaskResponse,
+    Project,
+    ProjectAgentTeamInstance,
+    ProjectCreateRequest,
+    ProjectListResponse,
+    ProjectOverviewResponse,
+    ProjectUpdateRequest,
+    RunListResponse,
+    SendMessageRequest,
+    Task,
+    TaskListResponse,
+    UpdateTaskRequest,
+    UpdateTeamInstanceRequest,
+)
+
+
+@dataclass(frozen=True)
+class ProjectsRouterDeps:
+    project_repo: object
+    task_repo: object
+    run_repo: object
+    artifact_repo: object
+    approval_request_repo: object
+    audit_log_repo: object
+    agent_team_repo: object
+    project_team_repo: object
+    conversation_repo: object
+    stream_conversation_message: object
+
+
+def build_projects_router(deps: ProjectsRouterDeps) -> APIRouter:
+    router = APIRouter()
+
+    def _db_to_project(proj) -> Project:
+        return db_to_project(proj, deps.project_team_repo, deps.agent_team_repo)
+
+    def _db_to_team_instance(instance) -> ProjectAgentTeamInstance:
+        return db_to_team_instance(instance, deps.agent_team_repo)
+
+    def _ensure_project_conversation(project_id: str) -> str:
+        from swarmmind.db import session_scope
+        from swarmmind.db_models import ProjectDB
+
+        proj = deps.project_repo.get_by_id(project_id)
+        if proj.conversation_id:
+            return proj.conversation_id
+        conv = deps.conversation_repo.create(title=proj.title, title_status="pending")
+        with session_scope() as session:
+            proj_db = session.get(ProjectDB, project_id)
+            if proj_db is not None:
+                proj_db.conversation_id = conv.id
+                session.commit()
+        return conv.id
+
+    def _attach_team(project_id: str, team_template_id: str | None) -> None:
+        import logging
+        _logger = logging.getLogger(__name__)
+        if team_template_id:
+            try:
+                deps.agent_team_repo.get_by_id(team_template_id)
+                deps.project_team_repo.create(
+                    project_id=project_id,
+                    team_template_id=team_template_id,
+                )
+            except Exception as e:
+                _logger.warning("Failed to attach team %s to project %s: %s", team_template_id, project_id, e)
+
+    # ---- Project CRUD ----
+
+    @router.get("/projects", tags=["projects"])
+    def list_projects() -> ProjectListResponse:
+        """List all projects ordered by updated_at descending."""
+        rows = deps.project_repo.list_all()
+        return ProjectListResponse(items=[_db_to_project(r) for r in rows], total=len(rows))
+
+    @router.get("/projects/{project_id}", tags=["projects"], responses={404: {"description": "Project not found"}})
+    def get_project(project_id: str) -> Project:
+        """Get a single project by ID."""
+        return _db_to_project(deps.project_repo.get_by_id(project_id))
+
+    @router.post("/projects", tags=["projects"])
+    def create_project(body: ProjectCreateRequest) -> Project:
+        """Create a new project manually."""
+        proj = deps.project_repo.create(
+            title=body.title,
+            goal=body.goal,
+            scope=body.scope,
+            constraints=body.constraints,
+            source_conversation_id=body.source_conversation_id,
+            next_step=body.next_step,
+            phase=body.phase,
+            risk_level=body.risk_level,
+        )
+        _ensure_project_conversation(proj.project_id)
+        _attach_team(proj.project_id, body.team_template_id)
+        return _db_to_project(proj)
+
+    @router.delete("/projects/{project_id}", tags=["projects"], responses={404: {"description": "Project not found"}})
+    def delete_project(project_id: str) -> DeleteProjectResponse:
+        """Delete a project."""
+        deps.project_repo.get_by_id(project_id)
+        deps.project_repo.delete(project_id)
+        return DeleteProjectResponse(project_id=project_id)
+
+    @router.patch("/projects/{project_id}", tags=["projects"], responses={404: {"description": "Project not found"}})
+    def update_project(project_id: str, body: ProjectUpdateRequest) -> Project:
+        """Update a project. Only provided fields are changed."""
+        fields: dict[str, object] = {}
+        if body.title is not None:
+            fields["title"] = body.title
+        if body.goal is not None:
+            fields["goal"] = body.goal
+        if body.scope is not None:
+            fields["scope"] = body.scope
+        if body.constraints is not None:
+            fields["constraints"] = body.constraints
+        if body.next_step is not None:
+            fields["next_step"] = body.next_step
+        if body.phase is not None:
+            fields["phase"] = body.phase
+        if body.risk_level is not None:
+            fields["risk_level"] = body.risk_level
+        if body.status is not None:
+            fields["status"] = body.status.value
+        if not fields:
+            return _db_to_project(deps.project_repo.get_by_id(project_id))
+        deps.project_repo.update(project_id, **fields)
+        return _db_to_project(deps.project_repo.get_by_id(project_id))
+
+    # ---- Project overview / audit / artifacts ----
+
+    @router.get("/projects/{project_id}/overview", tags=["projects"], responses={404: {"description": "Project not found"}})
+    def get_project_overview(project_id: str) -> ProjectOverviewResponse:
+        """Get aggregated project overview with stats and recent items."""
+        proj = deps.project_repo.get_by_id(project_id)
+        tasks = deps.task_repo.list_by_project(project_id)
+        artifacts = deps.artifact_repo.list_by_project(project_id)
+        runs = deps.run_repo.list_by_project(project_id)
+        approvals = deps.approval_request_repo.list_by_project(project_id)
+
+        blocked_count = sum(1 for t in tasks if t.status == "blocked")
+        pending_approval_count = sum(1 for a in approvals if a.status == "pending")
+        stats = {
+            "blocked_count": blocked_count,
+            "pending_approval_count": pending_approval_count,
+            "task_count": len(tasks),
+            "artifact_count": len(artifacts),
+            "run_count": len(runs),
+        }
+        recent_limit = 5
+        return ProjectOverviewResponse(
+            project=_db_to_project(proj),
+            stats=stats,
+            recent_tasks=[db_to_task(t) for t in tasks[:recent_limit]],
+            recent_artifacts=[db_to_artifact(a) for a in artifacts[:recent_limit]],
+            recent_runs=[db_to_run(r) for r in runs[:recent_limit]],
+            recent_approvals=[db_to_approval_request(a) for a in approvals[:recent_limit]],
+        )
+
+    @router.get("/projects/{project_id}/audit", tags=["projects"], responses={404: {"description": "Project not found"}})
+    def list_project_audit_logs(project_id: str) -> AuditLogListResponse:
+        """List audit log entries for a specific project."""
+        deps.project_repo.get_by_id(project_id)
+        rows = deps.audit_log_repo.list_by_project(project_id)
+        return AuditLogListResponse(
+            items=[db_to_audit_log_entry(r) for r in rows],
+            total=len(rows),
+        )
+
+    @router.get("/projects/{project_id}/artifacts", tags=["projects"], responses={404: {"description": "Project not found"}})
+    def list_project_artifacts(project_id: str) -> ArtifactListResponse:
+        """List artifacts for a project."""
+        deps.project_repo.get_by_id(project_id)
+        rows = deps.artifact_repo.list_by_project(project_id)
+        return ArtifactListResponse(items=[db_to_artifact(r) for r in rows], total=len(rows))
+
+    @router.get("/projects/{project_id}/runs", tags=["runs"], responses={404: {"description": "Project not found"}})
+    def list_project_runs(project_id: str) -> RunListResponse:
+        """List runs for a project."""
+        deps.project_repo.get_by_id(project_id)
+        rows = deps.run_repo.list_by_project(project_id)
+        return RunListResponse(items=[db_to_run(r) for r in rows], total=len(rows))
+
+    # ---- Task routes ----
+
+    @router.get("/projects/{project_id}/tasks", tags=["projects"], responses={404: {"description": "Project not found"}})
+    def list_project_tasks(project_id: str) -> TaskListResponse:
+        """List tasks for a project."""
+        deps.project_repo.get_by_id(project_id)
+        rows = deps.task_repo.list_by_project(project_id)
+        return TaskListResponse(items=[db_to_task(r) for r in rows], total=len(rows))
+
+    @router.post("/projects/{project_id}/tasks", tags=["projects"], responses={404: {"description": "Project not found"}})
+    def create_task(project_id: str, body: CreateTaskRequest) -> Task:
+        """Create a new task for a project."""
+        deps.project_repo.get_by_id(project_id)
+        task = deps.task_repo.create(
+            project_id=project_id,
+            title=body.title,
+            description=body.description,
+            status=body.status.value,
+            assignee_role=body.assignee_role,
+            source_workstream=body.source_workstream,
+            artifact_ids=body.artifact_ids,
+            priority=body.priority.value,
+        )
+        return db_to_task(task)
+
+    @router.get(
+        "/projects/{project_id}/tasks/{task_id}",
+        tags=["projects"],
+        responses={404: {"description": "Project or task not found"}},
+    )
+    def get_task(project_id: str, task_id: str) -> Task:
+        """Get a single task by ID."""
+        deps.project_repo.get_by_id(project_id)
+        task = deps.task_repo.get_by_id(task_id)
+        if task.project_id != project_id:
+            raise HTTPException(status_code=404, detail="Task not found in this project")
+        return db_to_task(task)
+
+    @router.patch(
+        "/projects/{project_id}/tasks/{task_id}",
+        tags=["projects"],
+        responses={404: {"description": "Project or task not found"}},
+    )
+    def update_task(project_id: str, task_id: str, body: UpdateTaskRequest) -> Task:
+        """Update a task. Only provided fields are changed."""
+        deps.project_repo.get_by_id(project_id)
+        task = deps.task_repo.get_by_id(task_id)
+        if task.project_id != project_id:
+            raise HTTPException(status_code=404, detail="Task not found in this project")
+        fields: dict[str, object] = {}
+        if body.title is not None:
+            fields["title"] = body.title
+        if body.description is not None:
+            fields["description"] = body.description
+        if body.status is not None:
+            fields["status"] = body.status.value
+        if body.assignee_role is not None:
+            fields["assignee_role"] = body.assignee_role
+        if body.source_workstream is not None:
+            fields["source_workstream"] = body.source_workstream
+        if body.artifact_ids is not None:
+            fields["artifact_ids"] = body.artifact_ids
+        if body.priority is not None:
+            fields["priority"] = body.priority.value
+        if not fields:
+            return db_to_task(task)
+        return db_to_task(deps.task_repo.update(task_id, **fields))
+
+    @router.delete(
+        "/projects/{project_id}/tasks/{task_id}",
+        tags=["projects"],
+        responses={404: {"description": "Project or task not found"}},
+    )
+    def delete_task(project_id: str, task_id: str) -> DeleteTaskResponse:
+        """Delete a task."""
+        deps.project_repo.get_by_id(project_id)
+        task = deps.task_repo.get_by_id(task_id)
+        if task.project_id != project_id:
+            raise HTTPException(status_code=404, detail="Task not found in this project")
+        deps.task_repo.delete(task_id)
+        return DeleteTaskResponse(task_id=task_id)
+
+    # ---- Agent team instance routes ----
+
+    @router.post(
+        "/projects/{project_id}/agent-team",
+        tags=["projects"],
+        status_code=201,
+        responses={
+            404: {"description": "Project or team template not found"},
+            409: {"description": "Project already has a team attached"},
+        },
+    )
+    def attach_team_to_project(project_id: str, body: AttachTeamRequest) -> ProjectAgentTeamInstance:
+        """Attach an agent team template to a project."""
+        deps.project_repo.get_by_id(project_id)
+        instance = deps.project_team_repo.create(
+            project_id=project_id,
+            team_template_id=body.team_template_id,
+            instance_config=body.instance_config,
+        )
+        return _db_to_team_instance(instance)
+
+    @router.get("/projects/{project_id}/agent-team", tags=["projects"], responses={404: {"description": "Project not found"}})
+    def get_project_team(project_id: str) -> ProjectAgentTeamInstance:
+        """Get the agent team instance attached to a project."""
+        deps.project_repo.get_by_id(project_id)
+        instance = deps.project_team_repo.get_by_project(project_id)
+        if instance is None:
+            raise HTTPException(status_code=404, detail="Project does not have an agent team attached")
+        return _db_to_team_instance(instance)
+
+    @router.patch(
+        "/projects/{project_id}/agent-team",
+        tags=["projects"],
+        responses={404: {"description": "Project or team instance not found"}},
+    )
+    def update_project_team(project_id: str, body: UpdateTeamInstanceRequest) -> ProjectAgentTeamInstance:
+        """Update the agent team instance for a project."""
+        instance = deps.project_team_repo.update(
+            project_id=project_id,
+            instance_config=body.instance_config,
+            status=body.status,
+        )
+        return _db_to_team_instance(instance)
+
+    @router.delete("/projects/{project_id}/agent-team", tags=["projects"], status_code=204)
+    def detach_team_from_project(project_id: str) -> None:
+        """Detach the agent team from a project."""
+        deps.project_repo.get_by_id(project_id)
+        deps.project_team_repo.delete(project_id)
+
+    # ---- Project streaming ----
+
+    @router.post(
+        "/projects/{project_id}/messages/stream",
+        tags=["projects"],
+        responses={404: {"description": "Project not found"}},
+    )
+    def send_project_message_stream(project_id: str, body: SendMessageRequest) -> StreamingResponse:
+        """Stream a project execution turn with SwarmMind runtime semantics."""
+        deps.project_repo.get_by_id(project_id)
+        conversation_id = _ensure_project_conversation(project_id)
+        return StreamingResponse(
+            deps.stream_conversation_message(conversation_id, body),
+            media_type="application/x-ndjson",
+        )
+
+    return router

--- a/swarmmind/api/routers/promotions.py
+++ b/swarmmind/api/routers/promotions.py
@@ -28,6 +28,8 @@ NEW_CONVERSATION_TITLE = "New Conversation"
 
 @dataclass(frozen=True)
 class PromotionsRouterDeps:
+    """Dependencies for the promotions router."""
+
     conversation_repo: object
     message_repo: object
     project_repo: object
@@ -41,6 +43,7 @@ class PromotionsRouterDeps:
 
 
 def build_promotions_router(deps: PromotionsRouterDeps) -> APIRouter:
+    """Return an APIRouter for conversation promotion, trace, and artifact endpoints."""
     router = APIRouter()
 
     def _db_to_project(proj) -> Project:
@@ -194,9 +197,7 @@ def build_promotions_router(deps: PromotionsRouterDeps) -> APIRouter:
             404: {"description": "Conversation or artifact not found"},
         },
     )
-    def get_conversation_artifact_file(
-        conversation_id: str, artifact_path: str, download: bool = False
-    ) -> Response:
+    def get_conversation_artifact_file(conversation_id: str, artifact_path: str, download: bool = False) -> Response:
         """Return the registered artifact file content for a conversation."""
         conversation = deps.conversation_repo.get_by_id(conversation_id)
         artifact = deps.artifact_repo.get_by_conversation_path(conversation_id, artifact_path)

--- a/swarmmind/api/routers/promotions.py
+++ b/swarmmind/api/routers/promotions.py
@@ -1,0 +1,220 @@
+"""Conversation promotion, artifact extraction, trace, and artifact serving routes."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import Response
+
+from swarmmind.api.routers.mappers import db_to_artifact, db_to_project
+from swarmmind.models import (
+    ArtifactListResponse,
+    ExtractArtifactsResponse,
+    Project,
+    PromoteConversationRequest,
+    TraceSummaryResponse,
+)
+from swarmmind.services.artifact_content import (
+    build_artifact_file_response,
+    resolve_virtual_artifact_path,
+)
+
+logger = logging.getLogger(__name__)
+
+NEW_CONVERSATION_TITLE = "New Conversation"
+
+
+@dataclass(frozen=True)
+class PromotionsRouterDeps:
+    conversation_repo: object
+    message_repo: object
+    project_repo: object
+    project_team_repo: object
+    agent_team_repo: object
+    artifact_repo: object
+    # Callable[[], service] so tests can monkeypatch the module-level attribute and
+    # have route handlers pick up the new value without rebuilding the router.
+    message_trace_service_fn: object
+    runtime_support: object
+
+
+def build_promotions_router(deps: PromotionsRouterDeps) -> APIRouter:
+    router = APIRouter()
+
+    def _db_to_project(proj) -> Project:
+        return db_to_project(proj, deps.project_team_repo, deps.agent_team_repo)
+
+    def _ensure_project_conversation(project_id: str) -> str:
+        from swarmmind.db import session_scope
+        from swarmmind.db_models import ProjectDB
+
+        proj = deps.project_repo.get_by_id(project_id)
+        if proj.conversation_id:
+            return proj.conversation_id
+        conv = deps.conversation_repo.create(title=proj.title, title_status="pending")
+        with session_scope() as session:
+            proj_db = session.get(ProjectDB, project_id)
+            if proj_db is not None:
+                proj_db.conversation_id = conv.id
+                session.commit()
+        return conv.id
+
+    def _attach_team(project_id: str, team_template_id: str | None) -> None:
+        if team_template_id:
+            try:
+                deps.agent_team_repo.get_by_id(team_template_id)
+                deps.project_team_repo.create(
+                    project_id=project_id,
+                    team_template_id=team_template_id,
+                )
+            except Exception as e:
+                logger.warning("Failed to attach team %s to project %s: %s", team_template_id, project_id, e)
+
+    def _generate_project_seed(conversation_id: str, override: PromoteConversationRequest | None) -> dict:
+        conv = deps.conversation_repo.get_by_id(conversation_id)
+        messages = deps.message_repo.list_by_conversation(conversation_id)
+        user_msgs = [m for m in messages if m.role == "user"]
+        assistant_msgs = [m for m in messages if m.role == "assistant"]
+
+        title = override.title if override and override.title else conv.title
+        if title in ("New Conversation", NEW_CONVERSATION_TITLE) and user_msgs:
+            first_user = user_msgs[0].content.strip()
+            title = first_user[:50] if len(first_user) <= 50 else first_user[:47] + "..."
+
+        goal = override.goal if override and override.goal else None
+        if goal is None and user_msgs:
+            parts = [m.content.strip() for m in user_msgs[:3]]
+            goal = "\n".join(parts)
+            if len(goal) > 2000:
+                goal = goal[:1997] + "..."
+
+        scope = override.scope if override and override.scope else None
+        constraints = override.constraints if override and override.constraints else None
+
+        next_step = override.next_step if override and override.next_step else None
+        if next_step is None and assistant_msgs:
+            last = assistant_msgs[-1].content.strip()
+            sentence_end = max(last.find("."), last.find("。"), last.find("\n"))
+            if sentence_end > 0:
+                next_step = last[: sentence_end + 1]
+            else:
+                next_step = last[:100] + "..." if len(last) > 100 else last
+
+        return {
+            "title": title or "Untitled Project",
+            "goal": goal,
+            "scope": scope,
+            "constraints": constraints,
+            "source_conversation_id": conversation_id,
+            "next_step": next_step,
+        }
+
+    # ---- Routes ----
+
+    @router.post(
+        "/conversations/{conversation_id}/promote",
+        tags=["conversations"],
+        responses={404: {"description": "Conversation not found"}},
+    )
+    def promote_conversation(
+        conversation_id: str,
+        body: PromoteConversationRequest | None = None,
+    ) -> Project:
+        """Promote a ChatSession to a formal Project."""
+        deps.conversation_repo.get_by_id(conversation_id)
+        try:
+            seed = _generate_project_seed(conversation_id, override=body)
+        except Exception as e:
+            logger.error("Project seed generation failed for %s: %s", conversation_id, e)
+            seed = {
+                "title": "Project from conversation",
+                "goal": None,
+                "scope": None,
+                "constraints": None,
+                "source_conversation_id": conversation_id,
+                "next_step": "Review the source conversation and define next steps.",
+            }
+
+        proj = deps.project_repo.create(**seed)
+        deps.project_repo.link_conversation(proj.project_id, conversation_id)
+        _ensure_project_conversation(proj.project_id)
+        _attach_team(proj.project_id, body.team_template_id if body else None)
+
+        logger.info(
+            "Conversation %s promoted to project %s (%s)",
+            conversation_id,
+            proj.project_id,
+            proj.title,
+        )
+        return _db_to_project(proj)
+
+    @router.get(
+        "/conversations/{conversation_id}/messages/{message_id}/trace",
+        tags=["conversations"],
+        responses={404: {"description": "Conversation or message not found"}},
+    )
+    def get_message_trace(conversation_id: str, message_id: str) -> TraceSummaryResponse:
+        """Return a readable trace summary for an assistant message."""
+        deps.conversation_repo.get_by_id(conversation_id)
+        msg = deps.message_repo.get_by_id(message_id)
+        if msg.conversation_id != conversation_id:
+            raise HTTPException(status_code=404, detail="Message not found in this conversation")
+        try:
+            return deps.message_trace_service_fn().get_summary(conversation_id, message_id)
+        except Exception as exc:
+            logger.warning("Trace summary failed for message %s: %s", message_id, exc)
+            summary = "执行完成" if msg.run_id else "直接回复"
+            return TraceSummaryResponse(
+                steps_count=1 if msg.run_id else 0,
+                subagent_calls_count=0,
+                artifacts_count=0,
+                blocked_points=[],
+                summary=summary,
+            )
+
+    @router.get(
+        "/conversations/{conversation_id}/artifacts",
+        tags=["conversations"],
+        responses={404: {"description": "Conversation not found"}},
+    )
+    def list_conversation_artifacts(conversation_id: str) -> ArtifactListResponse:
+        """List artifacts for a conversation."""
+        deps.conversation_repo.get_by_id(conversation_id)
+        rows = deps.artifact_repo.list_by_conversation(conversation_id)
+        return ArtifactListResponse(items=[db_to_artifact(r) for r in rows], total=len(rows))
+
+    @router.get(
+        "/conversations/{conversation_id}/artifacts/{artifact_path:path}",
+        tags=["conversations"],
+        responses={
+            400: {"description": "Invalid artifact path"},
+            403: {"description": "Artifact path escapes the conversation sandbox"},
+            404: {"description": "Conversation or artifact not found"},
+        },
+    )
+    def get_conversation_artifact_file(
+        conversation_id: str, artifact_path: str, download: bool = False
+    ) -> Response:
+        """Return the registered artifact file content for a conversation."""
+        conversation = deps.conversation_repo.get_by_id(conversation_id)
+        artifact = deps.artifact_repo.get_by_conversation_path(conversation_id, artifact_path)
+        virtual_path = artifact.path or artifact.name or artifact_path
+        thread_id = conversation.thread_id or deps.runtime_support.conversation_thread_id(conversation_id)
+        actual_path = resolve_virtual_artifact_path(thread_id, virtual_path)
+        return build_artifact_file_response(actual_path, download=download)
+
+    @router.post(
+        "/conversations/{conversation_id}/extract-artifacts",
+        tags=["conversations"],
+        responses={404: {"description": "Conversation not found"}},
+    )
+    def extract_conversation_artifacts(conversation_id: str) -> ExtractArtifactsResponse:
+        """Extract artifacts from conversation trace and persist them. Idempotent."""
+        conv = deps.conversation_repo.get_by_id(conversation_id)
+        project_id = conv.promoted_project_id if conv else None
+        created = deps.message_trace_service_fn().extract_artifacts(conversation_id, project_id=project_id)
+        return ExtractArtifactsResponse(conversation_id=conversation_id, extracted=len(created), artifacts=created)
+
+    return router

--- a/swarmmind/api/routers/runs.py
+++ b/swarmmind/api/routers/runs.py
@@ -17,15 +17,22 @@ from swarmmind.models import (
 
 @dataclass(frozen=True)
 class RunsRouterDeps:
+    """Dependencies for the runs router."""
+
     run_repo: object
     project_repo: object
     conversation_repo: object
 
 
 def build_runs_router(deps: RunsRouterDeps) -> APIRouter:
+    """Return an APIRouter with all run CRUD endpoints."""
     router = APIRouter()
 
-    @router.get("/conversations/{conversation_id}/runs", tags=["runs"], responses={404: {"description": "Conversation not found"}})
+    @router.get(
+        "/conversations/{conversation_id}/runs",
+        tags=["runs"],
+        responses={404: {"description": "Conversation not found"}},
+    )
     def list_conversation_runs(conversation_id: str) -> RunListResponse:
         """List runs for a conversation."""
         deps.conversation_repo.get_by_id(conversation_id)

--- a/swarmmind/api/routers/runs.py
+++ b/swarmmind/api/routers/runs.py
@@ -1,0 +1,67 @@
+"""Run domain routes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from fastapi import APIRouter
+
+from swarmmind.api.routers.mappers import db_to_run
+from swarmmind.models import (
+    CreateRunRequest,
+    Run,
+    RunListResponse,
+    UpdateRunRequest,
+)
+
+
+@dataclass(frozen=True)
+class RunsRouterDeps:
+    run_repo: object
+    project_repo: object
+    conversation_repo: object
+
+
+def build_runs_router(deps: RunsRouterDeps) -> APIRouter:
+    router = APIRouter()
+
+    @router.get("/conversations/{conversation_id}/runs", tags=["runs"], responses={404: {"description": "Conversation not found"}})
+    def list_conversation_runs(conversation_id: str) -> RunListResponse:
+        """List runs for a conversation."""
+        deps.conversation_repo.get_by_id(conversation_id)
+        rows = deps.run_repo.list_by_conversation(conversation_id)
+        return RunListResponse(items=[db_to_run(r) for r in rows], total=len(rows))
+
+    @router.get("/runs/{run_id}", tags=["runs"], responses={404: {"description": "Run not found"}})
+    def get_run(run_id: str) -> Run:
+        """Get a single run by ID."""
+        return db_to_run(deps.run_repo.get_by_id(run_id))
+
+    @router.post("/runs", tags=["runs"])
+    def create_run(body: CreateRunRequest) -> Run:
+        """Create a run record linked to a conversation and/or a project."""
+        if body.conversation_id:
+            deps.conversation_repo.get_by_id(body.conversation_id)
+        if body.project_id:
+            deps.project_repo.get_by_id(body.project_id)
+        run = deps.run_repo.create(
+            conversation_id=body.conversation_id,
+            project_id=body.project_id,
+            goal=body.goal,
+            status=body.status.value,
+        )
+        return db_to_run(run)
+
+    @router.patch("/runs/{run_id}", tags=["runs"], responses={404: {"description": "Run not found"}})
+    def update_run(run_id: str, body: UpdateRunRequest) -> Run:
+        """Update a run. Only provided fields are changed."""
+        run = deps.run_repo.update(
+            run_id,
+            project_id=body.project_id,
+            status=body.status.value if body.status else None,
+            goal=body.goal,
+            summary=body.summary,
+        )
+        return db_to_run(run)
+
+    return router

--- a/swarmmind/api/routers/runtime_models.py
+++ b/swarmmind/api/routers/runtime_models.py
@@ -13,6 +13,7 @@ from swarmmind.runtime.catalog import (
 
 
 def build_runtime_models_router() -> APIRouter:
+    """Return an APIRouter for the runtime model catalog endpoints."""
     router = APIRouter()
 
     @router.get("/models", tags=["runtime"])

--- a/swarmmind/api/routers/runtime_models.py
+++ b/swarmmind/api/routers/runtime_models.py
@@ -1,0 +1,60 @@
+"""Runtime model catalog routes."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from swarmmind.models import RuntimeModelCatalogResponse, RuntimeModelOption
+from swarmmind.runtime.catalog import (
+    ANONYMOUS_SUBJECT_ID,
+    ANONYMOUS_SUBJECT_TYPE,
+    list_models_for_subject,
+)
+
+
+def build_runtime_models_router() -> APIRouter:
+    router = APIRouter()
+
+    @router.get("/models", tags=["runtime"])
+    @router.get("/runtime/models", tags=["runtime"])
+    def list_runtime_models() -> RuntimeModelCatalogResponse:
+        """List runtime models available to the current anonymous visitor subject."""
+        return _list_runtime_models()
+
+    return router
+
+
+def list_runtime_models() -> RuntimeModelCatalogResponse:
+    """Return the runtime model catalog for the anonymous subject.
+
+    Exposed as a module-level function so supervisor.py can re-export it
+    for backward-compatible direct calls in tests.
+    """
+    return _list_runtime_models()
+
+
+def _list_runtime_models() -> RuntimeModelCatalogResponse:
+    models = list_models_for_subject(
+        subject_type=ANONYMOUS_SUBJECT_TYPE,
+        subject_id=ANONYMOUS_SUBJECT_ID,
+    )
+    default_model = next((m.name for m in models if m.is_default), None)
+    return RuntimeModelCatalogResponse(
+        models=[
+            RuntimeModelOption(
+                name=m.name,
+                provider=m.provider,
+                model=m.model,
+                display_name=m.display_name,
+                description=m.description,
+                supports_vision=m.supports_vision,
+                supports_thinking=m.supports_thinking,
+                capability_tags=m.capability_tags,
+                is_default=m.is_default,
+            )
+            for m in models
+        ],
+        default_model=default_model,
+        subject_type=ANONYMOUS_SUBJECT_TYPE,
+        subject_id=ANONYMOUS_SUBJECT_ID,
+    )

--- a/swarmmind/api/routers/system.py
+++ b/swarmmind/api/routers/system.py
@@ -13,11 +13,14 @@ from swarmmind.models import HealthResponse, ReadyResponse, StatusResponse
 
 @dataclass(frozen=True)
 class SystemRouterDeps:
+    """Dependencies for the system router."""
+
     ensure_default_runtime_instance: Callable
     render_status: Callable
 
 
 def build_system_router(deps: SystemRouterDeps) -> APIRouter:
+    """Return an APIRouter for health, readiness, and status endpoints."""
     router = APIRouter()
 
     @router.get("/health", tags=["system"])

--- a/swarmmind/api/routers/system.py
+++ b/swarmmind/api/routers/system.py
@@ -1,0 +1,48 @@
+"""System health and status routes."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from fastapi import APIRouter, HTTPException, Query
+
+from swarmmind.models import HealthResponse, ReadyResponse, StatusResponse
+
+
+@dataclass(frozen=True)
+class SystemRouterDeps:
+    ensure_default_runtime_instance: Callable
+    render_status: Callable
+
+
+def build_system_router(deps: SystemRouterDeps) -> APIRouter:
+    router = APIRouter()
+
+    @router.get("/health", tags=["system"])
+    def health() -> HealthResponse:
+        """Health check endpoint."""
+        return HealthResponse(timestamp=datetime.now(UTC).isoformat())
+
+    @router.get("/ready", tags=["system"])
+    def ready() -> ReadyResponse:
+        """Readiness check: database plus DeerFlow runtime bundle."""
+        runtime_instance = deps.ensure_default_runtime_instance()
+        return ReadyResponse(
+            runtime_profile_id=runtime_instance.runtime_profile_id,
+            runtime_instance_id=runtime_instance.runtime_instance_id,
+        )
+
+    @router.get("/status", tags=["supervisor"])
+    def get_status(goal: str = Query(..., max_length=2000)) -> StatusResponse:
+        """LLM Status Renderer: given a goal, read shared context and
+        generate a human-readable status summary (Phase 1: prose only).
+        """
+        try:
+            summary = deps.render_status(goal)
+            return StatusResponse(summary=summary, goal=goal)
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=str(e))
+
+    return router

--- a/swarmmind/api/supervisor.py
+++ b/swarmmind/api/supervisor.py
@@ -1,99 +1,42 @@
-"""Supervisor REST API — FastAPI server for human oversight."""
+"""Supervisor REST API — FastAPI app assembly and router registration."""
 
 import logging
-import uuid
 from contextlib import asynccontextmanager
-from datetime import UTC, datetime
 
-from fastapi import FastAPI, HTTPException, Query
+from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import Response, StreamingResponse
-from pydantic import BaseModel
 
 from swarmmind.api.conversation_routes import (
     ClarificationResponseRequest as ConversationClarificationResponseRequest,
 )
-from swarmmind.api.conversation_routes import (
-    ConversationRouteDeps,
-    build_conversation_router,
-)
+from swarmmind.api.conversation_routes import ConversationRouteDeps, build_conversation_router
+from swarmmind.api.routers.agent_teams import AgentTeamsRouterDeps, build_agent_teams_router
+from swarmmind.api.routers.approvals import ApprovalsRouterDeps, build_approvals_router
+from swarmmind.api.routers.audit_logs import AuditLogsRouterDeps, build_audit_logs_router
+from swarmmind.api.routers.legacy_supervisor import LegacySupervisorRouterDeps, build_legacy_supervisor_router
+from swarmmind.api.routers.projects import ProjectsRouterDeps, build_projects_router
+from swarmmind.api.routers.promotions import PromotionsRouterDeps, build_promotions_router
+from swarmmind.api.routers.runtime_models import build_runtime_models_router
+from swarmmind.api.routers.runtime_models import list_runtime_models  # noqa: F401  (re-export for tests)
+from swarmmind.api.routers.runs import RunsRouterDeps, build_runs_router
+from swarmmind.api.routers.system import SystemRouterDeps, build_system_router
 from swarmmind.config import ACTION_TIMEOUT_SECONDS, API_HOST, API_PORT
-from swarmmind.context_broker import (
-    derive_situation_tag,
-    dispatch,
-    record_supervisor_decision,
-)
+from swarmmind.context_broker import derive_situation_tag, dispatch, record_supervisor_decision
 from swarmmind.db import init_db, seed_builtin_agent_teams, seed_default_agents
 from swarmmind.models import (
-    AgentTeamTemplate,
-    AgentTeamTemplateCreateRequest,
-    AgentTeamTemplateListResponse,
-    AgentTeamTemplateUpdateRequest,
-    ApprovalRequest,
-    ApprovalRequestListResponse,
-    ApprovalStatus,
-    ApproveResponse,
-    Artifact,
-    ArtifactListResponse,
-    AttachTeamRequest,
-    AuditLogEntry,
-    AuditLogListResponse,
     Conversation,
     ConversationListResponse,
     ConversationRuntimeOptions,
     ConversationTraceResponse,
-    CreateApprovalRequest,
-    CreateAuditLogEntry,
-    CreateConversationRequest,
-    CreateRunRequest,
-    CreateTaskRequest,
-    DeleteApprovalResponse,
-    DeleteAuditLogResponse,
     DeleteConversationResponse,
-    DeleteProjectResponse,
-    DeleteTaskResponse,
-    DispatchResponse,
-    ExtractArtifactsResponse,
-    GoalRequest,
-    HealthResponse,
     Message,
     MessageListResponse,
-    PendingResponse,
-    Project,
-    ProjectAgentTeamInstance,
-    ProjectCreateRequest,
-    ProjectListResponse,
-    ProjectOverviewResponse,
-    ProjectUpdateRequest,
-    PromoteConversationRequest,
-    ReadyResponse,
     RecentConversationResponse,
-    RejectRequest,
-    RejectResponse,
-    RiskTier,
-    Run,
-    RunListResponse,
-    RuntimeModelCatalogResponse,
-    RuntimeModelOption,
     SendMessageRequest,
-    StatusResponse,
-    StrategyEntry,
-    StrategyResponse,
     SupervisorDecision,
-    Task,
-    TaskListResponse,
-    TeamRole,
-    TraceSummaryResponse,
-    UpdateApprovalRequest,
-    UpdateRunRequest,
-    UpdateTaskRequest,
-    UpdateTeamInstanceRequest,
 )
 from swarmmind.renderer import render_status
-from swarmmind.repositories.action_proposal import (
-    ActionProposalRepository,
-    _db_to_action_proposal,
-)
+from swarmmind.repositories.action_proposal import ActionProposalRepository
 from swarmmind.repositories.agent_team import AgentTeamRepository
 from swarmmind.repositories.approval_request import ApprovalRequestRepository
 from swarmmind.repositories.artifact import ArtifactRepository
@@ -106,12 +49,9 @@ from swarmmind.repositories.project_team import ProjectTeamInstanceRepository
 from swarmmind.repositories.run import RunRepository
 from swarmmind.repositories.strategy import StrategyRepository
 from swarmmind.repositories.task import TaskRepository
-from swarmmind.services.artifact_content import (
-    build_artifact_file_response,
-    is_virtual_user_data_path,
-    normalize_virtual_path,
-    resolve_virtual_artifact_path,
-)
+from swarmmind.agents.general_agent import DeerFlowRuntimeAdapter
+from swarmmind.runtime import ensure_default_runtime_instance
+from swarmmind.runtime.catalog import sync_env_runtime_model
 from swarmmind.services.conversation_execution import ConversationExecutionService
 from swarmmind.services.conversation_support import (
     ConversationSupportService,
@@ -119,28 +59,19 @@ from swarmmind.services.conversation_support import (
 )
 from swarmmind.services.conversation_trace_service import ConversationTraceService
 from swarmmind.services.lifecycle import run_cleanup_scanner, startup_lifecycle
-from swarmmind.services.message_trace_service import (
-    _default_message_trace_service,
-)
+from swarmmind.services.message_trace_service import _default_message_trace_service
 from swarmmind.services.runtime_support import RuntimeSupportService
 from swarmmind.services.stream_events import (
-    general_agent_status_labels as service_general_agent_status_labels,
+    general_agent_status_labels as _svc_general_agent_status_labels,
+    serialize_stream_event as _svc_serialize_stream_event,
+    translate_general_agent_event as _svc_translate_general_agent_event,
 )
-from swarmmind.services.stream_events import (
-    serialize_stream_event as service_serialize_stream_event,
-)
-from swarmmind.services.stream_events import (
-    task_card_title as service_task_card_title,
-)
-from swarmmind.services.stream_events import (
-    task_status_from_result as service_task_status_from_result,
-)
-from swarmmind.services.stream_events import (
-    tool_activity_label as service_tool_activity_label,
-)
-from swarmmind.services.stream_events import (
-    translate_general_agent_event as service_translate_general_agent_event,
-)
+
+logger = logging.getLogger(__name__)
+
+NEW_CONVERSATION_TITLE = "New Conversation"
+
+# ---- Singletons ----
 
 conversation_repo = ConversationRepository()
 message_repo = MessageRepository()
@@ -155,6 +86,7 @@ agent_team_repo = AgentTeamRepository()
 project_team_repo = ProjectTeamInstanceRepository()
 task_repo = TaskRepository()
 audit_log_repo = AuditLogRepository()
+
 conversation_support = ConversationSupportService(
     conversation_repo=conversation_repo,
     message_repo=message_repo,
@@ -169,30 +101,20 @@ def _generate_title_with_deerflow(user_msg: str, assistant_msg: str) -> tuple[st
     return generate_title_with_deerflow(user_msg, assistant_msg)
 
 
-from swarmmind.agents.general_agent import DeerFlowRuntimeAdapter
-from swarmmind.runtime import (
-    ensure_default_runtime_instance,
-)
-from swarmmind.runtime.catalog import (
-    ANONYMOUS_SUBJECT_ID,
-    ANONYMOUS_SUBJECT_TYPE,
-    list_models_for_subject,
-    sync_env_runtime_model,
-)
+# ---- Cleanup scanner ----
 
-logger = logging.getLogger(__name__)
-
-NEW_CONVERSATION_TITLE = "New Conversation"
-
-
-class StrategyChangeApproveRequest(BaseModel):
-    """Request to approve a strategy change."""
-
-    change_id: str
+def _cleanup_scanner():
+    run_cleanup_scanner(
+        action_proposal_repo=action_proposal_repo,
+        memory_repo=memory_repo,
+        action_timeout_seconds=ACTION_TIMEOUT_SECONDS,
+        record_supervisor_decision=record_supervisor_decision,
+        supervisor_timeout_decision=SupervisorDecision.TIMEOUT,
+        lifecycle_logger=logger,
+    )
 
 
 # ---- FastAPI app ----
-
 
 @asynccontextmanager
 async def lifespan(_app: FastAPI):
@@ -225,217 +147,10 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-# ---- Timeout scanner ----
-
-
-def _cleanup_scanner():
-    """Background thread: clean up stale proposals and expired memory entries."""
-    run_cleanup_scanner(
-        action_proposal_repo=action_proposal_repo,
-        memory_repo=memory_repo,
-        action_timeout_seconds=ACTION_TIMEOUT_SECONDS,
-        record_supervisor_decision=record_supervisor_decision,
-        supervisor_timeout_decision=SupervisorDecision.TIMEOUT,
-        lifecycle_logger=logger,
-    )
-
-
-# ---- Supervisor endpoints ----
-
-
-@app.get("/pending", tags=["supervisor"])
-def get_pending(limit: int = Query(50, ge=1, le=200), offset: int = Query(0, ge=0)) -> PendingResponse:
-    """List pending action proposals (paginated)."""
-    rows, total = action_proposal_repo.list_pending(limit=limit, offset=offset)
-    items = [_db_to_action_proposal(row) for row in rows]
-    return PendingResponse(items=items, total=total)
-
-
-@app.post("/approve/{proposal_id}", tags=["supervisor"], responses={404: {"description": "Proposal not found"}})
-def approve(proposal_id: str) -> ApproveResponse:
-    """Approve an action proposal."""
-    action_proposal_repo.approve(proposal_id)
-    record_supervisor_decision(proposal_id, SupervisorDecision.APPROVED)
-    logger.info("Proposal %s approved by supervisor", proposal_id)
-    return ApproveResponse(id=proposal_id)
-
-
-@app.post("/reject/{proposal_id}", tags=["supervisor"], responses={404: {"description": "Proposal not found"}})
-def reject(proposal_id: str, body: RejectRequest | None = None) -> RejectResponse:
-    """Reject an action proposal."""
-    action_proposal_repo.reject_proposal(proposal_id)
-    record_supervisor_decision(proposal_id, SupervisorDecision.REJECTED)
-    logger.info("Proposal %s rejected by supervisor", proposal_id)
-    reason = body.reason if body else None
-    return RejectResponse(id=proposal_id, reason=reason)
-
-
-@app.get("/status", tags=["supervisor"])
-def get_status(goal: str = Query(..., max_length=2000)) -> StatusResponse:
-    """LLM Status Renderer: given a goal, read shared context and
-    generate a human-readable status summary (Phase 1: prose only).
-    """
-    try:
-        summary = render_status(goal)
-        return StatusResponse(summary=summary, goal=goal)
-    except Exception as e:
-        logger.error("Status renderer error: %s", e)
-        raise HTTPException(status_code=500, detail=str(e))
-
-
-@app.get("/strategy", tags=["supervisor"])
-def get_strategy() -> StrategyResponse:
-    """View the strategy routing table."""
-    rows = strategy_repo.list_all()
-    entries = [
-        StrategyEntry(
-            situation_tag=row.situation_tag,
-            agent_id=row.agent_id,
-            success_count=row.success_count,
-            failure_count=row.failure_count,
-        )
-        for row in rows
-    ]
-    return StrategyResponse(entries=entries)
-
-
-@app.post("/dispatch", tags=["supervisor"])
-def post_dispatch(body: GoalRequest) -> DispatchResponse:
-    """Submit a new goal for dispatch to an agent."""
-    try:
-        session_id = str(uuid.uuid4())
-        result = dispatch(
-            body.goal,
-            user_id="supervisor",
-            session_id=session_id,
-        )
-        return result
-    except Exception as e:
-        logger.error("Dispatch error: %s", e)
-        raise HTTPException(status_code=500, detail=str(e))
-
-
-@app.get("/health", tags=["system"])
-def health() -> HealthResponse:
-    """Health check endpoint."""
-    return HealthResponse(timestamp=datetime.now(UTC).isoformat())
-
-
-@app.get("/ready", tags=["system"])
-def ready() -> ReadyResponse:
-    """Readiness check: database plus DeerFlow runtime bundle."""
-    runtime_instance = ensure_default_runtime_instance()
-    return ReadyResponse(
-        runtime_profile_id=runtime_instance.runtime_profile_id,
-        runtime_instance_id=runtime_instance.runtime_instance_id,
-    )
-
-
-@app.get("/models", tags=["runtime"])
-@app.get("/runtime/models", tags=["runtime"])
-def list_runtime_models() -> RuntimeModelCatalogResponse:
-    """List runtime models available to the current anonymous visitor subject."""
-    models = list_models_for_subject(
-        subject_type=ANONYMOUS_SUBJECT_TYPE,
-        subject_id=ANONYMOUS_SUBJECT_ID,
-    )
-    default_model = next((model.name for model in models if model.is_default), None)
-    return RuntimeModelCatalogResponse(
-        models=[
-            RuntimeModelOption(
-                name=model.name,
-                provider=model.provider,
-                model=model.model,
-                display_name=model.display_name,
-                description=model.description,
-                supports_vision=model.supports_vision,
-                supports_thinking=model.supports_thinking,
-                capability_tags=model.capability_tags,
-                is_default=model.is_default,
-            )
-            for model in models
-        ],
-        default_model=default_model,
-        subject_type=ANONYMOUS_SUBJECT_TYPE,
-        subject_id=ANONYMOUS_SUBJECT_ID,
-    )
-
-
-# ---- Conversation endpoints ----
-
-
-def _db_to_conversation(conv, messages: list[Message] | None = None) -> Conversation:
-    conv_model = conversation_support.db_to_conversation(conv)
-    if messages is not None:
-        conv_model.messages = messages
-    return conv_model
-
-
-def _db_to_message(msg) -> Message:
-    return conversation_support.db_to_message(msg)
-
-
-def _serialize_stream_event(event_type: str, **payload) -> str:
-    return service_serialize_stream_event(event_type, **payload)
-
-
-def _tool_activity_label(tool_name: str, args: dict | None = None) -> str:
-    return service_tool_activity_label(tool_name, args)
-
-
-def _task_card_title(tool_args: dict | None) -> str:
-    return service_task_card_title(tool_args)
-
-
-def _task_status_from_result(content: str) -> tuple[str, str | None]:
-    return service_task_status_from_result(content)
-
-
-def _persist_user_message(conversation_id: str, content: str, run_id: str | None = None) -> Message:
-    return conversation_support.persist_user_message(conversation_id, content, run_id=run_id)
-
-
-def _persist_assistant_message(conversation_id: str, content: str) -> Message:
-    return conversation_support.persist_assistant_message(conversation_id, content)
-
-
-def _normalize_model_name(model_name: str | None) -> str | None:
-    return runtime_support.normalize_model_name(model_name)
-
-
-def _resolve_model_name_for_request(model_name: str | None) -> str:
-    return runtime_support.resolve_model_name_for_request(model_name)
-
-
-def _conversation_thread_id(conversation_id: str) -> str:
-    return runtime_support.conversation_thread_id(conversation_id)
-
-
-def _bind_conversation_runtime(conversation_id: str) -> tuple[object, str]:
-    return runtime_support.bind_conversation_runtime(conversation_id)
-
-
-def _format_runtime_error(exc: Exception) -> str:
-    return runtime_support.format_runtime_error(exc)
-
+# ---- Conversation handler helpers ----
 
 def _resolve_runtime_options(body: SendMessageRequest) -> ConversationRuntimeOptions:
     return runtime_support.resolve_runtime_options(body)
-
-
-def _general_agent_status_labels(runtime_options: ConversationRuntimeOptions) -> tuple[str, str]:
-    return service_general_agent_status_labels(runtime_options)
-
-
-def _translate_general_agent_event(
-    event: dict,
-    runtime_options: ConversationRuntimeOptions,
-) -> list[str]:
-    return service_translate_general_agent_event(event, runtime_options)
-
-
-def _maybe_generate_conversation_title(conversation_id: str) -> None:
-    conversation_support.maybe_generate_conversation_title(conversation_id, _generate_title_with_deerflow)
 
 
 def _conversation_execution_service() -> ConversationExecutionService:
@@ -448,39 +163,52 @@ def _conversation_execution_service() -> ConversationExecutionService:
         derive_situation_tag_fn=derive_situation_tag,
         record_supervisor_decision_fn=record_supervisor_decision,
         approved_decision=SupervisorDecision.APPROVED,
-        persist_user_message_fn=_persist_user_message,
-        persist_assistant_message_fn=_persist_assistant_message,
-        maybe_generate_conversation_title_fn=_maybe_generate_conversation_title,
-        bind_conversation_runtime_fn=_bind_conversation_runtime,
-        format_runtime_error_fn=_format_runtime_error,
+        persist_user_message_fn=lambda cid, content, run_id=None: conversation_support.persist_user_message(
+            cid, content, run_id=run_id
+        ),
+        persist_assistant_message_fn=conversation_support.persist_assistant_message,
+        maybe_generate_conversation_title_fn=lambda cid: conversation_support.maybe_generate_conversation_title(
+            cid, _generate_title_with_deerflow
+        ),
+        bind_conversation_runtime_fn=runtime_support.bind_conversation_runtime,
+        format_runtime_error_fn=runtime_support.format_runtime_error,
         resolve_runtime_options_fn=_resolve_runtime_options,
-        general_agent_status_labels_fn=_general_agent_status_labels,
-        translate_general_agent_event_fn=_translate_general_agent_event,
-        serialize_stream_event_fn=_serialize_stream_event,
-        db_to_message_fn=_db_to_message,
+        general_agent_status_labels_fn=_svc_general_agent_status_labels,
+        translate_general_agent_event_fn=_svc_translate_general_agent_event,
+        serialize_stream_event_fn=_svc_serialize_stream_event,
+        db_to_message_fn=conversation_support.db_to_message,
         execution_logger=logger,
     )
 
 
+def _stream_conversation_message(conversation_id: str, body: SendMessageRequest):
+    yield from _conversation_execution_service().stream_message(conversation_id, body)
+
+
+def _respond_to_clarification(conversation_id: str, tool_call_id: str, response: str) -> Message:
+    return _conversation_execution_service().respond_to_clarification(conversation_id, tool_call_id, response)
+
+
 def _list_conversations() -> ConversationListResponse:
     rows = conversation_repo.list_all()
-    items = [_db_to_conversation(row) for row in rows]
-    return ConversationListResponse(items=items, total=len(items))
+    return ConversationListResponse(
+        items=[conversation_support.db_to_conversation(r) for r in rows],
+        total=len(rows),
+    )
 
 
-def _create_conversation(body: CreateConversationRequest) -> Conversation:
-    title = body.title or NEW_CONVERSATION_TITLE
-    conv = conversation_repo.create(title, "pending")
-    return _db_to_conversation(conv)
+def _create_conversation(body) -> Conversation:
+    conv = conversation_repo.create(body.title or NEW_CONVERSATION_TITLE, "pending")
+    return conversation_support.db_to_conversation(conv)
 
 
 def _get_conversation(conversation_id: str, include_messages: bool = False) -> Conversation:
     conv = conversation_repo.get_by_id(conversation_id)
-    messages = None
+    conv_model = conversation_support.db_to_conversation(conv)
     if include_messages:
         rows = message_repo.list_by_conversation(conversation_id)
-        messages = [_db_to_message(row) for row in rows]
-    return _db_to_conversation(conv, messages=messages)
+        conv_model.messages = [conversation_support.db_to_message(m) for m in rows]
+    return conv_model
 
 
 def _get_recent_conversation() -> RecentConversationResponse | None:
@@ -488,17 +216,16 @@ def _get_recent_conversation() -> RecentConversationResponse | None:
     if conv is None:
         return None
     rows = message_repo.list_by_conversation(conv.id)
-    messages = [_db_to_message(row) for row in rows]
     return RecentConversationResponse(
-        conversation=_db_to_conversation(conv),
-        messages=messages,
+        conversation=conversation_support.db_to_conversation(conv),
+        messages=[conversation_support.db_to_message(m) for m in rows],
     )
 
 
 def _get_conversation_messages(conversation_id: str) -> MessageListResponse:
     conversation_repo.get_by_id(conversation_id)
     rows = message_repo.list_by_conversation(conversation_id)
-    items = [_db_to_message(row) for row in rows]
+    items = [conversation_support.db_to_message(m) for m in rows]
     return MessageListResponse(items=items, total=len(items))
 
 
@@ -517,37 +244,24 @@ def _delete_conversation(conversation_id: str) -> DeleteConversationResponse:
     )
 
 
-# ---- Collaboration Trace Endpoints ----
-
-
 def _get_conversation_trace(conversation_id: str) -> ConversationTraceResponse:
-    trace = conversation_trace_service.get_trace(conversation_id)
-    return ConversationTraceResponse(conversation_id=conversation_id, trace=trace)
-
-
-def _stream_conversation_message(conversation_id: str, body: SendMessageRequest):
-    """Stream a ChatSession turn with SwarmMind runtime semantics."""
-    yield from _conversation_execution_service().stream_message(conversation_id, body)
-
-
-def _respond_to_clarification(conversation_id: str, tool_call_id: str, response: str) -> Message:
-    return _conversation_execution_service().respond_to_clarification(
-        conversation_id,
-        tool_call_id,
-        response,
+    return ConversationTraceResponse(
+        conversation_id=conversation_id,
+        trace=conversation_trace_service.get_trace(conversation_id),
     )
 
 
 def _search_conversations(q: str, limit: int = 20) -> ConversationListResponse:
     rows = conversation_repo.search_by_query(q, limit=limit)
-    items = [_db_to_conversation(row) for row in rows]
-    return ConversationListResponse(items=items, total=len(items))
+    return ConversationListResponse(
+        items=[conversation_support.db_to_conversation(r) for r in rows],
+        total=len(rows),
+    )
 
 
 def _export_conversation(conversation_id: str, fmt: str = "markdown") -> object:
     import json as _json
     from datetime import datetime as _dt
-
     from fastapi.responses import Response as _Response
 
     conv = conversation_repo.get_by_id(conversation_id)
@@ -556,27 +270,19 @@ def _export_conversation(conversation_id: str, fmt: str = "markdown") -> object:
 
     if fmt == "json":
         data = {
-            "id": conv.id,
-            "title": conv.title,
+            "id": conv.id, "title": conv.title,
             "created_at": str(conv.created_at) if conv.created_at else "",
             "updated_at": str(conv.updated_at) if conv.updated_at else "",
             "messages": [
-                {
-                    "id": m.id,
-                    "role": m.role,
-                    "content": m.content,
-                    "created_at": str(m.created_at) if m.created_at else "",
-                }
+                {"id": m.id, "role": m.role, "content": m.content,
+                 "created_at": str(m.created_at) if m.created_at else ""}
                 for m in visible
             ],
         }
         content = _json.dumps(data, ensure_ascii=False, indent=2)
         filename = f"conversation-{conv.id[:8]}.json"
-        return _Response(
-            content=content,
-            media_type="application/json",
-            headers={"Content-Disposition": f'attachment; filename="{filename}"'},
-        )
+        return _Response(content=content, media_type="application/json",
+                         headers={"Content-Disposition": f'attachment; filename="{filename}"'})
 
     now = _dt.now().strftime("%Y-%m-%d %H:%M")
     lines: list[str] = [f"# {conv.title}", "", f"*导出时间: {now}*", "", "---", ""]
@@ -585,12 +291,11 @@ def _export_conversation(conversation_id: str, fmt: str = "markdown") -> object:
         lines.extend([f"{label}\n\n{msg.content}", ""])
     content = "\n".join(lines)
     filename = f"conversation-{conv.id[:8]}.md"
-    return _Response(
-        content=content,
-        media_type="text/markdown; charset=utf-8",
-        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
-    )
+    return _Response(content=content, media_type="text/markdown; charset=utf-8",
+                     headers={"Content-Disposition": f'attachment; filename="{filename}"'})
 
+
+# ---- Register conversation router ----
 
 conversation_router, conversation_handlers = build_conversation_router(
     deps=ConversationRouteDeps(
@@ -609,6 +314,7 @@ conversation_router, conversation_handlers = build_conversation_router(
     ),
 )
 
+# Backward-compat re-exports consumed by tests
 ClarificationResponseRequest = ConversationClarificationResponseRequest
 list_conversations = conversation_handlers.list_conversations
 create_conversation = conversation_handlers.create_conversation
@@ -618,959 +324,83 @@ get_conversation_messages = conversation_handlers.get_conversation_messages
 send_message = conversation_handlers.send_message
 delete_conversation = conversation_handlers.delete_conversation
 get_conversation_trace = conversation_handlers.get_conversation_trace
-_stream_conversation_message = conversation_handlers.stream_conversation_message
 send_message_stream = conversation_handlers.send_message_stream
 respond_to_clarification = conversation_handlers.respond_to_clarification
 search_conversations = conversation_handlers.search_conversations
 export_conversation = conversation_handlers.export_conversation
 
-# ---- Project endpoints ----
-
-
-def _db_to_project(proj) -> Project:
-    team_instance = project_team_repo.get_by_project(proj.project_id)
-    agent_team = _db_to_team_instance(team_instance) if team_instance else None
-    return Project(
-        project_id=proj.project_id,
-        title=proj.title,
-        goal=proj.goal,
-        scope=proj.scope,
-        constraints=proj.constraints,
-        source_conversation_id=proj.source_conversation_id,
-        conversation_id=proj.conversation_id,
-        next_step=proj.next_step,
-        phase=proj.phase,
-        risk_level=proj.risk_level,
-        status=proj.status,
-        created_at=proj.created_at.isoformat() if proj.created_at else "",
-        updated_at=proj.updated_at.isoformat() if proj.updated_at else "",
-        agent_team=agent_team,
-    )
-
-
-def _ensure_project_conversation(project_id: str) -> str:
-    """Ensure a project has a dedicated conversation for execution.
-
-    Creates one if absent and updates the project record.
-    Returns the conversation_id.
-    """
-    from swarmmind.db import session_scope
-    from swarmmind.db_models import ProjectDB
-
-    proj = project_repo.get_by_id(project_id)
-    if proj.conversation_id:
-        return proj.conversation_id
-    conv = conversation_repo.create(title=proj.title, title_status="pending")
-    with session_scope() as session:
-        proj_db = session.get(ProjectDB, project_id)
-        if proj_db is not None:
-            proj_db.conversation_id = conv.id
-            session.commit()
-    return conv.id
-
-
-def _db_to_team_instance(instance) -> ProjectAgentTeamInstance:
-    import json
-
-    template = agent_team_repo.get_by_id(instance.team_template_id)
-    return ProjectAgentTeamInstance(
-        instance_id=instance.instance_id,
-        project_id=instance.project_id,
-        team_template_id=instance.team_template_id,
-        team_name=template.name,
-        team_description=template.description,
-        roles=[TeamRole(**r) for r in json.loads(template.roles)] if template.roles else [],
-        instance_config=json.loads(instance.instance_config) if instance.instance_config else {},
-        status=instance.status,
-        created_at=instance.created_at.isoformat() if instance.created_at else "",
-        updated_at=instance.updated_at.isoformat() if instance.updated_at else "",
-    )
-
-
-def _db_to_team_template(team) -> AgentTeamTemplate:
-    import json
-
-    return AgentTeamTemplate(
-        team_id=team.team_id,
-        name=team.name,
-        description=team.description,
-        icon=team.icon,
-        roles=[TeamRole(**r) for r in json.loads(team.roles)] if team.roles else [],
-        default_skills=json.loads(team.default_skills) if team.default_skills else [],
-        runtime_profile_prefs=json.loads(team.runtime_profile_prefs) if team.runtime_profile_prefs else {},
-        is_builtin=bool(team.is_builtin),
-        is_enabled=bool(team.is_enabled),
-        created_at=team.created_at.isoformat() if team.created_at else "",
-        updated_at=team.updated_at.isoformat() if team.updated_at else "",
-    )
-
-
-def _attach_team_to_project(project_id: str, team_template_id: str | None) -> None:
-    """Attach a team template to a project if provided."""
-    if team_template_id:
-        try:
-            agent_team_repo.get_by_id(team_template_id)
-            project_team_repo.create(
-                project_id=project_id,
-                team_template_id=team_template_id,
-            )
-        except Exception as e:
-            logger.warning("Failed to attach team %s to project %s: %s", team_template_id, project_id, e)
-
-
-@app.get("/projects", tags=["projects"])
-def list_projects() -> ProjectListResponse:
-    """List all projects ordered by updated_at descending."""
-    rows = project_repo.list_all()
-    items = [_db_to_project(row) for row in rows]
-    return ProjectListResponse(items=items, total=len(items))
-
-
-@app.get("/projects/{project_id}", tags=["projects"], responses={404: {"description": "Project not found"}})
-def get_project(project_id: str) -> Project:
-    """Get a single project by ID."""
-    proj = project_repo.get_by_id(project_id)
-    return _db_to_project(proj)
-
-
-@app.post("/projects", tags=["projects"])
-def create_project(body: ProjectCreateRequest) -> Project:
-    """Create a new project manually."""
-    proj = project_repo.create(
-        title=body.title,
-        goal=body.goal,
-        scope=body.scope,
-        constraints=body.constraints,
-        source_conversation_id=body.source_conversation_id,
-        next_step=body.next_step,
-        phase=body.phase,
-        risk_level=body.risk_level,
-    )
-    _ensure_project_conversation(proj.project_id)
-    _attach_team_to_project(proj.project_id, body.team_template_id)
-    return _db_to_project(proj)
-
-
-@app.delete("/projects/{project_id}", tags=["projects"], responses={404: {"description": "Project not found"}})
-def delete_project(project_id: str) -> DeleteProjectResponse:
-    """Delete a project."""
-    project_repo.get_by_id(project_id)
-    project_repo.delete(project_id)
-    return DeleteProjectResponse(project_id=project_id)
-
-
-def _generate_project_seed_from_conversation(
-    conversation_id: str, override: PromoteConversationRequest | None = None
-) -> dict:
-    """Generate project seed fields from conversation messages.
-
-    Strategy:
-    1. Use explicit overrides from request body if provided.
-    2. Fallback to conversation title and message heuristics.
-    3. Future: integrate light LLM prompt for richer extraction.
-    """
-    conv = conversation_repo.get_by_id(conversation_id)
-    messages = message_repo.list_by_conversation(conversation_id)
-
-    user_msgs = [m for m in messages if m.role == "user"]
-    assistant_msgs = [m for m in messages if m.role == "assistant"]
-
-    # Title
-    title = override.title if override and override.title else conv.title
-    if title in ("New Conversation", NEW_CONVERSATION_TITLE) and user_msgs:
-        first_user = user_msgs[0].content.strip()
-        title = first_user[:50] if len(first_user) <= 50 else first_user[:47] + "..."
-
-    # Goal: concatenate first few user messages
-    goal = override.goal if override and override.goal else None
-    if goal is None and user_msgs:
-        parts = [m.content.strip() for m in user_msgs[:3]]
-        goal = "\n".join(parts)
-        if len(goal) > 2000:
-            goal = goal[:1997] + "..."
-
-    # Scope: default empty for minimal slice
-    scope = override.scope if override and override.scope else None
-
-    # Constraints: default empty
-    constraints = override.constraints if override and override.constraints else None
-
-    # Next step: derive from last assistant message if available
-    next_step = override.next_step if override and override.next_step else None
-    if next_step is None and assistant_msgs:
-        last = assistant_msgs[-1].content.strip()
-        # Take first sentence or first 100 chars as next-step hint
-        sentence_end = max(last.find("."), last.find("。"), last.find("\n"))
-        if sentence_end > 0:
-            next_step = last[: sentence_end + 1]
-        else:
-            next_step = last[:100] + "..." if len(last) > 100 else last
-
-    return {
-        "title": title or "Untitled Project",
-        "goal": goal,
-        "scope": scope,
-        "constraints": constraints,
-        "source_conversation_id": conversation_id,
-        "next_step": next_step,
-    }
-
-
-@app.post(
-    "/conversations/{conversation_id}/promote",
-    tags=["conversations"],
-    responses={404: {"description": "Conversation not found"}},
-)
-def promote_conversation(
-    conversation_id: str,
-    body: PromoteConversationRequest | None = None,
-) -> Project:
-    """Promote a ChatSession to a formal Project.
-
-    - Source conversation remains as provenance.
-    - Project receives structured seed, not a copied chat thread.
-    - Falls back to minimal skeleton if generation fails.
-    """
-    # Ensure conversation exists
-    conversation_repo.get_by_id(conversation_id)
-
-    # Generate seed
-    try:
-        seed = _generate_project_seed_from_conversation(conversation_id, override=body)
-    except Exception as e:
-        logger.error("Project seed generation failed for %s: %s", conversation_id, e)
-        # Minimal fallback skeleton
-        seed = {
-            "title": "Project from conversation",
-            "goal": None,
-            "scope": None,
-            "constraints": None,
-            "source_conversation_id": conversation_id,
-            "next_step": "Review the source conversation and define next steps.",
-        }
-
-    # Create project
-    proj = project_repo.create(**seed)
-
-    # Link conversation -> project
-    project_repo.link_conversation(proj.project_id, conversation_id)
-
-    # Create project execution conversation
-    _ensure_project_conversation(proj.project_id)
-
-    # Attach team if specified
-    team_template_id = body.team_template_id if body else None
-    _attach_team_to_project(proj.project_id, team_template_id)
-
-    logger.info(
-        "Conversation %s promoted to project %s (%s)",
-        conversation_id,
-        proj.project_id,
-        proj.title,
-    )
-    return _db_to_project(proj)
-
-
-# ---- Trace summary endpoint (F1) ----
-
-
-@app.get(
-    "/conversations/{conversation_id}/messages/{message_id}/trace",
-    tags=["conversations"],
-    responses={404: {"description": "Conversation or message not found"}},
-)
-def get_message_trace(conversation_id: str, message_id: str) -> TraceSummaryResponse:
-    """Return a readable trace summary for an assistant message.
-
-    Integrates parsed checkpoint data from the trace service.
-    Degrades to a minimal fallback when the trace store is empty or unreadable.
-    """
-    # Verify conversation exists
-    conversation_repo.get_by_id(conversation_id)
-    # Verify message exists and belongs to the conversation
-    msg = message_repo.get_by_id(message_id)
-    if msg.conversation_id != conversation_id:
-        raise HTTPException(status_code=404, detail="Message not found in this conversation")
-
-    # Real trace summary from checkpoint data
-    try:
-        return message_trace_service.get_summary(conversation_id, message_id)
-    except Exception as exc:
-        logger.warning("Trace summary failed for message %s: %s", message_id, exc)
-        # Degraded fallback based on message metadata
-        summary = "执行完成" if msg.run_id else "直接回复"
-        return TraceSummaryResponse(
-            steps_count=1 if msg.run_id else 0,
-            subagent_calls_count=0,
-            artifacts_count=0,
-            blocked_points=[],
-            summary=summary,
-        )
-
-
-# ---- Artifact endpoints ----
-
-
-def _db_to_artifact(art) -> Artifact:
-    return Artifact(
-        artifact_id=art.artifact_id,
-        conversation_id=art.conversation_id,
-        project_id=art.project_id,
-        message_id=art.message_id,
-        run_id=art.run_id,
-        task_id=art.task_id,
-        author_role=art.author_role,
-        name=art.name,
-        path=art.path or (normalize_virtual_path(art.name) if is_virtual_user_data_path(art.name) else None),
-        storage_uri=art.storage_uri,
-        mime_type=art.mime_type,
-        size_bytes=art.size_bytes,
-        artifact_type=art.artifact_type,
-        created_at=art.created_at.isoformat() if art.created_at else "",
-    )
-
-
-@app.get(
-    "/conversations/{conversation_id}/artifacts",
-    tags=["conversations"],
-    responses={404: {"description": "Conversation not found"}},
-)
-def list_conversation_artifacts(conversation_id: str) -> ArtifactListResponse:
-    """List artifacts for a conversation."""
-    conversation_repo.get_by_id(conversation_id)
-    rows = artifact_repo.list_by_conversation(conversation_id)
-    return ArtifactListResponse(items=[_db_to_artifact(r) for r in rows], total=len(rows))
-
-
-@app.get(
-    "/conversations/{conversation_id}/artifacts/{artifact_path:path}",
-    tags=["conversations"],
-    responses={
-        400: {"description": "Invalid artifact path"},
-        403: {"description": "Artifact path escapes the conversation sandbox"},
-        404: {"description": "Conversation or artifact not found"},
-    },
-)
-def get_conversation_artifact_file(conversation_id: str, artifact_path: str, download: bool = False) -> Response:
-    """Return the registered artifact file content for a conversation."""
-    conversation = conversation_repo.get_by_id(conversation_id)
-    artifact = artifact_repo.get_by_conversation_path(conversation_id, artifact_path)
-    virtual_path = artifact.path or artifact.name or artifact_path
-    thread_id = conversation.thread_id or runtime_support.conversation_thread_id(conversation_id)
-    actual_path = resolve_virtual_artifact_path(thread_id, virtual_path)
-    return build_artifact_file_response(actual_path, download=download)
-
-
-@app.post(
-    "/conversations/{conversation_id}/extract-artifacts",
-    tags=["conversations"],
-    responses={404: {"description": "Conversation not found"}},
-)
-def extract_conversation_artifacts(conversation_id: str) -> ExtractArtifactsResponse:
-    """Extract artifacts from conversation trace and persist them.
-
-    Idempotent: skips artifacts that already exist by name.
-    """
-    conv = conversation_repo.get_by_id(conversation_id)
-    project_id = conv.promoted_project_id if conv else None
-    created = message_trace_service.extract_artifacts(conversation_id, project_id=project_id)
-    return ExtractArtifactsResponse(conversation_id=conversation_id, extracted=len(created), artifacts=created)
-
-
-@app.get("/projects/{project_id}/artifacts", tags=["projects"], responses={404: {"description": "Project not found"}})
-def list_project_artifacts(project_id: str) -> ArtifactListResponse:
-    """List artifacts for a project."""
-    project_repo.get_by_id(project_id)
-    rows = artifact_repo.list_by_project(project_id)
-    return ArtifactListResponse(items=[_db_to_artifact(r) for r in rows], total=len(rows))
-
-
-@app.patch("/projects/{project_id}", tags=["projects"], responses={404: {"description": "Project not found"}})
-def update_project(project_id: str, body: ProjectUpdateRequest) -> Project:
-    """Update a project. Only provided fields are changed."""
-    fields: dict[str, object] = {}
-    if body.title is not None:
-        fields["title"] = body.title
-    if body.goal is not None:
-        fields["goal"] = body.goal
-    if body.scope is not None:
-        fields["scope"] = body.scope
-    if body.constraints is not None:
-        fields["constraints"] = body.constraints
-    if body.next_step is not None:
-        fields["next_step"] = body.next_step
-    if body.phase is not None:
-        fields["phase"] = body.phase
-    if body.risk_level is not None:
-        fields["risk_level"] = body.risk_level
-    if body.status is not None:
-        fields["status"] = body.status.value
-
-    if not fields:
-        # No-op: just return current project
-        return _db_to_project(project_repo.get_by_id(project_id))
-
-    project_repo.update(project_id, **fields)
-    return _db_to_project(project_repo.get_by_id(project_id))
-
-
-@app.get("/projects/{project_id}/overview", tags=["projects"], responses={404: {"description": "Project not found"}})
-def get_project_overview(project_id: str) -> ProjectOverviewResponse:
-    """Get aggregated project overview with stats and recent items."""
-    proj = project_repo.get_by_id(project_id)
-
-    tasks = task_repo.list_by_project(project_id)
-    artifacts = artifact_repo.list_by_project(project_id)
-    runs = run_repo.list_by_project(project_id)
-    approvals = approval_request_repo.list_by_project(project_id)
-
-    blocked_count = sum(1 for t in tasks if t.status == "blocked")
-    pending_approval_count = sum(1 for a in approvals if a.status == "pending")
-
-    stats = {
-        "blocked_count": blocked_count,
-        "pending_approval_count": pending_approval_count,
-        "task_count": len(tasks),
-        "artifact_count": len(artifacts),
-        "run_count": len(runs),
-    }
-
-    recent_limit = 5
-    recent_tasks = [_db_to_task(t) for t in tasks[:recent_limit]]
-    recent_artifacts = [_db_to_artifact(a) for a in artifacts[:recent_limit]]
-    recent_runs = [_db_to_run(r) for r in runs[:recent_limit]]
-    recent_approvals = [_db_to_approval_request(a) for a in approvals[:recent_limit]]
-
-    return ProjectOverviewResponse(
-        project=_db_to_project(proj),
-        stats=stats,
-        recent_tasks=recent_tasks,
-        recent_artifacts=recent_artifacts,
-        recent_runs=recent_runs,
-        recent_approvals=recent_approvals,
-    )
-
-
-# ---- Run endpoints ----
-
-
-def _db_to_run(run) -> Run:
-    return Run(
-        run_id=run.run_id,
-        project_id=run.project_id,
-        conversation_id=run.conversation_id,
-        status=run.status,
-        goal=run.goal,
-        summary=run.summary,
-        started_at=run.started_at.isoformat() if run.started_at else "",
-        completed_at=run.completed_at.isoformat() if run.completed_at else None,
-    )
-
-
-@app.get("/projects/{project_id}/runs", tags=["runs"], responses={404: {"description": "Project not found"}})
-def list_project_runs(project_id: str) -> RunListResponse:
-    """List runs for a project."""
-    project_repo.get_by_id(project_id)
-    rows = run_repo.list_by_project(project_id)
-    return RunListResponse(items=[_db_to_run(r) for r in rows], total=len(rows))
-
-
-@app.get(
-    "/conversations/{conversation_id}/runs", tags=["runs"], responses={404: {"description": "Conversation not found"}}
-)
-def list_conversation_runs(conversation_id: str) -> RunListResponse:
-    """List runs for a conversation."""
-    conversation_repo.get_by_id(conversation_id)
-    rows = run_repo.list_by_conversation(conversation_id)
-    return RunListResponse(items=[_db_to_run(r) for r in rows], total=len(rows))
-
-
-@app.get("/runs/{run_id}", tags=["runs"], responses={404: {"description": "Run not found"}})
-def get_run(run_id: str) -> Run:
-    """Get a single run by ID."""
-    run = run_repo.get_by_id(run_id)
-    return _db_to_run(run)
-
-
-@app.post("/runs", tags=["runs"])
-def create_run(body: CreateRunRequest) -> Run:
-    """Create a run record.
-
-    Links to a conversation and/or a project.
-    At least one of conversation_id or project_id must be provided.
-    """
-    if body.conversation_id:
-        conversation_repo.get_by_id(body.conversation_id)
-    if body.project_id:
-        project_repo.get_by_id(body.project_id)
-    run = run_repo.create(
-        conversation_id=body.conversation_id,
-        project_id=body.project_id,
-        goal=body.goal,
-        status=body.status.value,
-    )
-    return _db_to_run(run)
-
-
-@app.patch("/runs/{run_id}", tags=["runs"], responses={404: {"description": "Run not found"}})
-def update_run(run_id: str, body: UpdateRunRequest) -> Run:
-    """Update a run. Only provided fields are changed."""
-    run = run_repo.update(
-        run_id,
-        project_id=body.project_id,
-        status=body.status.value if body.status else None,
-        goal=body.goal,
-        summary=body.summary,
-    )
-    return _db_to_run(run)
-
-
-# ---- Task endpoints ----
-
-
-def _db_to_task(task) -> Task:
-    return Task(
-        task_id=task.task_id,
-        project_id=task.project_id,
-        run_id=task.run_id,
-        title=task.title,
-        description=task.description,
-        status=task.status,
-        assignee_role=task.assignee_role,
-        source_workstream=task.source_workstream,
-        artifact_ids=task.artifact_ids or [],
-        priority=task.priority,
-        created_at=task.created_at.isoformat() if task.created_at else "",
-        updated_at=task.updated_at.isoformat() if task.updated_at else "",
-    )
-
-
-@app.get("/projects/{project_id}/tasks", tags=["projects"], responses={404: {"description": "Project not found"}})
-def list_project_tasks(project_id: str) -> TaskListResponse:
-    """List tasks for a project."""
-    project_repo.get_by_id(project_id)
-    rows = task_repo.list_by_project(project_id)
-    return TaskListResponse(items=[_db_to_task(r) for r in rows], total=len(rows))
-
-
-@app.post("/projects/{project_id}/tasks", tags=["projects"], responses={404: {"description": "Project not found"}})
-def create_task(project_id: str, body: CreateTaskRequest) -> Task:
-    """Create a new task for a project."""
-    project_repo.get_by_id(project_id)
-    task = task_repo.create(
-        project_id=project_id,
-        title=body.title,
-        description=body.description,
-        status=body.status.value,
-        assignee_role=body.assignee_role,
-        source_workstream=body.source_workstream,
-        artifact_ids=body.artifact_ids,
-        priority=body.priority.value,
-    )
-    return _db_to_task(task)
-
-
-@app.get(
-    "/projects/{project_id}/tasks/{task_id}",
-    tags=["projects"],
-    responses={404: {"description": "Project or task not found"}},
-)
-def get_task(project_id: str, task_id: str) -> Task:
-    """Get a single task by ID."""
-    project_repo.get_by_id(project_id)
-    task = task_repo.get_by_id(task_id)
-    if task.project_id != project_id:
-        raise HTTPException(status_code=404, detail="Task not found in this project")
-    return _db_to_task(task)
-
-
-@app.patch(
-    "/projects/{project_id}/tasks/{task_id}",
-    tags=["projects"],
-    responses={404: {"description": "Project or task not found"}},
-)
-def update_task(project_id: str, task_id: str, body: UpdateTaskRequest) -> Task:
-    """Update a task. Only provided fields are changed."""
-    project_repo.get_by_id(project_id)
-    task = task_repo.get_by_id(task_id)
-    if task.project_id != project_id:
-        raise HTTPException(status_code=404, detail="Task not found in this project")
-
-    fields: dict[str, object] = {}
-    if body.title is not None:
-        fields["title"] = body.title
-    if body.description is not None:
-        fields["description"] = body.description
-    if body.status is not None:
-        fields["status"] = body.status.value
-    if body.assignee_role is not None:
-        fields["assignee_role"] = body.assignee_role
-    if body.source_workstream is not None:
-        fields["source_workstream"] = body.source_workstream
-    if body.artifact_ids is not None:
-        fields["artifact_ids"] = body.artifact_ids
-    if body.priority is not None:
-        fields["priority"] = body.priority.value
-
-    if not fields:
-        return _db_to_task(task)
-
-    updated = task_repo.update(task_id, **fields)
-    return _db_to_task(updated)
-
-
-@app.delete(
-    "/projects/{project_id}/tasks/{task_id}",
-    tags=["projects"],
-    responses={404: {"description": "Project or task not found"}},
-)
-def delete_task(project_id: str, task_id: str) -> DeleteTaskResponse:
-    """Delete a task."""
-    project_repo.get_by_id(project_id)
-    task = task_repo.get_by_id(task_id)
-    if task.project_id != project_id:
-        raise HTTPException(status_code=404, detail="Task not found in this project")
-    task_repo.delete(task_id)
-    return DeleteTaskResponse(task_id=task_id)
-
-
-# ---- Approval Request endpoints ----
-
-
-def _db_to_approval_request(ar) -> ApprovalRequest:
-    return ApprovalRequest(
-        approval_id=ar.approval_id,
-        project_id=ar.project_id,
-        run_id=ar.run_id,
-        action_proposal_id=ar.action_proposal_id,
-        title=ar.title,
-        description=ar.description,
-        risk_tier=RiskTier(ar.risk_tier),
-        requested_capability=ar.requested_capability,
-        evidence=ar.evidence,
-        impact=ar.impact,
-        approver_role=ar.approver_role,
-        recovery_behavior=ar.recovery_behavior,
-        status=ApprovalStatus(ar.status),
-        decision_reason=ar.decision_reason,
-        created_at=ar.created_at.isoformat() if ar.created_at else "",
-        updated_at=ar.updated_at.isoformat() if ar.updated_at else "",
-    )
-
-
-@app.get("/approvals", tags=["approvals"])
-def list_approvals(
-    project_id: str | None = Query(None),
-    status: str | None = Query(None),
-    risk_tier: str | None = Query(None),
-) -> ApprovalRequestListResponse:
-    """List approval requests with optional filters."""
-    rows = approval_request_repo.list_by_filters(
-        project_id=project_id,
-        status=status,
-        risk_tier=risk_tier,
-    )
-    return ApprovalRequestListResponse(
-        items=[_db_to_approval_request(r) for r in rows],
-        total=len(rows),
-    )
-
-
-@app.post("/approvals", tags=["approvals"], responses={404: {"description": "Project not found"}})
-def create_approval(body: CreateApprovalRequest) -> ApprovalRequest:
-    """Create a new approval request."""
-    project_repo.get_by_id(body.project_id)
-    if body.run_id:
-        run_repo.get_by_id(body.run_id)
-    ar = approval_request_repo.create(
-        project_id=body.project_id,
-        run_id=body.run_id,
-        title=body.title,
-        description=body.description,
-        risk_tier=body.risk_tier.value,
-        requested_capability=body.requested_capability,
-        evidence=body.evidence,
-        impact=body.impact,
-        approver_role=body.approver_role,
-        recovery_behavior=body.recovery_behavior,
-    )
-    return _db_to_approval_request(ar)
-
-
-@app.get("/approvals/{approval_id}", tags=["approvals"], responses={404: {"description": "Approval request not found"}})
-def get_approval(approval_id: str) -> ApprovalRequest:
-    """Get a single approval request by ID."""
-    ar = approval_request_repo.get(approval_id)
-    return _db_to_approval_request(ar)
-
-
-@app.patch(
-    "/approvals/{approval_id}",
-    tags=["approvals"],
-    responses={404: {"description": "Approval request not found"}, 409: {"description": "Invalid status transition"}},
-)
-def update_approval(approval_id: str, body: UpdateApprovalRequest) -> ApprovalRequest:
-    """Update an approval request. Only provided fields are changed."""
-    ar = approval_request_repo.get(approval_id)
-
-    fields: dict[str, object] = {}
-    if body.status is not None:
-        if body.status in (ApprovalStatus.APPROVED, ApprovalStatus.REJECTED):
-            if ar.status != ApprovalStatus.PENDING.value:
-                raise HTTPException(
-                    status_code=409,
-                    detail=f"Only pending requests can be approved or rejected. Current status: {ar.status}",
-                )
-        fields["status"] = body.status.value
-    if body.decision_reason is not None:
-        fields["decision_reason"] = body.decision_reason
-    if body.title is not None:
-        fields["title"] = body.title
-    if body.description is not None:
-        fields["description"] = body.description
-    if body.risk_tier is not None:
-        fields["risk_tier"] = body.risk_tier.value
-
-    if not fields:
-        return _db_to_approval_request(ar)
-
-    updated = approval_request_repo.update(approval_id, **fields)
-    return _db_to_approval_request(updated)
-
-
-@app.delete(
-    "/approvals/{approval_id}", tags=["approvals"], responses={404: {"description": "Approval request not found"}}
-)
-def delete_approval(approval_id: str) -> DeleteApprovalResponse:
-    """Delete an approval request."""
-    approval_request_repo.get(approval_id)
-    approval_request_repo.delete(approval_id)
-    return DeleteApprovalResponse(approval_id=approval_id)
-
-
-# ---- Audit Log endpoints ----
-
-
-def _db_to_audit_log_entry(entry) -> AuditLogEntry:
-    return AuditLogEntry(
-        audit_id=entry.audit_id,
-        audit_type=entry.audit_type,
-        project_id=entry.project_id,
-        run_id=entry.run_id,
-        approval_id=entry.approval_id,
-        actor_id=entry.actor_id,
-        actor_type=entry.actor_type,
-        decision=entry.decision,
-        reason=entry.reason,
-        metadata=entry.extra_data or {},
-        timestamp=entry.timestamp.isoformat() if entry.timestamp else "",
-    )
-
-
-@app.get("/audit-logs", tags=["audit-logs"])
-def list_audit_logs(
-    project_id: str | None = Query(None),
-    run_id: str | None = Query(None),
-    approval_id: str | None = Query(None),
-) -> AuditLogListResponse:
-    """List audit log entries with optional filters."""
-    rows = audit_log_repo.list_by_filters(
-        project_id=project_id,
-        run_id=run_id,
-        approval_id=approval_id,
-    )
-    return AuditLogListResponse(
-        items=[_db_to_audit_log_entry(r) for r in rows],
-        total=len(rows),
-    )
-
-
-@app.post("/audit-logs", tags=["audit-logs"], responses={404: {"description": "Project not found"}})
-def create_audit_log(body: CreateAuditLogEntry) -> AuditLogEntry:
-    """Create a new audit log entry."""
-    project_repo.get_by_id(body.project_id)
-    if body.run_id:
-        run_repo.get_by_id(body.run_id)
-    if body.approval_id:
-        approval_request_repo.get(body.approval_id)
-    entry = audit_log_repo.create(
-        audit_type=body.audit_type,
-        project_id=body.project_id,
-        run_id=body.run_id,
-        approval_id=body.approval_id,
-        actor_id=body.actor_id,
-        actor_type=body.actor_type,
-        decision=body.decision,
-        reason=body.reason,
-        extra_data=body.metadata,
-    )
-    return _db_to_audit_log_entry(entry)
-
-
-@app.get("/audit-logs/{audit_id}", tags=["audit-logs"], responses={404: {"description": "Audit log entry not found"}})
-def get_audit_log(audit_id: str) -> AuditLogEntry:
-    """Get a single audit log entry by ID."""
-    entry = audit_log_repo.get(audit_id)
-    return _db_to_audit_log_entry(entry)
-
-
-@app.delete(
-    "/audit-logs/{audit_id}", tags=["audit-logs"], responses={404: {"description": "Audit log entry not found"}}
-)
-def delete_audit_log(audit_id: str) -> DeleteAuditLogResponse:
-    """Delete an audit log entry."""
-    audit_log_repo.get(audit_id)
-    audit_log_repo.delete(audit_id)
-    return DeleteAuditLogResponse(audit_id=audit_id)
-
-
-@app.get("/projects/{project_id}/audit", tags=["projects"], responses={404: {"description": "Project not found"}})
-def list_project_audit_logs(project_id: str) -> AuditLogListResponse:
-    """List audit log entries for a specific project."""
-    project_repo.get_by_id(project_id)
-    rows = audit_log_repo.list_by_project(project_id)
-    return AuditLogListResponse(
-        items=[_db_to_audit_log_entry(r) for r in rows],
-        total=len(rows),
-    )
-
-
-# ---- Agent Team endpoints ----
-
-
-@app.get("/agent-teams", tags=["agent-teams"])
-def list_agent_teams() -> AgentTeamTemplateListResponse:
-    """List all enabled agent team templates."""
-    rows = agent_team_repo.list_all(include_disabled=False)
-    items = [_db_to_team_template(row) for row in rows]
-    return AgentTeamTemplateListResponse(items=items, total=len(items))
-
-
-@app.get("/agent-teams/{team_id}", tags=["agent-teams"], responses={404: {"description": "Team template not found"}})
-def get_agent_team(team_id: str) -> AgentTeamTemplate:
-    """Get a single agent team template by ID."""
-    team = agent_team_repo.get_by_id(team_id)
-    return _db_to_team_template(team)
-
-
-@app.post("/agent-teams", tags=["agent-teams"], status_code=201)
-def create_agent_team(body: AgentTeamTemplateCreateRequest) -> AgentTeamTemplate:
-    """Create a new custom agent team template."""
-    team = agent_team_repo.create(
-        name=body.name,
-        description=body.description,
-        icon=body.icon,
-        roles=[r.model_dump() for r in body.roles],
-        default_skills=body.default_skills,
-        runtime_profile_prefs=body.runtime_profile_prefs,
-        is_builtin=False,
-    )
-    return _db_to_team_template(team)
-
-
-@app.patch("/agent-teams/{team_id}", tags=["agent-teams"], responses={404: {"description": "Team template not found"}})
-def update_agent_team(team_id: str, body: AgentTeamTemplateUpdateRequest) -> AgentTeamTemplate:
-    """Update an agent team template."""
-    roles = [r.model_dump() for r in body.roles] if body.roles is not None else None
-    team = agent_team_repo.update(
-        team_id=team_id,
-        name=body.name,
-        description=body.description,
-        icon=body.icon,
-        roles=roles,
-        default_skills=body.default_skills,
-        runtime_profile_prefs=body.runtime_profile_prefs,
-        is_enabled=body.is_enabled,
-    )
-    return _db_to_team_template(team)
-
-
-@app.delete("/agent-teams/{team_id}", tags=["agent-teams"], status_code=204)
-def delete_agent_team(team_id: str) -> None:
-    """Disable an agent team template."""
-    agent_team_repo.delete(team_id)
-
-
-# ---- Project Agent Team Instance endpoints ----
-
-
-@app.post(
-    "/projects/{project_id}/agent-team",
-    tags=["projects"],
-    status_code=201,
-    responses={
-        404: {"description": "Project or team template not found"},
-        409: {"description": "Project already has a team attached"},
-    },
-)
-def attach_team_to_project(project_id: str, body: AttachTeamRequest) -> ProjectAgentTeamInstance:
-    """Attach an agent team template to a project."""
-    project_repo.get_by_id(project_id)
-    instance = project_team_repo.create(
-        project_id=project_id,
-        team_template_id=body.team_template_id,
-        instance_config=body.instance_config,
-    )
-    return _db_to_team_instance(instance)
-
-
-@app.get("/projects/{project_id}/agent-team", tags=["projects"], responses={404: {"description": "Project not found"}})
-def get_project_team(project_id: str) -> ProjectAgentTeamInstance:
-    """Get the agent team instance attached to a project."""
-    project_repo.get_by_id(project_id)
-    instance = project_team_repo.get_by_project(project_id)
-    if instance is None:
-        raise HTTPException(status_code=404, detail="Project does not have an agent team attached")
-    return _db_to_team_instance(instance)
-
-
-@app.patch(
-    "/projects/{project_id}/agent-team",
-    tags=["projects"],
-    responses={404: {"description": "Project or team instance not found"}},
-)
-def update_project_team(project_id: str, body: UpdateTeamInstanceRequest) -> ProjectAgentTeamInstance:
-    """Update the agent team instance for a project."""
-    instance = project_team_repo.update(
-        project_id=project_id,
-        instance_config=body.instance_config,
-        status=body.status,
-    )
-    return _db_to_team_instance(instance)
-
-
-@app.delete("/projects/{project_id}/agent-team", tags=["projects"], status_code=204)
-def detach_team_from_project(project_id: str) -> None:
-    """Detach the agent team from a project."""
-    project_repo.get_by_id(project_id)
-    project_team_repo.delete(project_id)
-
-
-@app.post(
-    "/projects/{project_id}/messages/stream", tags=["projects"], responses={404: {"description": "Project not found"}}
-)
-def send_project_message_stream(project_id: str, body: SendMessageRequest) -> StreamingResponse:
-    """Stream a project execution turn with SwarmMind runtime semantics.
-
-    Uses the project's dedicated conversation as the execution surface.
-    """
-    project_repo.get_by_id(project_id)
-    conversation_id = _ensure_project_conversation(project_id)
-    return StreamingResponse(
-        _stream_conversation_message(conversation_id, body),
-        media_type="application/x-ndjson",
-    )
-
+# ---- Include all routers ----
 
 app.include_router(conversation_router)
 
-# ---- LLM Gateway & Provider routes ----
-from swarmmind.api.llm_gateway_routes import router as gateway_router
-from swarmmind.api.llm_provider_routes import router as provider_router
+app.include_router(build_system_router(SystemRouterDeps(
+    ensure_default_runtime_instance=ensure_default_runtime_instance,
+    render_status=render_status,
+)))
 
-app.include_router(gateway_router)
-app.include_router(provider_router)
+app.include_router(build_legacy_supervisor_router(LegacySupervisorRouterDeps(
+    action_proposal_repo=action_proposal_repo,
+    strategy_repo=strategy_repo,
+    record_supervisor_decision=record_supervisor_decision,
+    dispatch=dispatch,
+)))
 
+app.include_router(build_runtime_models_router())
+
+app.include_router(build_projects_router(ProjectsRouterDeps(
+    project_repo=project_repo,
+    task_repo=task_repo,
+    run_repo=run_repo,
+    artifact_repo=artifact_repo,
+    approval_request_repo=approval_request_repo,
+    audit_log_repo=audit_log_repo,
+    agent_team_repo=agent_team_repo,
+    project_team_repo=project_team_repo,
+    conversation_repo=conversation_repo,
+    stream_conversation_message=_stream_conversation_message,
+)))
+
+app.include_router(build_runs_router(RunsRouterDeps(
+    run_repo=run_repo,
+    project_repo=project_repo,
+    conversation_repo=conversation_repo,
+)))
+
+app.include_router(build_approvals_router(ApprovalsRouterDeps(
+    approval_request_repo=approval_request_repo,
+    project_repo=project_repo,
+    run_repo=run_repo,
+)))
+
+app.include_router(build_audit_logs_router(AuditLogsRouterDeps(
+    audit_log_repo=audit_log_repo,
+    project_repo=project_repo,
+    run_repo=run_repo,
+    approval_request_repo=approval_request_repo,
+)))
+
+app.include_router(build_agent_teams_router(AgentTeamsRouterDeps(
+    agent_team_repo=agent_team_repo,
+)))
+
+app.include_router(build_promotions_router(PromotionsRouterDeps(
+    conversation_repo=conversation_repo,
+    message_repo=message_repo,
+    project_repo=project_repo,
+    project_team_repo=project_team_repo,
+    agent_team_repo=agent_team_repo,
+    artifact_repo=artifact_repo,
+    message_trace_service_fn=lambda: message_trace_service,
+    runtime_support=runtime_support,
+)))
+
+# ---- LLM gateway & provider routes ----
+
+from swarmmind.api.llm_gateway_routes import router as _gateway_router  # noqa: E402
+from swarmmind.api.llm_provider_routes import router as _provider_router  # noqa: E402
+
+app.include_router(_gateway_router)
+app.include_router(_provider_router)
 
 # ---- Run ----
 

--- a/swarmmind/api/supervisor.py
+++ b/swarmmind/api/supervisor.py
@@ -6,6 +6,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from swarmmind.agents.general_agent import DeerFlowRuntimeAdapter
 from swarmmind.api.conversation_routes import (
     ClarificationResponseRequest as ConversationClarificationResponseRequest,
 )
@@ -16,9 +17,11 @@ from swarmmind.api.routers.audit_logs import AuditLogsRouterDeps, build_audit_lo
 from swarmmind.api.routers.legacy_supervisor import LegacySupervisorRouterDeps, build_legacy_supervisor_router
 from swarmmind.api.routers.projects import ProjectsRouterDeps, build_projects_router
 from swarmmind.api.routers.promotions import PromotionsRouterDeps, build_promotions_router
-from swarmmind.api.routers.runtime_models import build_runtime_models_router
-from swarmmind.api.routers.runtime_models import list_runtime_models  # noqa: F401  (re-export for tests)
 from swarmmind.api.routers.runs import RunsRouterDeps, build_runs_router
+from swarmmind.api.routers.runtime_models import (
+    build_runtime_models_router,
+    list_runtime_models,  # noqa: F401  (re-export for tests)
+)
 from swarmmind.api.routers.system import SystemRouterDeps, build_system_router
 from swarmmind.config import ACTION_TIMEOUT_SECONDS, API_HOST, API_PORT
 from swarmmind.context_broker import derive_situation_tag, dispatch, record_supervisor_decision
@@ -49,7 +52,6 @@ from swarmmind.repositories.project_team import ProjectTeamInstanceRepository
 from swarmmind.repositories.run import RunRepository
 from swarmmind.repositories.strategy import StrategyRepository
 from swarmmind.repositories.task import TaskRepository
-from swarmmind.agents.general_agent import DeerFlowRuntimeAdapter
 from swarmmind.runtime import ensure_default_runtime_instance
 from swarmmind.runtime.catalog import sync_env_runtime_model
 from swarmmind.services.conversation_execution import ConversationExecutionService
@@ -63,7 +65,11 @@ from swarmmind.services.message_trace_service import _default_message_trace_serv
 from swarmmind.services.runtime_support import RuntimeSupportService
 from swarmmind.services.stream_events import (
     general_agent_status_labels as _svc_general_agent_status_labels,
+)
+from swarmmind.services.stream_events import (
     serialize_stream_event as _svc_serialize_stream_event,
+)
+from swarmmind.services.stream_events import (
     translate_general_agent_event as _svc_translate_general_agent_event,
 )
 
@@ -103,6 +109,7 @@ def _generate_title_with_deerflow(user_msg: str, assistant_msg: str) -> tuple[st
 
 # ---- Cleanup scanner ----
 
+
 def _cleanup_scanner():
     run_cleanup_scanner(
         action_proposal_repo=action_proposal_repo,
@@ -115,6 +122,7 @@ def _cleanup_scanner():
 
 
 # ---- FastAPI app ----
+
 
 @asynccontextmanager
 async def lifespan(_app: FastAPI):
@@ -148,6 +156,7 @@ app.add_middleware(
 )
 
 # ---- Conversation handler helpers ----
+
 
 def _resolve_runtime_options(body: SendMessageRequest) -> ConversationRuntimeOptions:
     return runtime_support.resolve_runtime_options(body)
@@ -262,6 +271,7 @@ def _search_conversations(q: str, limit: int = 20) -> ConversationListResponse:
 def _export_conversation(conversation_id: str, fmt: str = "markdown") -> object:
     import json as _json
     from datetime import datetime as _dt
+
     from fastapi.responses import Response as _Response
 
     conv = conversation_repo.get_by_id(conversation_id)
@@ -270,19 +280,27 @@ def _export_conversation(conversation_id: str, fmt: str = "markdown") -> object:
 
     if fmt == "json":
         data = {
-            "id": conv.id, "title": conv.title,
+            "id": conv.id,
+            "title": conv.title,
             "created_at": str(conv.created_at) if conv.created_at else "",
             "updated_at": str(conv.updated_at) if conv.updated_at else "",
             "messages": [
-                {"id": m.id, "role": m.role, "content": m.content,
-                 "created_at": str(m.created_at) if m.created_at else ""}
+                {
+                    "id": m.id,
+                    "role": m.role,
+                    "content": m.content,
+                    "created_at": str(m.created_at) if m.created_at else "",
+                }
                 for m in visible
             ],
         }
         content = _json.dumps(data, ensure_ascii=False, indent=2)
         filename = f"conversation-{conv.id[:8]}.json"
-        return _Response(content=content, media_type="application/json",
-                         headers={"Content-Disposition": f'attachment; filename="{filename}"'})
+        return _Response(
+            content=content,
+            media_type="application/json",
+            headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+        )
 
     now = _dt.now().strftime("%Y-%m-%d %H:%M")
     lines: list[str] = [f"# {conv.title}", "", f"*导出时间: {now}*", "", "---", ""]
@@ -291,8 +309,11 @@ def _export_conversation(conversation_id: str, fmt: str = "markdown") -> object:
         lines.extend([f"{label}\n\n{msg.content}", ""])
     content = "\n".join(lines)
     filename = f"conversation-{conv.id[:8]}.md"
-    return _Response(content=content, media_type="text/markdown; charset=utf-8",
-                     headers={"Content-Disposition": f'attachment; filename="{filename}"'})
+    return _Response(
+        content=content,
+        media_type="text/markdown; charset=utf-8",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
 
 
 # ---- Register conversation router ----
@@ -333,71 +354,103 @@ export_conversation = conversation_handlers.export_conversation
 
 app.include_router(conversation_router)
 
-app.include_router(build_system_router(SystemRouterDeps(
-    ensure_default_runtime_instance=ensure_default_runtime_instance,
-    render_status=render_status,
-)))
+app.include_router(
+    build_system_router(
+        SystemRouterDeps(
+            ensure_default_runtime_instance=ensure_default_runtime_instance,
+            render_status=render_status,
+        )
+    )
+)
 
-app.include_router(build_legacy_supervisor_router(LegacySupervisorRouterDeps(
-    action_proposal_repo=action_proposal_repo,
-    strategy_repo=strategy_repo,
-    record_supervisor_decision=record_supervisor_decision,
-    dispatch=dispatch,
-)))
+app.include_router(
+    build_legacy_supervisor_router(
+        LegacySupervisorRouterDeps(
+            action_proposal_repo=action_proposal_repo,
+            strategy_repo=strategy_repo,
+            record_supervisor_decision=record_supervisor_decision,
+            dispatch=dispatch,
+        )
+    )
+)
 
 app.include_router(build_runtime_models_router())
 
-app.include_router(build_projects_router(ProjectsRouterDeps(
-    project_repo=project_repo,
-    task_repo=task_repo,
-    run_repo=run_repo,
-    artifact_repo=artifact_repo,
-    approval_request_repo=approval_request_repo,
-    audit_log_repo=audit_log_repo,
-    agent_team_repo=agent_team_repo,
-    project_team_repo=project_team_repo,
-    conversation_repo=conversation_repo,
-    stream_conversation_message=_stream_conversation_message,
-)))
+app.include_router(
+    build_projects_router(
+        ProjectsRouterDeps(
+            project_repo=project_repo,
+            task_repo=task_repo,
+            run_repo=run_repo,
+            artifact_repo=artifact_repo,
+            approval_request_repo=approval_request_repo,
+            audit_log_repo=audit_log_repo,
+            agent_team_repo=agent_team_repo,
+            project_team_repo=project_team_repo,
+            conversation_repo=conversation_repo,
+            stream_conversation_message=_stream_conversation_message,
+        )
+    )
+)
 
-app.include_router(build_runs_router(RunsRouterDeps(
-    run_repo=run_repo,
-    project_repo=project_repo,
-    conversation_repo=conversation_repo,
-)))
+app.include_router(
+    build_runs_router(
+        RunsRouterDeps(
+            run_repo=run_repo,
+            project_repo=project_repo,
+            conversation_repo=conversation_repo,
+        )
+    )
+)
 
-app.include_router(build_approvals_router(ApprovalsRouterDeps(
-    approval_request_repo=approval_request_repo,
-    project_repo=project_repo,
-    run_repo=run_repo,
-)))
+app.include_router(
+    build_approvals_router(
+        ApprovalsRouterDeps(
+            approval_request_repo=approval_request_repo,
+            project_repo=project_repo,
+            run_repo=run_repo,
+        )
+    )
+)
 
-app.include_router(build_audit_logs_router(AuditLogsRouterDeps(
-    audit_log_repo=audit_log_repo,
-    project_repo=project_repo,
-    run_repo=run_repo,
-    approval_request_repo=approval_request_repo,
-)))
+app.include_router(
+    build_audit_logs_router(
+        AuditLogsRouterDeps(
+            audit_log_repo=audit_log_repo,
+            project_repo=project_repo,
+            run_repo=run_repo,
+            approval_request_repo=approval_request_repo,
+        )
+    )
+)
 
-app.include_router(build_agent_teams_router(AgentTeamsRouterDeps(
-    agent_team_repo=agent_team_repo,
-)))
+app.include_router(
+    build_agent_teams_router(
+        AgentTeamsRouterDeps(
+            agent_team_repo=agent_team_repo,
+        )
+    )
+)
 
-app.include_router(build_promotions_router(PromotionsRouterDeps(
-    conversation_repo=conversation_repo,
-    message_repo=message_repo,
-    project_repo=project_repo,
-    project_team_repo=project_team_repo,
-    agent_team_repo=agent_team_repo,
-    artifact_repo=artifact_repo,
-    message_trace_service_fn=lambda: message_trace_service,
-    runtime_support=runtime_support,
-)))
+app.include_router(
+    build_promotions_router(
+        PromotionsRouterDeps(
+            conversation_repo=conversation_repo,
+            message_repo=message_repo,
+            project_repo=project_repo,
+            project_team_repo=project_team_repo,
+            agent_team_repo=agent_team_repo,
+            artifact_repo=artifact_repo,
+            message_trace_service_fn=lambda: message_trace_service,
+            runtime_support=runtime_support,
+        )
+    )
+)
 
 # ---- LLM gateway & provider routes ----
 
-from swarmmind.api.llm_gateway_routes import router as _gateway_router  # noqa: E402
-from swarmmind.api.llm_provider_routes import router as _provider_router  # noqa: E402
+from swarmmind.api.llm_gateway_routes import router as _gateway_router
+from swarmmind.api.llm_provider_routes import router as _provider_router
 
 app.include_router(_gateway_router)
 app.include_router(_provider_router)

--- a/tests/test_artifact_api.py
+++ b/tests/test_artifact_api.py
@@ -44,7 +44,9 @@ class TestArtifactEndpoints:
         conv_repo = ConversationRepository()
         art_repo = ArtifactRepository()
         conv = conv_repo.create("Chat", "pending")
-        art_repo.create(conv.id, None, "/mnt/user-data/outputs/report.md", "write_file", mime_type="text/markdown", size_bytes=123)
+        art_repo.create(
+            conv.id, None, "/mnt/user-data/outputs/report.md", "write_file", mime_type="text/markdown", size_bytes=123
+        )
         art_repo.create(conv.id, None, "plan.md", "present_files")
 
         response = client.get(f"/conversations/{conv.id}/artifacts")

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -6,12 +6,17 @@ import {
   FolderKanban,
   History,
   Library,
+  Loader2,
   Search,
   Sparkles,
+  TrendingUp,
 } from "lucide-react";
 
 import { Workbench } from "@/components/workbench";
 import { Button } from "@/components/ui/button";
+import { ProjectPage } from "@/components/workspace/project/project-page";
+import { ProjectEmptyState } from "@/components/workspace/project/project-empty-state";
+import { promoteConversation } from "@/core/projects/api";
 import {
   Card,
   CardContent,
@@ -157,12 +162,14 @@ export default function App() {
   const [activeConversationId, setActiveConversationId] = useState<
     string | undefined
   >(undefined);
+  const [activeProjectId, setActiveProjectId] = useState<string | undefined>(undefined);
   const [recentConversations, setRecentConversations] = useState<
     ConversationRecord[]
   >([]);
   const [draftResetToken, setDraftResetToken] = useState(0);
   const [searchQuery, setSearchQuery] = useState("");
   const [isRecentLoading, setIsRecentLoading] = useState(true);
+  const [isPromoting, setIsPromoting] = useState(false);
 
   const fetchRecentConversations = useCallback(async () => {
     try {
@@ -224,7 +231,13 @@ export default function App() {
     // Check URL first
     const params = new URLSearchParams(window.location.search);
     const urlConversationId = params.get("conversation");
-    if (urlConversationId) {
+    const urlProjectId = params.get("project");
+    if (urlProjectId) {
+      setActiveProjectId(urlProjectId);
+      setActiveView("projects");
+      void fetchRecentConversations();
+      setIsRecentLoading(false);
+    } else if (urlConversationId) {
       setActiveConversationId(urlConversationId);
       setActiveView("chat");
       void fetchRecentConversations();
@@ -259,12 +272,29 @@ export default function App() {
     }
   }, [activeConversationId, activeView]);
 
+  // Sync URL when active project changes
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const currentProjectId = params.get("project");
+    if (activeProjectId && activeView === "projects") {
+      if (currentProjectId !== activeProjectId) {
+        window.history.replaceState(null, "", `/?project=${activeProjectId}`);
+      }
+    } else if (activeView !== "projects" && currentProjectId) {
+      window.history.replaceState(null, "", "/");
+    }
+  }, [activeProjectId, activeView]);
+
   // Handle browser back/forward
   useEffect(() => {
     const handlePopState = () => {
       const params = new URLSearchParams(window.location.search);
       const urlConversationId = params.get("conversation");
-      if (urlConversationId) {
+      const urlProjectId = params.get("project");
+      if (urlProjectId) {
+        setActiveProjectId(urlProjectId);
+        setActiveView("projects");
+      } else if (urlConversationId) {
         setActiveConversationId(urlConversationId);
         setActiveView("chat");
       } else {
@@ -371,6 +401,21 @@ export default function App() {
     );
   }, [recentConversations, searchQuery]);
 
+  const handlePromote = async () => {
+    if (!activeConversationId || isPromoting) return;
+    setIsPromoting(true);
+    try {
+      const project = await promoteConversation(activeConversationId);
+      setActiveProjectId(project.project_id);
+      setActiveView("projects");
+      window.history.replaceState(null, "", `/?project=${project.project_id}`);
+    } catch (err) {
+      console.error("Promote failed:", err);
+    } finally {
+      setIsPromoting(false);
+    }
+  };
+
   const renderContent = () => {
     switch (activeView) {
       case "workbench":
@@ -383,13 +428,33 @@ export default function App() {
         );
       case "chat":
         return (
-          <V0Chat
-            conversationId={activeConversationId}
-            draftResetToken={draftResetToken}
-            onConversationCreated={handleConversationCreated}
-            onConversationsChange={setRecentConversations}
-            initialLoading={isRecentLoading}
-          />
+          <div className="relative flex min-h-0 flex-1 flex-col">
+            {activeConversationId && (
+              <div className="absolute right-4 top-4 z-10">
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  disabled={isPromoting}
+                  onClick={() => void handlePromote()}
+                  className="gap-1.5 text-xs"
+                >
+                  {isPromoting ? (
+                    <Loader2 className="size-3 animate-spin" />
+                  ) : (
+                    <TrendingUp className="size-3" />
+                  )}
+                  升级为项目
+                </Button>
+              </div>
+            )}
+            <V0Chat
+              conversationId={activeConversationId}
+              draftResetToken={draftResetToken}
+              onConversationCreated={handleConversationCreated}
+              onConversationsChange={setRecentConversations}
+              initialLoading={isRecentLoading}
+            />
+          </div>
         );
       case "teams":
         return (
@@ -428,13 +493,10 @@ export default function App() {
           />
         );
       case "projects":
-        return (
-          <PlaceholderView
-            icon={<FolderKanban className="size-5" />}
-            title="项目"
-            description="项目空间用于承接结构化执行、审批、结果沉淀与复用。"
-            action="新建项目"
-          />
+        return activeProjectId ? (
+          <ProjectPage projectId={activeProjectId} />
+        ) : (
+          <ProjectEmptyState />
         );
       case "recent":
         return (

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -3,7 +3,6 @@ import {
   BookOpenText,
   Bot,
   Clock3,
-  FolderKanban,
   History,
   Library,
   Loader2,

--- a/ui/src/components/ui/v0-ai-chat.tsx
+++ b/ui/src/components/ui/v0-ai-chat.tsx
@@ -297,6 +297,7 @@ function V0ChatInner({
           role: message.role,
           content: message.content,
           created_at: message.created_at,
+          run_id: message.run_id,
         })),
       );
     } catch (requestError) {
@@ -1253,6 +1254,7 @@ function V0ChatInner({
             <ChatMessageArea
               isLoading={isLoading}
               messages={messages}
+              conversationId={currentConversationId ?? undefined}
               pendingClarification={pendingClarification}
               tasks={tasks}
               onClarificationRespond={handleClarificationRespond}

--- a/ui/src/components/workspace/chat-message-area.tsx
+++ b/ui/src/components/workspace/chat-message-area.tsx
@@ -5,6 +5,7 @@ import { Loader2, RefreshCw } from "lucide-react";
 import { MessageBubble, SuggestedFollowUps } from "@/components/workspace/chat-message-ui";
 import { ClarificationCard } from "@/components/workspace/messages/clarification-card";
 import { SubtaskCard } from "@/components/workspace/messages/subtask-card";
+import { TraceSummary } from "@/components/workspace/messages/trace-summary";
 import { parseClarificationContent } from "@/core/messages/clarification";
 import type { ChatMessage, ChatError } from "@/core/chat/types";
 import type { Subtask } from "@/core/tasks/types";
@@ -20,6 +21,7 @@ interface PendingClarification {
 interface ChatMessageAreaProps {
   isLoading: boolean;
   messages: ChatMessage[];
+  conversationId?: string;
   pendingClarification: PendingClarification | null;
   tasks: Record<string, Subtask>;
   onClarificationRespond: (response: string, toolCallId: string) => void;
@@ -144,6 +146,7 @@ function ErrorCard({
 export function ChatMessageArea({
   isLoading,
   messages,
+  conversationId,
   pendingClarification,
   tasks,
   onClarificationRespond,
@@ -194,6 +197,13 @@ export function ChatMessageArea({
                 message.content.trim().length > 0,
               )}
             />
+            {message.role === "assistant" &&
+              !message.isStreaming &&
+              !message.isReasoningStreaming &&
+              message.run_id &&
+              conversationId ? (
+              <TraceSummary conversationId={conversationId} messageId={message.id} />
+            ) : null}
             {isLastAssistant && shouldShowSuggestedFollowUps ? (
               <SuggestedFollowUps
                 items={followUps}

--- a/ui/src/components/workspace/messages/trace-summary.tsx
+++ b/ui/src/components/workspace/messages/trace-summary.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronDown, ChevronRight, Loader2 } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { getMessageTrace, type TraceSummaryResponse } from "@/core/trace/api";
+import { cn } from "@/lib/utils";
+
+interface TraceSummaryProps {
+  conversationId: string;
+  messageId: string;
+}
+
+export function TraceSummary({ conversationId, messageId }: TraceSummaryProps) {
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [data, setData] = useState<TraceSummaryResponse | null>(null);
+  const [error, setError] = useState(false);
+
+  const handleToggle = () => {
+    if (!open && !data && !loading) {
+      setLoading(true);
+      setError(false);
+      getMessageTrace(conversationId, messageId)
+        .then((result) => {
+          setData(result);
+          setLoading(false);
+        })
+        .catch(() => {
+          setError(true);
+          setLoading(false);
+        });
+    }
+    setOpen((prev) => !prev);
+  };
+
+  return (
+    <div className="mt-2 rounded-lg border border-border/60 bg-surface-hover/40 text-xs">
+      <button
+        type="button"
+        onClick={handleToggle}
+        className="flex w-full items-center gap-1.5 px-3 py-2 text-left text-muted-foreground transition-colors hover:text-foreground"
+      >
+        {loading ? (
+          <Loader2 className="size-3 animate-spin" />
+        ) : open ? (
+          <ChevronDown className="size-3" />
+        ) : (
+          <ChevronRight className="size-3" />
+        )}
+        <span className="font-medium">执行摘要</span>
+        {data && !open && (
+          <span className="ml-auto text-[10px] opacity-60">
+            {data.steps_count} 步 · {data.subagent_calls_count} 子任务
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <div className="border-t border-border/40 px-3 pb-3 pt-2">
+          {loading && (
+            <div className="flex items-center gap-1.5 text-muted-foreground">
+              <Loader2 className="size-3 animate-spin" />
+              <span>加载中…</span>
+            </div>
+          )}
+          {error && !loading && (
+            <p className="text-muted-foreground">摘要暂不可用</p>
+          )}
+          {data && !loading && (
+            <div className="space-y-2">
+              {data.summary && (
+                <p className="text-foreground/90">{data.summary}</p>
+              )}
+              <div className="flex flex-wrap gap-1.5">
+                <CountBadge label="步骤" value={data.steps_count} />
+                <CountBadge label="子任务" value={data.subagent_calls_count} />
+                <CountBadge label="产物" value={data.artifacts_count} />
+                {data.blocked_points.map((pt, i) => (
+                  <Badge
+                    key={i}
+                    variant="secondary"
+                    className={cn("text-[10px]", "border-amber-300 bg-amber-50 text-amber-700 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-400")}
+                  >
+                    阻塞: {pt}
+                  </Badge>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CountBadge({ label, value }: { label: string; value: number }) {
+  return (
+    <Badge variant="secondary" className="text-[10px]">
+      {label} {value}
+    </Badge>
+  );
+}

--- a/ui/src/components/workspace/project/project-empty-state.tsx
+++ b/ui/src/components/workspace/project/project-empty-state.tsx
@@ -1,0 +1,17 @@
+import { FolderKanban } from "lucide-react";
+
+export function ProjectEmptyState() {
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center gap-4 p-12 text-center">
+      <div className="flex size-14 items-center justify-center rounded-2xl border border-border bg-surface-hover">
+        <FolderKanban className="size-6 text-muted-foreground" />
+      </div>
+      <div className="space-y-1">
+        <h3 className="text-sm font-semibold text-foreground">未选择项目</h3>
+        <p className="max-w-xs text-xs text-muted-foreground">
+          从对话工作区点击「升级为项目」，或在此处新建项目。
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/workspace/project/project-page.tsx
+++ b/ui/src/components/workspace/project/project-page.tsx
@@ -1,0 +1,224 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  AlertCircle,
+  CheckCircle2,
+  Clock,
+  FileText,
+  Layers,
+  Loader2,
+  Play,
+} from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { getProjectOverview } from "@/core/projects/api";
+import type { ProjectOverviewResponse } from "@/core/projects/types";
+import { cn } from "@/lib/utils";
+
+interface ProjectPageProps {
+  projectId: string;
+}
+
+export function ProjectPage({ projectId }: ProjectPageProps) {
+  const [overview, setOverview] = useState<ProjectOverviewResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    getProjectOverview(projectId)
+      .then((data) => {
+        if (!cancelled) {
+          setOverview(data);
+          setLoading(false);
+        }
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "加载失败");
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [projectId]);
+
+  if (loading) {
+    return (
+      <div className="flex flex-1 items-center justify-center p-12">
+        <Loader2 className="size-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (error || !overview) {
+    return (
+      <div className="flex flex-1 items-center justify-center gap-2 p-12 text-sm text-destructive">
+        <AlertCircle className="size-4" />
+        {error ?? "项目数据加载失败"}
+      </div>
+    );
+  }
+
+  const { project, stats, recent_tasks, recent_artifacts, recent_runs } = overview;
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-6 p-6">
+      {/* Header */}
+      <div className="space-y-1">
+        <div className="flex items-start gap-2">
+          <h1 className="flex-1 text-xl font-semibold text-foreground">{project.title}</h1>
+          <Badge variant="secondary" className="shrink-0 text-[11px]">
+            {project.status}
+          </Badge>
+        </div>
+        {project.phase && (
+          <p className="text-xs text-muted-foreground">阶段: {project.phase}</p>
+        )}
+        {project.source_conversation_id && (
+          <p className="text-xs text-muted-foreground">
+            来源对话:{" "}
+            <a
+              href={`/?conversation=${project.source_conversation_id}`}
+              className="underline-offset-2 hover:underline"
+            >
+              {project.source_conversation_id.slice(0, 8)}…
+            </a>
+          </p>
+        )}
+      </div>
+
+      {/* Goal */}
+      {project.goal && (
+        <Section title="目标">
+          <p className="whitespace-pre-wrap text-sm text-foreground/90">{project.goal}</p>
+        </Section>
+      )}
+
+      {/* Next step */}
+      {project.next_step && (
+        <Section title="下一步">
+          <p className="whitespace-pre-wrap text-sm text-foreground/90">{project.next_step}</p>
+        </Section>
+      )}
+
+      {/* Stats strip */}
+      <div className="grid grid-cols-4 gap-3">
+        <StatCard icon={<Layers className="size-3.5" />} label="任务" value={stats.task_count} />
+        <StatCard icon={<FileText className="size-3.5" />} label="产物" value={stats.artifact_count} />
+        <StatCard icon={<Play className="size-3.5" />} label="运行" value={stats.run_count} />
+        <StatCard
+          icon={<AlertCircle className="size-3.5" />}
+          label="待审批"
+          value={stats.pending_approval_count}
+          highlight={stats.pending_approval_count > 0}
+        />
+      </div>
+
+      {/* Recent tasks */}
+      {recent_tasks.length > 0 && (
+        <Section title="近期任务">
+          <ul className="space-y-1.5">
+            {recent_tasks.map((task) => (
+              <li key={task.task_id} className="flex items-center gap-2 text-sm">
+                <StatusDot status={task.status} />
+                <span className="flex-1 truncate">{task.title}</span>
+                <span className="shrink-0 text-[11px] text-muted-foreground">{task.status}</span>
+              </li>
+            ))}
+          </ul>
+        </Section>
+      )}
+
+      {/* Recent runs */}
+      {recent_runs.length > 0 && (
+        <Section title="近期执行">
+          <ul className="space-y-1.5">
+            {recent_runs.map((run) => (
+              <li key={run.run_id} className="flex items-center gap-2 text-sm">
+                <StatusDot status={run.status} />
+                <span className="flex-1 truncate text-muted-foreground">
+                  {run.goal ?? run.run_id.slice(0, 8)}
+                </span>
+                <span className="shrink-0 text-[11px] text-muted-foreground">{run.status}</span>
+              </li>
+            ))}
+          </ul>
+        </Section>
+      )}
+
+      {/* Recent artifacts */}
+      {recent_artifacts.length > 0 && (
+        <Section title="近期产物">
+          <ul className="space-y-1.5">
+            {recent_artifacts.map((art) => (
+              <li key={art.artifact_id} className="flex items-center gap-2 text-sm">
+                <FileText className="size-3.5 shrink-0 text-muted-foreground" />
+                <span className="flex-1 truncate">{art.name ?? art.artifact_id.slice(0, 8)}</span>
+                {art.artifact_type && (
+                  <Badge variant="secondary" className="shrink-0 text-[10px]">
+                    {art.artifact_type}
+                  </Badge>
+                )}
+              </li>
+            ))}
+          </ul>
+        </Section>
+      )}
+    </div>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="space-y-2 rounded-xl border border-border bg-card p-4">
+      <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{title}</h2>
+      {children}
+    </div>
+  );
+}
+
+function StatCard({
+  icon,
+  label,
+  value,
+  highlight = false,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: number;
+  highlight?: boolean;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col gap-1 rounded-xl border p-3",
+        highlight ? "border-amber-200 bg-amber-50 dark:border-amber-800 dark:bg-amber-950/30" : "border-border bg-card",
+      )}
+    >
+      <span className={cn("text-muted-foreground", highlight && "text-amber-600 dark:text-amber-400")}>{icon}</span>
+      <span className="text-xl font-semibold text-foreground">{value}</span>
+      <span className="text-[11px] text-muted-foreground">{label}</span>
+    </div>
+  );
+}
+
+function StatusDot({ status }: { status: string }) {
+  const color =
+    status === "completed" || status === "done"
+      ? "text-green-500"
+      : status === "blocked" || status === "failed"
+        ? "text-red-500"
+        : status === "in_progress" || status === "running"
+          ? "text-blue-500"
+          : "text-muted-foreground";
+
+  const Icon = status === "completed" || status === "done" ? CheckCircle2 : Clock;
+  return <Icon className={cn("size-3.5 shrink-0", color)} />;
+}

--- a/ui/src/core/chat/types.ts
+++ b/ui/src/core/chat/types.ts
@@ -3,6 +3,7 @@ export interface StoredMessage {
   role: "user" | "assistant";
   content: string;
   created_at?: string;
+  run_id?: string | null;
 }
 
 export interface RuntimeModelOption {

--- a/ui/src/core/projects/api.ts
+++ b/ui/src/core/projects/api.ts
@@ -1,0 +1,37 @@
+import type {
+  Project,
+  ProjectListResponse,
+  ProjectOverviewResponse,
+} from "./types";
+
+async function fetchJson<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(path, init);
+  if (!res.ok) {
+    const detail = await res.text().catch(() => res.statusText);
+    throw new Error(`HTTP ${res.status}: ${detail}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+export async function listProjects(): Promise<ProjectListResponse> {
+  return fetchJson<ProjectListResponse>("/projects");
+}
+
+export async function getProject(id: string): Promise<Project> {
+  return fetchJson<Project>(`/projects/${id}`);
+}
+
+export async function getProjectOverview(id: string): Promise<ProjectOverviewResponse> {
+  return fetchJson<ProjectOverviewResponse>(`/projects/${id}/overview`);
+}
+
+export async function promoteConversation(
+  conversationId: string,
+  body?: { title?: string; goal?: string; next_step?: string },
+): Promise<Project> {
+  return fetchJson<Project>(`/conversations/${conversationId}/promote`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+}

--- a/ui/src/core/projects/types.ts
+++ b/ui/src/core/projects/types.ts
@@ -1,0 +1,94 @@
+export interface ProjectAgentTeamInstance {
+  instance_id: string;
+  project_id: string;
+  team_template_id: string;
+  team_name: string;
+  team_description?: string | null;
+  status: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface Project {
+  project_id: string;
+  title: string;
+  goal?: string | null;
+  scope?: string | null;
+  constraints?: string | null;
+  source_conversation_id?: string | null;
+  conversation_id?: string | null;
+  next_step?: string | null;
+  phase?: string | null;
+  risk_level?: string | null;
+  status: string;
+  agent_team?: ProjectAgentTeamInstance | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ProjectListResponse {
+  items: Project[];
+  total: number;
+}
+
+export interface Run {
+  run_id: string;
+  project_id?: string | null;
+  conversation_id?: string | null;
+  status: string;
+  goal?: string | null;
+  summary?: string | null;
+  started_at: string;
+  completed_at?: string | null;
+}
+
+export interface Task {
+  task_id: string;
+  project_id: string;
+  run_id?: string | null;
+  title: string;
+  description?: string | null;
+  status: string;
+  priority: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface Artifact {
+  artifact_id: string;
+  conversation_id?: string | null;
+  project_id?: string | null;
+  name?: string | null;
+  path?: string | null;
+  mime_type?: string | null;
+  size_bytes?: number | null;
+  artifact_type?: string | null;
+  created_at: string;
+}
+
+export interface ApprovalRequest {
+  approval_id: string;
+  project_id: string;
+  title: string;
+  status: string;
+  risk_tier: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ProjectOverviewStats {
+  task_count: number;
+  artifact_count: number;
+  run_count: number;
+  blocked_count: number;
+  pending_approval_count: number;
+}
+
+export interface ProjectOverviewResponse {
+  project: Project;
+  stats: ProjectOverviewStats;
+  recent_tasks: Task[];
+  recent_artifacts: Artifact[];
+  recent_runs: Run[];
+  recent_approvals: ApprovalRequest[];
+}

--- a/ui/src/core/trace/api.ts
+++ b/ui/src/core/trace/api.ts
@@ -1,0 +1,20 @@
+export interface TraceSummaryResponse {
+  steps_count: number;
+  subagent_calls_count: number;
+  artifacts_count: number;
+  blocked_points: string[];
+  summary: string;
+}
+
+export async function getMessageTrace(
+  conversationId: string,
+  messageId: string,
+): Promise<TraceSummaryResponse> {
+  const res = await fetch(
+    `/conversations/${conversationId}/messages/${messageId}/trace`,
+  );
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status}`);
+  }
+  return res.json() as Promise<TraceSummaryResponse>;
+}

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -15,8 +15,6 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "ignoreDeprecations": "6.0",
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -15,6 +15,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
+    "ignoreDeprecations": "6.0",
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]


### PR DESCRIPTION
## Summary

Implements all three phases of issue #62.

**Phase 1 — Supervisor modularisation**
- Split `swarmmind/api/supervisor.py` (1581 → 411 lines) into per-domain `APIRouter` factories under `swarmmind/api/routers/`: `mappers`, `system`, `legacy_supervisor`, `runtime_models`, `projects`, `runs`, `approvals`, `audit_logs`, `agent_teams`, `promotions`
- Each router uses a frozen `RouterDeps` dataclass for clean dependency injection and testability
- All backward-compat re-exports preserved so existing tests are unaffected
- `message_trace_service_fn: Callable` lambda pattern keeps `monkeypatch.setattr` working for promotion route tests

**Phase 2 — Project page UI**
- `ui/src/core/projects/{types,api}.ts` — typed TypeScript client for `/projects/*` endpoints
- `ui/src/components/workspace/project/project-page.tsx` — full project overview panel (header, goal, next-step, 4-column stats strip, recent tasks/runs/artifacts)
- `ui/src/components/workspace/project/project-empty-state.tsx` — empty state for project tab
- `App.tsx`: `?project=` URL sync mirroring `?conversation=`, "升级为项目" promote button in chat toolbar, project tab routing

**Phase 3 — Trace summary panel**
- `ui/src/core/trace/api.ts` — lazy `GET /conversations/{id}/messages/{mid}/trace` fetcher
- `ui/src/components/workspace/messages/trace-summary.tsx` — collapsible "执行摘要" accordion: lazy-fetches on first expand, caches in state, shows summary text + step/subagent/artifact count badges + blocked-point badges
- `StoredMessage` gains `run_id?: string | null`; `ChatMessageArea` renders `<TraceSummary>` beneath each completed assistant message that carries a `run_id`

## Test plan

- [x] TypeScript: `tsc --noEmit` — zero errors (one pre-existing deprecation warning for `baseUrl`)
- [x] Python tests: 338 passed, 4 skipped; 4 pre-existing failures in `test_conversation_detail` (require LLM model config, unrelated to this PR)
- [x] All domain tests pass: projects, runs, approvals, audit_logs, agent_teams, promotions, trace
- [ ] Manual: load a conversation with a `run_id`-bearing assistant message → trace accordion appears and fetches on expand
- [ ] Manual: click "升级为项目" on a conversation → redirects to `?project=<id>` with the project overview page

https://claude.ai/code/session_01Sv446JqkiaWPsdp52fbTVs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sv446JqkiaWPsdp52fbTVs)_