### PR TITLE
feat(phase-c): RunContext + RunLifecycleService — Phase 1 of #65

### DIFF
--- a/swarmmind/api/routers/projects.py
+++ b/swarmmind/api/routers/projects.py
@@ -52,6 +52,7 @@ class ProjectsRouterDeps:
     project_team_repo: object
     conversation_repo: object
     stream_conversation_message: object
+    stream_project_message: object
 
 
 def build_projects_router(deps: ProjectsRouterDeps) -> APIRouter:
@@ -361,11 +362,11 @@ def build_projects_router(deps: ProjectsRouterDeps) -> APIRouter:
         responses={404: {"description": "Project not found"}},
     )
     def send_project_message_stream(project_id: str, body: SendMessageRequest) -> StreamingResponse:
-        """Stream a project execution turn with SwarmMind runtime semantics."""
+        """Stream a project execution turn, creating a RunDB row anchored on project_id."""
         deps.project_repo.get_by_id(project_id)
         conversation_id = _ensure_project_conversation(project_id)
         return StreamingResponse(
-            deps.stream_conversation_message(conversation_id, body),
+            deps.stream_project_message(project_id, conversation_id, body),
             media_type="application/x-ndjson",
         )
 

--- a/swarmmind/api/supervisor.py
+++ b/swarmmind/api/supervisor.py
@@ -62,6 +62,8 @@ from swarmmind.services.conversation_support import (
 from swarmmind.services.conversation_trace_service import ConversationTraceService
 from swarmmind.services.lifecycle import run_cleanup_scanner, startup_lifecycle
 from swarmmind.services.message_trace_service import _default_message_trace_service
+from swarmmind.services.run_context import RunContext
+from swarmmind.services.run_lifecycle import RunLifecycleService
 from swarmmind.services.runtime_support import RuntimeSupportService
 from swarmmind.services.stream_events import (
     general_agent_status_labels as _svc_general_agent_status_labels,
@@ -98,6 +100,7 @@ conversation_support = ConversationSupportService(
     message_repo=message_repo,
     title_generator=generate_title_with_deerflow,
 )
+run_lifecycle_service = RunLifecycleService(run_repo=run_repo)
 runtime_support = RuntimeSupportService(conversation_repo=conversation_repo)
 conversation_trace_service = ConversationTraceService(conversation_repo=conversation_repo)
 message_trace_service = _default_message_trace_service()
@@ -187,11 +190,17 @@ def _conversation_execution_service() -> ConversationExecutionService:
         serialize_stream_event_fn=_svc_serialize_stream_event,
         db_to_message_fn=conversation_support.db_to_message,
         execution_logger=logger,
+        run_lifecycle_service=run_lifecycle_service,
     )
 
 
 def _stream_conversation_message(conversation_id: str, body: SendMessageRequest):
     yield from _conversation_execution_service().stream_message(conversation_id, body)
+
+
+def _stream_project_message(project_id: str, conversation_id: str, body: SendMessageRequest):
+    run_context = RunContext.for_project(project_id, conversation_id)
+    yield from _conversation_execution_service().stream_message(conversation_id, body, run_context=run_context)
 
 
 def _respond_to_clarification(conversation_id: str, tool_call_id: str, response: str) -> Message:
@@ -389,6 +398,7 @@ app.include_router(
             project_team_repo=project_team_repo,
             conversation_repo=conversation_repo,
             stream_conversation_message=_stream_conversation_message,
+            stream_project_message=_stream_project_message,
         )
     )
 )

--- a/swarmmind/repositories/run.py
+++ b/swarmmind/repositories/run.py
@@ -18,15 +18,16 @@ class RunRepository:
     def create(
         self,
         *,
+        run_id: str | None = None,
         conversation_id: str | None = None,
         project_id: str | None = None,
         goal: str | None = None,
         status: str = "running",
     ) -> RunDB:
-        """Create a new run record."""
+        """Create a new run record. Caller may supply run_id for deterministic identity."""
         with session_scope() as session:
             run = RunDB(
-                run_id=str(uuid.uuid4()),
+                run_id=run_id or str(uuid.uuid4()),
                 conversation_id=conversation_id,
                 project_id=project_id,
                 goal=goal,
@@ -120,3 +121,46 @@ class RunRepository:
             if run is None:
                 raise HTTPException(status_code=404, detail="Run not found")
             run.project_id = project_id
+
+    # ---- Lifecycle helpers ----
+
+    def mark_completed(self, run_id: str, summary: str | None = None) -> None:
+        """Transition run to completed status."""
+        with session_scope() as session:
+            run = session.get(RunDB, run_id)
+            if run is None:
+                raise HTTPException(status_code=404, detail="Run not found")
+            run.status = "completed"
+            run.completed_at = utc_now()
+            if summary is not None:
+                run.summary = summary
+            session.commit()
+
+    def mark_failed(self, run_id: str, error_class: str, message: str) -> None:
+        """Transition run to failed status, recording the error."""
+        with session_scope() as session:
+            run = session.get(RunDB, run_id)
+            if run is None:
+                raise HTTPException(status_code=404, detail="Run not found")
+            run.status = "failed"
+            run.completed_at = utc_now()
+            run.summary = f"{error_class}: {message}"[:500]
+            session.commit()
+
+    def mark_waiting_approval(self, run_id: str, approval_id: str) -> None:
+        """Transition run to waiting_approval status."""
+        with session_scope() as session:
+            run = session.get(RunDB, run_id)
+            if run is None:
+                raise HTTPException(status_code=404, detail="Run not found")
+            run.status = "waiting_approval"
+            session.commit()
+
+    def mark_running(self, run_id: str) -> None:
+        """Transition run back to running (e.g. after approval resume)."""
+        with session_scope() as session:
+            run = session.get(RunDB, run_id)
+            if run is None:
+                raise HTTPException(status_code=404, detail="Run not found")
+            run.status = "running"
+            session.commit()

--- a/swarmmind/services/conversation_execution.py
+++ b/swarmmind/services/conversation_execution.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import uuid
 from collections.abc import Callable, Generator
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from fastapi import HTTPException
 
@@ -16,6 +16,10 @@ from swarmmind.models import (
     SendMessageRequest,
     SendMessageResponse,
 )
+
+if TYPE_CHECKING:
+    from swarmmind.services.run_context import RunContext
+    from swarmmind.services.run_lifecycle import RunLifecycleService
 
 
 def _is_client_disconnect_error(exc: BaseException) -> bool:
@@ -60,6 +64,7 @@ class ConversationExecutionService:
         serialize_stream_event_fn: Callable[..., str],
         db_to_message_fn: Callable[[Any], Message],
         execution_logger: logging.Logger,
+        run_lifecycle_service: RunLifecycleService | None = None,
     ) -> None:
         self._conversation_repo = conversation_repo
         self._message_repo = message_repo
@@ -80,6 +85,7 @@ class ConversationExecutionService:
         self._serialize_stream_event = serialize_stream_event_fn
         self._db_to_message = db_to_message_fn
         self._logger = execution_logger
+        self._run_lifecycle = run_lifecycle_service
 
     def send_message(self, conversation_id: str, body: SendMessageRequest) -> SendMessageResponse:
         """Run a non-streaming conversation turn."""
@@ -107,9 +113,24 @@ class ConversationExecutionService:
         self._maybe_generate_conversation_title(conversation_id)
         return SendMessageResponse(user_message=user_msg, assistant_message=assistant_msg)
 
-    def stream_message(self, conversation_id: str, body: SendMessageRequest) -> Generator[str, None, None]:
-        """Stream a conversation turn with runtime-status events."""
-        run_id = str(uuid.uuid4())
+    def stream_message(
+        self,
+        conversation_id: str,
+        body: SendMessageRequest,
+        *,
+        run_context: RunContext | None = None,
+    ) -> Generator[str, None, None]:
+        """Stream a conversation turn with runtime-status events.
+
+        When run_context is provided and has a project_id, lifecycle events are
+        persisted via RunLifecycleService. ChatSession-only calls pass no
+        run_context and are unaffected.
+        """
+        run_id = run_context.run_id if run_context is not None else str(uuid.uuid4())
+
+        if self._run_lifecycle is not None and run_context is not None:
+            self._run_lifecycle.start(run_context)
+
         user_message = self._persist_user_message(conversation_id, body.content, run_id)
         yield self._serialize_stream_event("status", phase="accepted", label="消息已加入当前会话")
         yield self._serialize_stream_event(
@@ -172,9 +193,16 @@ class ConversationExecutionService:
                 self._logger.info("Client disconnected from stream: %s", exc)
                 return
             self._logger.error("Conversation stream error: %s", exc, exc_info=True)
+            if self._run_lifecycle is not None and run_context is not None:
+                error_class = "TIMEOUT" if isinstance(exc, TimeoutError) else "RUNTIME_ERROR"
+                self._run_lifecycle.fail(run_context, error_class, str(exc))
             ai_response = self._format_runtime_error(exc)
             error_code = "TIMEOUT" if isinstance(exc, TimeoutError) else "RUNTIME_ERROR"
             yield self._serialize_stream_event("error", code=error_code, message=ai_response)
+
+        if self._run_lifecycle is not None and run_context is not None:
+            summary = ai_response[:500] if ai_response else None
+            self._run_lifecycle.finish(run_context, summary)
 
         assistant_message = self._persist_assistant_message(conversation_id, ai_response)
         self._maybe_generate_conversation_title(conversation_id)

--- a/swarmmind/services/run_context.py
+++ b/swarmmind/services/run_context.py
@@ -1,0 +1,59 @@
+"""RunContext value object for project-scoped execution."""
+
+from __future__ import annotations
+
+import enum
+import uuid
+from dataclasses import dataclass
+
+
+class RiskPolicy(str, enum.Enum):
+    """Determines which capability risk tiers trigger approval gates."""
+
+    PERMISSIVE = "permissive"  # never pauses for approval
+    MODERATE = "moderate"  # pauses on high-risk capabilities only
+    STRICT = "strict"  # pauses on medium or high-risk capabilities
+
+
+@dataclass(frozen=True)
+class RunContext:
+    """Immutable context for a single execution run.
+
+    When project_id is None this is a plain ChatSession run and all governance
+    hooks (lifecycle persistence, approval gates, audit) are no-ops.
+    """
+
+    run_id: str
+    project_id: str | None
+    conversation_id: str
+    risk_policy: RiskPolicy
+    approver_role: str | None
+
+    @classmethod
+    def for_chat_session(cls, conversation_id: str) -> RunContext:
+        """Create a no-project context for a plain ChatSession run."""
+        return cls(
+            run_id=str(uuid.uuid4()),
+            project_id=None,
+            conversation_id=conversation_id,
+            risk_policy=RiskPolicy.PERMISSIVE,
+            approver_role=None,
+        )
+
+    @classmethod
+    def for_project(
+        cls,
+        project_id: str,
+        conversation_id: str,
+        *,
+        risk_policy: RiskPolicy = RiskPolicy.MODERATE,
+        approver_role: str | None = None,
+    ) -> RunContext:
+        """Create a project-scoped run context."""
+        return cls(
+            run_id=str(uuid.uuid4()),
+            project_id=project_id,
+            conversation_id=conversation_id,
+            risk_policy=risk_policy,
+            approver_role=approver_role,
+        )

--- a/swarmmind/services/run_lifecycle.py
+++ b/swarmmind/services/run_lifecycle.py
@@ -1,0 +1,63 @@
+"""RunLifecycleService: persists run lifecycle transitions for project-scoped executions."""
+
+from __future__ import annotations
+
+import logging
+
+from swarmmind.db_models import RunDB
+from swarmmind.repositories.run import RunRepository
+from swarmmind.services.run_context import RunContext
+
+logger = logging.getLogger(__name__)
+
+
+class RunLifecycleService:
+    """Persists run lifecycle events for project-scoped executions.
+
+    When ctx.project_id is None (ChatSession-only), all methods are no-ops so
+    existing ChatSession flows are unaffected.
+    """
+
+    def __init__(self, run_repo: RunRepository) -> None:
+        self._run_repo = run_repo
+
+    def start(self, ctx: RunContext) -> RunDB | None:
+        """Create a RunDB row for this execution. No-op for ChatSession runs."""
+        if ctx.project_id is None:
+            return None
+        run = self._run_repo.create(
+            run_id=ctx.run_id,
+            project_id=ctx.project_id,
+            conversation_id=ctx.conversation_id,
+            status="running",
+        )
+        logger.info("Run started: run_id=%s project_id=%s", ctx.run_id, ctx.project_id)
+        return run
+
+    def finish(self, ctx: RunContext, summary: str | None = None) -> None:
+        """Mark run as completed. No-op for ChatSession runs."""
+        if ctx.project_id is None:
+            return
+        self._run_repo.mark_completed(ctx.run_id, summary)
+        logger.info("Run finished: run_id=%s", ctx.run_id)
+
+    def fail(self, ctx: RunContext, error_class: str, message: str) -> None:
+        """Mark run as failed. No-op for ChatSession runs."""
+        if ctx.project_id is None:
+            return
+        self._run_repo.mark_failed(ctx.run_id, error_class, message)
+        logger.warning("Run failed: run_id=%s error=%s: %s", ctx.run_id, error_class, message)
+
+    def pause_for_approval(self, ctx: RunContext, approval_id: str) -> None:
+        """Mark run as waiting for approval. No-op for ChatSession runs."""
+        if ctx.project_id is None:
+            return
+        self._run_repo.mark_waiting_approval(ctx.run_id, approval_id)
+        logger.info("Run paused for approval: run_id=%s approval_id=%s", ctx.run_id, approval_id)
+
+    def resume(self, ctx: RunContext) -> None:
+        """Mark run as running again after approval. No-op for ChatSession runs."""
+        if ctx.project_id is None:
+            return
+        self._run_repo.mark_running(ctx.run_id)
+        logger.info("Run resumed: run_id=%s", ctx.run_id)

--- a/tests/test_run_lifecycle.py
+++ b/tests/test_run_lifecycle.py
@@ -1,0 +1,228 @@
+"""Run lifecycle service tests.
+
+Covers: start→finish, start→fail, start→pause→resume, and ChatSession no-op behavior.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from swarmmind.db import dispose_engines, init_db
+from swarmmind.repositories.conversation import ConversationRepository
+from swarmmind.repositories.project import ProjectRepository
+from swarmmind.repositories.run import RunRepository
+from swarmmind.services.run_context import RiskPolicy, RunContext
+from swarmmind.services.run_lifecycle import RunLifecycleService
+
+
+@pytest.fixture(autouse=True)
+def setup_db(monkeypatch, tmp_path):
+    db_path = tmp_path / "run_lifecycle_test.db"
+    monkeypatch.setenv("SWARMMIND_DATABASE_URL", f"sqlite:///{db_path}")
+    dispose_engines()
+    init_db()
+
+
+@pytest.fixture
+def run_repo():
+    return RunRepository()
+
+
+@pytest.fixture
+def lifecycle(run_repo):
+    return RunLifecycleService(run_repo=run_repo)
+
+
+@pytest.fixture
+def project():
+    return ProjectRepository().create(title="Test Project")
+
+
+@pytest.fixture
+def conversation():
+    return ConversationRepository().create("Test Chat", "pending")
+
+
+class TestRunContext:
+    def test_for_chat_session_has_no_project(self, conversation):
+        ctx = RunContext.for_chat_session(conversation.id)
+        assert ctx.project_id is None
+        assert ctx.conversation_id == conversation.id
+        assert ctx.risk_policy == RiskPolicy.PERMISSIVE
+        assert ctx.approver_role is None
+        assert ctx.run_id  # non-empty
+
+    def test_for_project_sets_fields(self, project, conversation):
+        ctx = RunContext.for_project(project.project_id, conversation.id)
+        assert ctx.project_id == project.project_id
+        assert ctx.conversation_id == conversation.id
+        assert ctx.risk_policy == RiskPolicy.MODERATE
+        assert ctx.run_id
+
+    def test_for_project_custom_policy(self, project, conversation):
+        ctx = RunContext.for_project(project.project_id, conversation.id, risk_policy=RiskPolicy.STRICT)
+        assert ctx.risk_policy == RiskPolicy.STRICT
+
+    def test_run_ids_are_unique(self, conversation):
+        ctx1 = RunContext.for_chat_session(conversation.id)
+        ctx2 = RunContext.for_chat_session(conversation.id)
+        assert ctx1.run_id != ctx2.run_id
+
+
+class TestRunLifecycleServiceNoOp:
+    """ChatSession-only runs (project_id=None) must produce zero DB rows."""
+
+    def test_start_noop_returns_none(self, lifecycle, conversation):
+        ctx = RunContext.for_chat_session(conversation.id)
+        result = lifecycle.start(ctx)
+        assert result is None
+
+    def test_finish_noop(self, lifecycle, conversation, run_repo):
+        ctx = RunContext.for_chat_session(conversation.id)
+        lifecycle.start(ctx)
+        lifecycle.finish(ctx, summary="done")
+        # No RunDB row should exist
+        with pytest.raises(HTTPException):
+            run_repo.get_by_id(ctx.run_id)
+
+    def test_fail_noop(self, lifecycle, conversation, run_repo):
+        ctx = RunContext.for_chat_session(conversation.id)
+        lifecycle.start(ctx)
+        lifecycle.fail(ctx, "RUNTIME_ERROR", "something broke")
+        with pytest.raises(HTTPException):
+            run_repo.get_by_id(ctx.run_id)
+
+    def test_pause_and_resume_noop(self, lifecycle, conversation, run_repo):
+        ctx = RunContext.for_chat_session(conversation.id)
+        lifecycle.start(ctx)
+        lifecycle.pause_for_approval(ctx, "approval-123")
+        lifecycle.resume(ctx)
+        with pytest.raises(HTTPException):
+            run_repo.get_by_id(ctx.run_id)
+
+
+class TestRunLifecycleServiceProjectScoped:
+    """Project-scoped runs must create and transition RunDB rows."""
+
+    def test_start_creates_run_row(self, lifecycle, project, conversation, run_repo):
+        ctx = RunContext.for_project(project.project_id, conversation.id)
+        run = lifecycle.start(ctx)
+        assert run is not None
+        assert run.run_id == ctx.run_id
+        assert run.project_id == project.project_id
+        assert run.conversation_id == conversation.id
+        assert run.status == "running"
+
+    def test_start_finish_completes_run(self, lifecycle, project, conversation, run_repo):
+        ctx = RunContext.for_project(project.project_id, conversation.id)
+        lifecycle.start(ctx)
+        lifecycle.finish(ctx, summary="All done")
+
+        run = run_repo.get_by_id(ctx.run_id)
+        assert run.status == "completed"
+        assert run.summary == "All done"
+        assert run.completed_at is not None
+
+    def test_start_finish_no_summary(self, lifecycle, project, conversation, run_repo):
+        ctx = RunContext.for_project(project.project_id, conversation.id)
+        lifecycle.start(ctx)
+        lifecycle.finish(ctx)
+
+        run = run_repo.get_by_id(ctx.run_id)
+        assert run.status == "completed"
+
+    def test_start_fail_marks_failed(self, lifecycle, project, conversation, run_repo):
+        ctx = RunContext.for_project(project.project_id, conversation.id)
+        lifecycle.start(ctx)
+        lifecycle.fail(ctx, "TIMEOUT", "took too long")
+
+        run = run_repo.get_by_id(ctx.run_id)
+        assert run.status == "failed"
+        assert "TIMEOUT" in run.summary
+        assert "took too long" in run.summary
+        assert run.completed_at is not None
+
+    def test_start_pause_resume_transitions(self, lifecycle, project, conversation, run_repo):
+        ctx = RunContext.for_project(project.project_id, conversation.id)
+        lifecycle.start(ctx)
+
+        lifecycle.pause_for_approval(ctx, "approval-abc")
+        run = run_repo.get_by_id(ctx.run_id)
+        assert run.status == "waiting_approval"
+
+        lifecycle.resume(ctx)
+        run = run_repo.get_by_id(ctx.run_id)
+        assert run.status == "running"
+
+    def test_start_pause_fail(self, lifecycle, project, conversation, run_repo):
+        ctx = RunContext.for_project(project.project_id, conversation.id)
+        lifecycle.start(ctx)
+        lifecycle.pause_for_approval(ctx, "approval-xyz")
+        lifecycle.fail(ctx, "approval_rejected", "user rejected")
+
+        run = run_repo.get_by_id(ctx.run_id)
+        assert run.status == "failed"
+
+    def test_run_anchored_on_project(self, lifecycle, project, conversation, run_repo):
+        ctx = RunContext.for_project(project.project_id, conversation.id)
+        lifecycle.start(ctx)
+        lifecycle.finish(ctx, "summary")
+
+        runs = run_repo.list_by_project(project.project_id)
+        assert len(runs) == 1
+        assert runs[0].run_id == ctx.run_id
+
+
+class TestRunRepositoryLifecycleHelpers:
+    """Unit tests for the new RunRepository lifecycle helper methods."""
+
+    def test_mark_completed(self, run_repo, project, conversation):
+        run = run_repo.create(
+            project_id=project.project_id,
+            conversation_id=conversation.id,
+            status="running",
+        )
+        run_repo.mark_completed(run.run_id, summary="finished")
+        fetched = run_repo.get_by_id(run.run_id)
+        assert fetched.status == "completed"
+        assert fetched.summary == "finished"
+        assert fetched.completed_at is not None
+
+    def test_mark_failed(self, run_repo, project, conversation):
+        run = run_repo.create(
+            project_id=project.project_id,
+            conversation_id=conversation.id,
+        )
+        run_repo.mark_failed(run.run_id, "RUNTIME_ERROR", "boom")
+        fetched = run_repo.get_by_id(run.run_id)
+        assert fetched.status == "failed"
+        assert "RUNTIME_ERROR" in fetched.summary
+        assert fetched.completed_at is not None
+
+    def test_mark_waiting_approval(self, run_repo, project, conversation):
+        run = run_repo.create(project_id=project.project_id)
+        run_repo.mark_waiting_approval(run.run_id, "approval-999")
+        fetched = run_repo.get_by_id(run.run_id)
+        assert fetched.status == "waiting_approval"
+
+    def test_mark_running(self, run_repo, project):
+        run = run_repo.create(project_id=project.project_id, status="waiting_approval")
+        run_repo.mark_running(run.run_id)
+        fetched = run_repo.get_by_id(run.run_id)
+        assert fetched.status == "running"
+
+    def test_create_with_explicit_run_id(self, run_repo, project):
+        explicit_id = "my-deterministic-run-id"
+        run = run_repo.create(run_id=explicit_id, project_id=project.project_id)
+        assert run.run_id == explicit_id
+        fetched = run_repo.get_by_id(explicit_id)
+        assert fetched.run_id == explicit_id
+
+    def test_mark_completed_not_found_raises(self, run_repo):
+        with pytest.raises(HTTPException):
+            run_repo.mark_completed("nonexistent-run-id")
+
+    def test_mark_failed_not_found_raises(self, run_repo):
+        with pytest.raises(HTTPException):
+            run_repo.mark_failed("nonexistent-run-id", "ERR", "msg")


### PR DESCRIPTION
## Summary

Implements **Phase 1** of Issue #65 "Wire Project Execution Loop — Make Project a Live Governance Boundary".

The data model was already in place. This PR wires the **runtime lifecycle** into it: every project-scoped execution now creates a `RunDB` row with correct `project_id`, transitions through `running → completed / failed / waiting_approval`, and ChatSession-only flows are completely unaffected.

### What changed

- **`swarmmind/services/run_context.py`** (new): frozen `RunContext` dataclass carrying `run_id`, `project_id`, `conversation_id`, `risk_policy`, `approver_role`. Factory methods `for_chat_session()` (project_id=None, no-op governance) and `for_project()`. Includes `RiskPolicy` enum as a typed placeholder for Phase 3 capability classification.

- **`swarmmind/services/run_lifecycle.py`** (new): `RunLifecycleService` with `start / finish / fail / pause_for_approval / resume`. All methods are no-ops when `ctx.project_id is None`, so existing ChatSession paths are unchanged.

- **`swarmmind/repositories/run.py`**: `create()` gains optional `run_id` parameter for deterministic identity. Four new lifecycle helpers: `mark_completed`, `mark_failed`, `mark_waiting_approval`, `mark_running`.

- **`swarmmind/services/conversation_execution.py`**: `stream_message()` gains `run_context: RunContext | None = None`. Calls `lifecycle.start` on entry, `lifecycle.finish` after stream completes, `lifecycle.fail` on unhandled exception. Constructor gains optional `run_lifecycle_service`.

- **`swarmmind/api/routers/projects.py`**: `ProjectsRouterDeps` gains `stream_project_message`. The project streaming endpoint now delegates to it (builds a project-scoped `RunContext` before streaming).

- **`swarmmind/api/supervisor.py`**: `RunLifecycleService` singleton wired in. New `_stream_project_message()` helper builds `RunContext.for_project()` and passes it through to the execution service.

- **`tests/test_run_lifecycle.py`** (new): 22 tests covering start→finish, start→fail, start→pause→resume, ChatSession no-op behavior, RunRepository lifecycle helpers, and RunContext construction.

## Test plan

- [x] `uv run pytest tests/test_run_lifecycle.py -v` — 22 passed
- [x] Full suite run — identical failure set to pre-existing baseline (pre-existing test infrastructure failures unrelated to this change)
- [x] Zero regressions confirmed by stash comparison

## Key decisions

- **`run_context` passed as kwarg, not injected via constructor** — keeps the streaming path self-contained; callers that don't need governance (chat sessions) pass nothing.
- **Lifecycle is a no-op when `project_id is None`** — the same `ConversationExecutionService` serves both chat and project streams; the governance boundary is enforced by `RunContext`, not by separate code paths.
- **`run_id` pre-allocated in `RunContext`** — ensures the same ID flows through `RunDB`, `MessageDB.run_id`, and the stream event, without requiring a round-trip before streaming begins.
- **`RiskPolicy` enum defined in `run_context.py`** — minimal placeholder; full `risk_policy.py` with capability classification table comes in Phase 3.

## Risks

- The `pause_for_approval` / `resume` lifecycle transition surface is present but the capability guard that triggers it is not wired yet (Phase 3). The `waiting_approval` status is a new string value for `RunDB.status`; existing queries filtering on `running | completed | failed | blocked` are unaffected.
- `ConversationExecutionService` constructor now has 20 parameters. The issue noted this. Acceptable for now; a future refactor to a `ExecutionConfig` dataclass is a clean follow-up.

## Follow-up

- **Phase 2** (Issue #65): `POST /projects/{id}/messages` integration test, `ProjectAgentTeamInstance` runtime profile resolver.
- **Phase 3** (Issue #65): `CapabilityGuard` middleware, `AuditWriter`, approval gate, UI approval card.

Closes phase-1 of #65.

https://claude.ai/code/session_014DfxKttXCToWFwe5YkYT4K

---
_Generated by [Claude Code](https://claude.ai/code/session_014DfxKttXCToWFwe5YkYT4K)_