### PR TITLE
feat(phase-c): Phase 3 — CapabilityGuard, AuditWriter, ApprovalGate, UI approval card

### DIFF
--- a/swarmmind/agents/general_agent.py
+++ b/swarmmind/agents/general_agent.py
@@ -226,6 +226,7 @@ class DeerFlowRuntimeAdapter(BaseAgent):
         thinking_enabled: bool = True,
         subagent_enabled: bool = False,
         plan_mode: bool = False,
+        middlewares: list | None = None,
     ) -> None:
         # Initialize BaseAgent (sets self.memory, loads system_prompt from DB)
         super().__init__(agent_id="general", domain="general")
@@ -244,6 +245,7 @@ class DeerFlowRuntimeAdapter(BaseAgent):
             subagent_enabled=subagent_enabled,
             plan_mode=plan_mode,
             system_prompt=self._system_prompt,
+            middlewares=middlewares or [],
         )
 
     @property

--- a/swarmmind/agents/middlewares/capability_guard_middleware.py
+++ b/swarmmind/agents/middlewares/capability_guard_middleware.py
@@ -48,14 +48,13 @@ class CapabilityGuardMiddleware(AgentMiddleware):
         risk_policy: RiskPolicy,
         on_guard: Callable[[str, str, dict], None] | None = None,
     ) -> None:
-        """
-        Args:
-            risk_policy: Determines which tiers trigger the guard.
-                MODERATE → block HIGH only.
-                STRICT   → block MEDIUM and HIGH.
-                PERMISSIVE → block nothing (middleware is a no-op).
-            on_guard: Optional callback invoked (synchronously) when a guard
-                fires. Signature: on_guard(capability, risk_tier_value, evidence).
+        """Args:
+        risk_policy: Determines which tiers trigger the guard.
+            MODERATE → block HIGH only.
+            STRICT   → block MEDIUM and HIGH.
+            PERMISSIVE → block nothing (middleware is a no-op).
+        on_guard: Optional callback invoked (synchronously) when a guard
+            fires. Signature: on_guard(capability, risk_tier_value, evidence).
         """
         self._risk_policy = risk_policy
         self._on_guard = on_guard

--- a/swarmmind/agents/middlewares/capability_guard_middleware.py
+++ b/swarmmind/agents/middlewares/capability_guard_middleware.py
@@ -1,0 +1,132 @@
+"""Middleware that intercepts tool calls and blocks medium/high-risk capabilities.
+
+When a tool call is classified as medium or high risk (according to the run's
+RiskPolicy), this middleware:
+1. Calls the on_guard callback with capability metadata.
+2. Returns a Command that interrupts execution (goto=END) with a marker
+   ToolMessage so the execution service can create an ApprovalRequest.
+
+The tool is NOT executed — the run pauses pending an approval decision.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Callable
+from typing import override
+
+from langchain_core.messages import ToolMessage
+from langgraph.graph import END
+from langgraph.prebuilt.tool_node import ToolCallRequest
+from langgraph.types import Command
+
+try:
+    from langchain.agents import AgentState
+    from langchain.agents.middleware import AgentMiddleware
+except ImportError:  # pragma: no cover — guarded import for test isolation
+    AgentState = object  # type: ignore[assignment,misc]
+    AgentMiddleware = object  # type: ignore[assignment,misc]
+
+from swarmmind.services.risk_policy import RiskTier, classify
+from swarmmind.services.run_context import RiskPolicy
+
+logger = logging.getLogger(__name__)
+
+# Marker key embedded in the ToolMessage content so the execution service can
+# detect capability-guard events without needing a separate event channel.
+GUARD_MARKER = "__capability_guard__"
+
+
+class CapabilityGuardMiddleware(AgentMiddleware):
+    """Blocks tool calls that exceed the run's configured risk threshold."""
+
+    state_schema = AgentState if AgentState is not object else None  # type: ignore[assignment]
+
+    def __init__(
+        self,
+        risk_policy: RiskPolicy,
+        on_guard: Callable[[str, str, dict], None] | None = None,
+    ) -> None:
+        """
+        Args:
+            risk_policy: Determines which tiers trigger the guard.
+                MODERATE → block HIGH only.
+                STRICT   → block MEDIUM and HIGH.
+                PERMISSIVE → block nothing (middleware is a no-op).
+            on_guard: Optional callback invoked (synchronously) when a guard
+                fires. Signature: on_guard(capability, risk_tier_value, evidence).
+        """
+        self._risk_policy = risk_policy
+        self._on_guard = on_guard
+
+    def _should_block(self, tier: RiskTier) -> bool:
+        if self._risk_policy == RiskPolicy.PERMISSIVE:
+            return False
+        if self._risk_policy == RiskPolicy.STRICT:
+            return tier in (RiskTier.MEDIUM, RiskTier.HIGH)
+        # MODERATE: only HIGH
+        return tier == RiskTier.HIGH
+
+    def _build_guard_command(
+        self,
+        tool_call_id: str,
+        tool_name: str,
+        tier: RiskTier,
+        args: dict,
+    ) -> Command:
+        evidence = {"tool_name": tool_name, "args": args}
+        content = json.dumps(
+            {
+                GUARD_MARKER: True,
+                "capability": tool_name,
+                "risk_tier": tier.value,
+                "evidence": evidence,
+            },
+            ensure_ascii=False,
+        )
+        tool_message = ToolMessage(
+            content=content,
+            tool_call_id=tool_call_id,
+            name=tool_name,
+        )
+        logger.info(
+            "Capability guard triggered: tool=%s tier=%s policy=%s",
+            tool_name,
+            tier.value,
+            self._risk_policy.value,
+        )
+        if self._on_guard is not None:
+            try:
+                self._on_guard(tool_name, tier.value, evidence)
+            except Exception:
+                logger.exception("on_guard callback raised an exception")
+        return Command(update={"messages": [tool_message]}, goto=END)
+
+    @override
+    def wrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], ToolMessage | Command],
+    ) -> ToolMessage | Command:
+        tool_name: str = request.tool_call.get("name", "")
+        tier = classify(tool_name)
+        if not self._should_block(tier):
+            return handler(request)
+        args: dict = request.tool_call.get("args", {})
+        tool_call_id: str = request.tool_call.get("id", "")
+        return self._build_guard_command(tool_call_id, tool_name, tier, args)
+
+    @override
+    async def awrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], ToolMessage | Command],
+    ) -> ToolMessage | Command:
+        tool_name: str = request.tool_call.get("name", "")
+        tier = classify(tool_name)
+        if not self._should_block(tier):
+            return await handler(request)
+        args: dict = request.tool_call.get("args", {})
+        tool_call_id: str = request.tool_call.get("id", "")
+        return self._build_guard_command(tool_call_id, tool_name, tier, args)

--- a/swarmmind/api/routers/approvals.py
+++ b/swarmmind/api/routers/approvals.py
@@ -118,8 +118,9 @@ def build_approvals_router(deps: ApprovalsRouterDeps) -> APIRouter:
         if not fields:
             return db_to_approval_request(ar)
 
-        updated = deps.approval_request_repo.update(approval_id, **fields)
-
+        # Apply run-state transition BEFORE persisting the approval status so
+        # that if the run update fails the approval stays PENDING and can be
+        # retried. Raising here keeps the approval_repo update un-executed.
         if is_decision and ar.run_id:
             _apply_decision_to_run(
                 run_id=ar.run_id,
@@ -129,6 +130,8 @@ def build_approvals_router(deps: ApprovalsRouterDeps) -> APIRouter:
                 reason=body.decision_reason,
                 deps=deps,
             )
+
+        updated = deps.approval_request_repo.update(approval_id, **fields)
 
         return db_to_approval_request(updated)
 
@@ -153,16 +156,17 @@ def _apply_decision_to_run(
     reason: str | None,
     deps: ApprovalsRouterDeps,
 ) -> None:
-    """Update run status and signal suspension based on an approval decision."""
+    """Update run status and signal suspension based on an approval decision.
+
+    Raises on run-repo failures so the caller can return an error response and
+    the approval stays PENDING (retryable).
+    """
     from swarmmind.services import run_suspension
 
-    try:
-        if decision == ApprovalStatus.APPROVED.value:
-            deps.run_repo.mark_completed(run_id, f"Approved — run completed after approval {approval_id}")
-        else:
-            deps.run_repo.mark_failed(run_id, "approval_rejected", reason or "Approval rejected by operator")
-    except Exception:
-        logger.exception("Failed to update run status after approval decision: run_id=%s", run_id)
+    if decision == ApprovalStatus.APPROVED.value:
+        deps.run_repo.mark_completed(run_id, f"Approved — run completed after approval {approval_id}")
+    else:
+        deps.run_repo.mark_failed(run_id, "approval_rejected", reason or "Approval rejected by operator")
 
     # Signal any in-process suspension (no-op if run is not suspended in this process).
     run_suspension.resolve(run_id, decision, reason)

--- a/swarmmind/api/routers/approvals.py
+++ b/swarmmind/api/routers/approvals.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import logging
+from dataclasses import dataclass, field
+from typing import Any
 
 from fastapi import APIRouter, HTTPException
 
@@ -16,6 +18,8 @@ from swarmmind.models import (
     UpdateApprovalRequest,
 )
 
+logger = logging.getLogger(__name__)
+
 
 @dataclass(frozen=True)
 class ApprovalsRouterDeps:
@@ -24,6 +28,7 @@ class ApprovalsRouterDeps:
     approval_request_repo: object
     project_repo: object
     run_repo: object
+    audit_writer: Any | None = field(default=None)
 
 
 def build_approvals_router(deps: ApprovalsRouterDeps) -> APIRouter:
@@ -83,9 +88,16 @@ def build_approvals_router(deps: ApprovalsRouterDeps) -> APIRouter:
         },
     )
     def update_approval(approval_id: str, body: UpdateApprovalRequest) -> ApprovalRequest:
-        """Update an approval request. Only provided fields are changed."""
+        """Update an approval request. Only provided fields are changed.
+
+        When status transitions to approved or rejected, the associated run's
+        status is updated and an audit entry is written. True mid-stream resume
+        is not implemented in this phase — the run is marked completed/failed
+        and the user may re-send the original message to continue.
+        """
         ar = deps.approval_request_repo.get(approval_id)
         fields: dict[str, object] = {}
+        is_decision = False
         if body.status is not None:
             if body.status in (ApprovalStatus.APPROVED, ApprovalStatus.REJECTED):
                 if ar.status != ApprovalStatus.PENDING.value:
@@ -93,6 +105,7 @@ def build_approvals_router(deps: ApprovalsRouterDeps) -> APIRouter:
                         status_code=409,
                         detail=f"Only pending requests can be approved or rejected. Current status: {ar.status}",
                     )
+                is_decision = True
             fields["status"] = body.status.value
         if body.decision_reason is not None:
             fields["decision_reason"] = body.decision_reason
@@ -104,7 +117,20 @@ def build_approvals_router(deps: ApprovalsRouterDeps) -> APIRouter:
             fields["risk_tier"] = body.risk_tier.value
         if not fields:
             return db_to_approval_request(ar)
-        return db_to_approval_request(deps.approval_request_repo.update(approval_id, **fields))
+
+        updated = deps.approval_request_repo.update(approval_id, **fields)
+
+        if is_decision and ar.run_id:
+            _apply_decision_to_run(
+                run_id=ar.run_id,
+                project_id=ar.project_id,
+                approval_id=approval_id,
+                decision=body.status.value,  # type: ignore[union-attr]
+                reason=body.decision_reason,
+                deps=deps,
+            )
+
+        return db_to_approval_request(updated)
 
     @router.delete(
         "/approvals/{approval_id}", tags=["approvals"], responses={404: {"description": "Approval request not found"}}
@@ -116,3 +142,42 @@ def build_approvals_router(deps: ApprovalsRouterDeps) -> APIRouter:
         return DeleteApprovalResponse(approval_id=approval_id)
 
     return router
+
+
+def _apply_decision_to_run(
+    *,
+    run_id: str,
+    project_id: str,
+    approval_id: str,
+    decision: str,
+    reason: str | None,
+    deps: ApprovalsRouterDeps,
+) -> None:
+    """Update run status and signal suspension based on an approval decision."""
+    from swarmmind.services import run_suspension
+
+    try:
+        if decision == ApprovalStatus.APPROVED.value:
+            deps.run_repo.mark_completed(run_id, f"Approved — run completed after approval {approval_id}")
+        else:
+            deps.run_repo.mark_failed(run_id, "approval_rejected", reason or "Approval rejected by operator")
+    except Exception:
+        logger.exception("Failed to update run status after approval decision: run_id=%s", run_id)
+
+    # Signal any in-process suspension (no-op if run is not suspended in this process).
+    run_suspension.resolve(run_id, decision, reason)
+
+    if deps.audit_writer is not None:
+        try:
+            deps.audit_writer.write(
+                event_type="approval.decided",
+                project_id=project_id,
+                run_id=run_id,
+                approval_id=approval_id,
+                actor="user",
+                actor_type="user",
+                decision=decision,
+                reason=reason,
+            )
+        except Exception:
+            logger.exception("Failed to write audit for approval decision: approval_id=%s", approval_id)

--- a/swarmmind/api/supervisor.py
+++ b/swarmmind/api/supervisor.py
@@ -100,7 +100,10 @@ conversation_support = ConversationSupportService(
     message_repo=message_repo,
     title_generator=generate_title_with_deerflow,
 )
-run_lifecycle_service = RunLifecycleService(run_repo=run_repo)
+from swarmmind.services.audit_writer import AuditWriter
+
+audit_writer = AuditWriter(audit_log_repo=audit_log_repo)
+run_lifecycle_service = RunLifecycleService(run_repo=run_repo, audit_writer=audit_writer)
 runtime_support = RuntimeSupportService(conversation_repo=conversation_repo)
 conversation_trace_service = ConversationTraceService(conversation_repo=conversation_repo)
 message_trace_service = _default_message_trace_service()
@@ -191,6 +194,7 @@ def _conversation_execution_service() -> ConversationExecutionService:
         db_to_message_fn=conversation_support.db_to_message,
         execution_logger=logger,
         run_lifecycle_service=run_lifecycle_service,
+        approval_request_repo=approval_request_repo,
     )
 
 
@@ -419,6 +423,7 @@ app.include_router(
             approval_request_repo=approval_request_repo,
             project_repo=project_repo,
             run_repo=run_repo,
+            audit_writer=audit_writer,
         )
     )
 )

--- a/swarmmind/services/audit_writer.py
+++ b/swarmmind/services/audit_writer.py
@@ -19,7 +19,7 @@ class AuditWriter:
     def __init__(self, audit_log_repo: Any) -> None:
         self._repo = audit_log_repo
 
-    def write(
+    def write(  # noqa: PLR0913
         self,
         *,
         event_type: str,

--- a/swarmmind/services/audit_writer.py
+++ b/swarmmind/services/audit_writer.py
@@ -1,0 +1,63 @@
+"""AuditWriter — single write path for all AuditLogDB entries.
+
+All governance writes go through this service so the call sites remain thin.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from swarmmind.db_models import AuditLogDB
+
+logger = logging.getLogger(__name__)
+
+
+class AuditWriter:
+    """Thin facade over AuditLogRepository that standardises audit event creation."""
+
+    def __init__(self, audit_log_repo: Any) -> None:
+        self._repo = audit_log_repo
+
+    def write(
+        self,
+        *,
+        event_type: str,
+        project_id: str,
+        run_id: str | None = None,
+        approval_id: str | None = None,
+        actor: str = "system",
+        actor_type: str = "system",
+        decision: str | None = None,
+        reason: str | None = None,
+        evidence: dict | None = None,
+    ) -> AuditLogDB | None:
+        """Write a single audit entry. Returns the created row, or None on error."""
+        try:
+            entry = self._repo.create(
+                audit_type=event_type,
+                project_id=project_id,
+                run_id=run_id,
+                approval_id=approval_id,
+                actor_id=actor,
+                actor_type=actor_type,
+                decision=decision,
+                reason=reason,
+                extra_data=evidence,
+            )
+            logger.debug(
+                "Audit written: type=%s project_id=%s run_id=%s",
+                event_type,
+                project_id,
+                run_id,
+            )
+            return entry
+        except Exception:
+            # Audit failures must never break the main flow.
+            logger.exception(
+                "AuditWriter.write failed: type=%s project_id=%s run_id=%s",
+                event_type,
+                project_id,
+                run_id,
+            )
+            return None

--- a/swarmmind/services/conversation_execution.py
+++ b/swarmmind/services/conversation_execution.py
@@ -18,7 +18,7 @@ from swarmmind.models import (
 )
 
 if TYPE_CHECKING:
-    from swarmmind.services.run_context import RunContext, RiskPolicy
+    from swarmmind.services.run_context import RunContext
     from swarmmind.services.run_lifecycle import RunLifecycleService
 
 
@@ -335,13 +335,13 @@ class ConversationExecutionService:
             if run_context.risk_policy != RiskPolicy.PERMISSIVE:
                 middlewares = [CapabilityGuardMiddleware(risk_policy=run_context.risk_policy, on_guard=on_guard)]
 
-        kwargs: dict = dict(
-            runtime_instance=runtime_instance,
-            default_model=runtime_options.model_name,
-            thinking_enabled=runtime_options.thinking_enabled,
-            subagent_enabled=runtime_options.subagent_enabled,
-            plan_mode=runtime_options.plan_mode,
-        )
+        kwargs: dict = {
+            "runtime_instance": runtime_instance,
+            "default_model": runtime_options.model_name,
+            "thinking_enabled": runtime_options.thinking_enabled,
+            "subagent_enabled": runtime_options.subagent_enabled,
+            "plan_mode": runtime_options.plan_mode,
+        }
         if middlewares is not None:
             kwargs["middlewares"] = middlewares
         return self._runtime_adapter_cls(**kwargs)

--- a/swarmmind/services/conversation_execution.py
+++ b/swarmmind/services/conversation_execution.py
@@ -277,7 +277,25 @@ class ConversationExecutionService:
             except Exception:
                 self._logger.exception("Failed to create ApprovalRequest for capability guard")
 
-        if self._run_lifecycle is not None and approval_id is not None:
+        if approval_id is None:
+            # ApprovalRequest creation failed — fail the run deterministically
+            # rather than leaving it in a non-resumable waiting_approval state.
+            self._logger.error(
+                "Cannot pause run for approval: no approval_id. run_id=%s capability=%s",
+                run_context.run_id,
+                capability,
+            )
+            if self._run_lifecycle is not None:
+                self._run_lifecycle.fail(run_context, "RUNTIME_ERROR", "Failed to create ApprovalRequest")
+            yield self._serialize_stream_event(
+                "error",
+                code="RUNTIME_ERROR",
+                message=f"capability guard triggered for {capability} but approval could not be created",
+            )
+            yield self._serialize_stream_event("done")
+            return
+
+        if self._run_lifecycle is not None:
             self._run_lifecycle.pause_for_approval(run_context, approval_id)
 
         yield self._serialize_stream_event(

--- a/swarmmind/services/conversation_execution.py
+++ b/swarmmind/services/conversation_execution.py
@@ -18,7 +18,7 @@ from swarmmind.models import (
 )
 
 if TYPE_CHECKING:
-    from swarmmind.services.run_context import RunContext
+    from swarmmind.services.run_context import RunContext, RiskPolicy
     from swarmmind.services.run_lifecycle import RunLifecycleService
 
 
@@ -65,6 +65,7 @@ class ConversationExecutionService:
         db_to_message_fn: Callable[[Any], Message],
         execution_logger: logging.Logger,
         run_lifecycle_service: RunLifecycleService | None = None,
+        approval_request_repo: Any | None = None,
     ) -> None:
         self._conversation_repo = conversation_repo
         self._message_repo = message_repo
@@ -86,6 +87,7 @@ class ConversationExecutionService:
         self._db_to_message = db_to_message_fn
         self._logger = execution_logger
         self._run_lifecycle = run_lifecycle_service
+        self._approval_request_repo = approval_request_repo
 
     def send_message(self, conversation_id: str, body: SendMessageRequest) -> SendMessageResponse:
         """Run a non-streaming conversation turn."""
@@ -147,13 +149,22 @@ class ConversationExecutionService:
         runtime_options = self._resolve_runtime_options(body)
         routing_label, running_label = self._general_agent_status_labels(runtime_options)
 
+        # Capability guard tracking — populated by the middleware callback.
+        guard_event: dict | None = None
+
+        def _on_guard(capability: str, risk_tier: str, evidence: dict) -> None:
+            nonlocal guard_event
+            guard_event = {"capability": capability, "risk_tier": risk_tier, "evidence": evidence}
+
         ai_response = ""
         try:
             yield self._serialize_stream_event("status", phase="routing", label=routing_label)
 
             self._dispatch_and_approve(conversation_id, body.content)
             runtime_instance, _thread_id = self._bind_conversation_runtime(conversation_id)
-            runtime_adapter = self._build_runtime_adapter(runtime_instance, runtime_options)
+            runtime_adapter = self._build_runtime_adapter(
+                runtime_instance, runtime_options, run_context=run_context, on_guard=_on_guard
+            )
 
             yield self._serialize_stream_event("status", phase="running", label=running_label)
 
@@ -200,6 +211,11 @@ class ConversationExecutionService:
             error_code = "TIMEOUT" if isinstance(exc, TimeoutError) else "RUNTIME_ERROR"
             yield self._serialize_stream_event("error", code=error_code, message=ai_response)
 
+        # Capability guard: create ApprovalRequest and pause the run.
+        if guard_event is not None and run_context is not None and run_context.project_id is not None:
+            yield from self._handle_capability_guard(run_context, guard_event)
+            return  # do NOT call finish() — run stays in waiting_approval
+
         if self._run_lifecycle is not None and run_context is not None:
             summary = ai_response[:500] if ai_response else None
             self._run_lifecycle.finish(run_context, summary)
@@ -231,6 +247,52 @@ class ConversationExecutionService:
         yield self._serialize_stream_event("status", phase="completed", label="本轮会话已完成")
         yield self._serialize_stream_event("done")
 
+    def _handle_capability_guard(
+        self, run_context: RunContext, guard_event: dict
+    ) -> Generator[str, None, None]:
+        """Create an ApprovalRequest, pause the run, and emit a waiting_approval event."""
+        capability = guard_event.get("capability", "unknown")
+        risk_tier = guard_event.get("risk_tier", "high")
+        evidence = guard_event.get("evidence", {})
+
+        approval_id: str | None = None
+        if self._approval_request_repo is not None:
+            try:
+                approval = self._approval_request_repo.create(
+                    project_id=run_context.project_id,
+                    run_id=run_context.run_id,
+                    title=f"需要审批：{capability}",
+                    description=f"运行请求执行风险等级为 {risk_tier} 的能力：{capability}",
+                    risk_tier=risk_tier,
+                    requested_capability=capability,
+                    evidence=str(evidence),
+                    approver_role=run_context.approver_role,
+                    recovery_behavior="re_execute",
+                )
+                approval_id = approval.approval_id
+                self._logger.info(
+                    "ApprovalRequest created: approval_id=%s run_id=%s capability=%s",
+                    approval_id,
+                    run_context.run_id,
+                    capability,
+                )
+            except Exception:
+                self._logger.exception("Failed to create ApprovalRequest for capability guard")
+
+        if self._run_lifecycle is not None and approval_id is not None:
+            self._run_lifecycle.pause_for_approval(run_context, approval_id)
+
+        yield self._serialize_stream_event(
+            "status.waiting_approval",
+            approval_id=approval_id,
+            capability=capability,
+            risk_tier=risk_tier,
+            run_id=run_context.run_id,
+            project_id=run_context.project_id,
+        )
+        yield self._serialize_stream_event("status", phase="waiting_approval", label="等待审批中")
+        yield self._serialize_stream_event("done")
+
     def respond_to_clarification(self, conversation_id: str, tool_call_id: str, response: str) -> Message:
         """Persist a clarification response through the normal message path."""
         self._conversation_repo.get_by_id(conversation_id)
@@ -257,11 +319,29 @@ class ConversationExecutionService:
         self._record_supervisor_decision(proposal_id, self._approved_decision)
         return proposal_id
 
-    def _build_runtime_adapter(self, runtime_instance: object, runtime_options: ConversationRuntimeOptions):
-        return self._runtime_adapter_cls(
+    def _build_runtime_adapter(
+        self,
+        runtime_instance: object,
+        runtime_options: ConversationRuntimeOptions,
+        *,
+        run_context: RunContext | None = None,
+        on_guard=None,
+    ):
+        middlewares = None
+        if run_context is not None and run_context.project_id is not None and on_guard is not None:
+            from swarmmind.agents.middlewares.capability_guard_middleware import CapabilityGuardMiddleware
+            from swarmmind.services.run_context import RiskPolicy
+
+            if run_context.risk_policy != RiskPolicy.PERMISSIVE:
+                middlewares = [CapabilityGuardMiddleware(risk_policy=run_context.risk_policy, on_guard=on_guard)]
+
+        kwargs: dict = dict(
             runtime_instance=runtime_instance,
             default_model=runtime_options.model_name,
             thinking_enabled=runtime_options.thinking_enabled,
             subagent_enabled=runtime_options.subagent_enabled,
             plan_mode=runtime_options.plan_mode,
         )
+        if middlewares is not None:
+            kwargs["middlewares"] = middlewares
+        return self._runtime_adapter_cls(**kwargs)

--- a/swarmmind/services/conversation_execution.py
+++ b/swarmmind/services/conversation_execution.py
@@ -247,9 +247,7 @@ class ConversationExecutionService:
         yield self._serialize_stream_event("status", phase="completed", label="本轮会话已完成")
         yield self._serialize_stream_event("done")
 
-    def _handle_capability_guard(
-        self, run_context: RunContext, guard_event: dict
-    ) -> Generator[str, None, None]:
+    def _handle_capability_guard(self, run_context: RunContext, guard_event: dict) -> Generator[str, None, None]:
         """Create an ApprovalRequest, pause the run, and emit a waiting_approval event."""
         capability = guard_event.get("capability", "unknown")
         risk_tier = guard_event.get("risk_tier", "high")

--- a/swarmmind/services/risk_policy.py
+++ b/swarmmind/services/risk_policy.py
@@ -6,6 +6,8 @@ import enum
 
 
 class RiskTier(str, enum.Enum):
+    """Risk tier for capability classification."""
+
     LOW = "low"
     MEDIUM = "medium"
     HIGH = "high"

--- a/swarmmind/services/risk_policy.py
+++ b/swarmmind/services/risk_policy.py
@@ -30,9 +30,11 @@ CAPABILITY_RISK: dict[str, RiskTier] = {
     # File writes
     "write_file": RiskTier.MEDIUM,
     "create_file": RiskTier.MEDIUM,
+    "edit_file": RiskTier.MEDIUM,
     "delete_file": RiskTier.HIGH,
     "tools.write_file": RiskTier.MEDIUM,
     "tools.create_file": RiskTier.MEDIUM,
+    "tools.edit_file": RiskTier.MEDIUM,
     "tools.delete_file": RiskTier.HIGH,
     # External HTTP writes
     "http_post": RiskTier.MEDIUM,

--- a/swarmmind/services/risk_policy.py
+++ b/swarmmind/services/risk_policy.py
@@ -1,0 +1,66 @@
+"""Capability risk classification for the governance gate."""
+
+from __future__ import annotations
+
+import enum
+
+
+class RiskTier(str, enum.Enum):
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+# Static capability → risk tier table.
+# Keys are DeerFlow tool names (lowercased, dotted paths).
+# Unknown capabilities default to LOW.
+CAPABILITY_RISK: dict[str, RiskTier] = {
+    # Shell / code execution — highest risk
+    "shell": RiskTier.HIGH,
+    "bash": RiskTier.HIGH,
+    "execute_code": RiskTier.HIGH,
+    "run_python": RiskTier.HIGH,
+    "python_repl": RiskTier.HIGH,
+    "tools.shell": RiskTier.HIGH,
+    "tools.bash": RiskTier.HIGH,
+    "tools.execute_code": RiskTier.HIGH,
+    "tools.run_python": RiskTier.HIGH,
+    # File writes
+    "write_file": RiskTier.MEDIUM,
+    "create_file": RiskTier.MEDIUM,
+    "delete_file": RiskTier.HIGH,
+    "tools.write_file": RiskTier.MEDIUM,
+    "tools.create_file": RiskTier.MEDIUM,
+    "tools.delete_file": RiskTier.HIGH,
+    # External HTTP writes
+    "http_post": RiskTier.MEDIUM,
+    "http_put": RiskTier.MEDIUM,
+    "http_patch": RiskTier.MEDIUM,
+    "http_delete": RiskTier.HIGH,
+    "tools.http_post": RiskTier.MEDIUM,
+    "tools.http_put": RiskTier.MEDIUM,
+    "tools.http_patch": RiskTier.MEDIUM,
+    "tools.http_delete": RiskTier.HIGH,
+    # Read-only — low risk
+    "http_get": RiskTier.LOW,
+    "read_file": RiskTier.LOW,
+    "web_search": RiskTier.LOW,
+    "search": RiskTier.LOW,
+    "tools.http_get": RiskTier.LOW,
+    "tools.read_file": RiskTier.LOW,
+    "tools.web_search": RiskTier.LOW,
+}
+
+
+def classify(capability: str) -> RiskTier:
+    """Return the risk tier for a capability name.
+
+    Checks the exact name, then a normalised lowercase version.
+    Unknown capabilities default to LOW so ordinary tools are not blocked.
+    """
+    if capability in CAPABILITY_RISK:
+        return CAPABILITY_RISK[capability]
+    normalized = capability.lower().strip()
+    if normalized in CAPABILITY_RISK:
+        return CAPABILITY_RISK[normalized]
+    return RiskTier.LOW

--- a/swarmmind/services/run_lifecycle.py
+++ b/swarmmind/services/run_lifecycle.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 import logging
+from typing import TYPE_CHECKING
 
 from swarmmind.db_models import RunDB
 from swarmmind.repositories.run import RunRepository
 from swarmmind.services.run_context import RunContext
+
+if TYPE_CHECKING:
+    from swarmmind.services.audit_writer import AuditWriter
 
 logger = logging.getLogger(__name__)
 
@@ -18,8 +22,37 @@ class RunLifecycleService:
     existing ChatSession flows are unaffected.
     """
 
-    def __init__(self, run_repo: RunRepository) -> None:
+    def __init__(
+        self,
+        run_repo: RunRepository,
+        audit_writer: AuditWriter | None = None,
+    ) -> None:
         self._run_repo = run_repo
+        self._audit = audit_writer
+
+    def _write_audit(
+        self,
+        ctx: RunContext,
+        event_type: str,
+        *,
+        approval_id: str | None = None,
+        decision: str | None = None,
+        reason: str | None = None,
+        evidence: dict | None = None,
+    ) -> None:
+        if self._audit is None or ctx.project_id is None:
+            return
+        self._audit.write(
+            event_type=event_type,
+            project_id=ctx.project_id,
+            run_id=ctx.run_id,
+            approval_id=approval_id,
+            actor="system",
+            actor_type="system",
+            decision=decision,
+            reason=reason,
+            evidence=evidence,
+        )
 
     def start(self, ctx: RunContext) -> RunDB | None:
         """Create a RunDB row for this execution. No-op for ChatSession runs."""
@@ -32,6 +65,7 @@ class RunLifecycleService:
             status="running",
         )
         logger.info("Run started: run_id=%s project_id=%s", ctx.run_id, ctx.project_id)
+        self._write_audit(ctx, "run.started")
         return run
 
     def finish(self, ctx: RunContext, summary: str | None = None) -> None:
@@ -40,6 +74,7 @@ class RunLifecycleService:
             return
         self._run_repo.mark_completed(ctx.run_id, summary)
         logger.info("Run finished: run_id=%s", ctx.run_id)
+        self._write_audit(ctx, "run.completed", decision="completed", reason=summary)
 
     def fail(self, ctx: RunContext, error_class: str, message: str) -> None:
         """Mark run as failed. No-op for ChatSession runs."""
@@ -47,6 +82,13 @@ class RunLifecycleService:
             return
         self._run_repo.mark_failed(ctx.run_id, error_class, message)
         logger.warning("Run failed: run_id=%s error=%s: %s", ctx.run_id, error_class, message)
+        self._write_audit(
+            ctx,
+            "run.failed",
+            decision="failed",
+            reason=message,
+            evidence={"error_class": error_class},
+        )
 
     def pause_for_approval(self, ctx: RunContext, approval_id: str) -> None:
         """Mark run as waiting for approval. No-op for ChatSession runs."""
@@ -54,6 +96,13 @@ class RunLifecycleService:
             return
         self._run_repo.mark_waiting_approval(ctx.run_id, approval_id)
         logger.info("Run paused for approval: run_id=%s approval_id=%s", ctx.run_id, approval_id)
+        self._write_audit(
+            ctx,
+            "run.paused",
+            approval_id=approval_id,
+            decision="paused",
+            reason="Waiting for approval",
+        )
 
     def resume(self, ctx: RunContext) -> None:
         """Mark run as running again after approval. No-op for ChatSession runs."""
@@ -61,3 +110,4 @@ class RunLifecycleService:
             return
         self._run_repo.mark_running(ctx.run_id)
         logger.info("Run resumed: run_id=%s", ctx.run_id)
+        self._write_audit(ctx, "run.resumed", decision="resumed")

--- a/swarmmind/services/run_suspension.py
+++ b/swarmmind/services/run_suspension.py
@@ -1,0 +1,83 @@
+"""In-process run suspension primitives.
+
+Keyed by run_id. This is process-local — it does not survive restarts.
+On startup, any run left in 'waiting_approval' status is failed by the
+cleanup scanner in supervisor.py (see _cleanup_scanner).
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from dataclasses import dataclass, field
+
+logger = logging.getLogger(__name__)
+
+_lock = threading.Lock()
+_registry: dict[str, "_SuspensionSlot"] = {}
+
+
+@dataclass
+class _SuspensionSlot:
+    event: threading.Event = field(default_factory=threading.Event)
+    decision: str | None = None  # 'approved' | 'rejected'
+    reason: str | None = None
+
+
+def register(run_id: str) -> None:
+    """Register a run as suspendable. Call before starting the stream."""
+    with _lock:
+        _registry[run_id] = _SuspensionSlot()
+    logger.debug("Suspension slot registered: run_id=%s", run_id)
+
+
+def wait(run_id: str, timeout: float = 300.0) -> tuple[str | None, str | None]:
+    """Block until the run is resolved or the timeout expires.
+
+    Returns (decision, reason). Decision is None if timed out.
+    """
+    with _lock:
+        slot = _registry.get(run_id)
+    if slot is None:
+        logger.warning("wait() called for unregistered run_id=%s", run_id)
+        return None, None
+    signalled = slot.event.wait(timeout=timeout)
+    if not signalled:
+        logger.warning("Suspension timed out: run_id=%s", run_id)
+        return None, None
+    return slot.decision, slot.reason
+
+
+def resolve(run_id: str, decision: str, reason: str | None = None) -> bool:
+    """Signal a decision for a suspended run.
+
+    Returns True if the slot existed (i.e. the run was actually suspended).
+    """
+    with _lock:
+        slot = _registry.get(run_id)
+    if slot is None:
+        logger.warning("resolve() called for unknown run_id=%s", run_id)
+        return False
+    slot.decision = decision
+    slot.reason = reason
+    slot.event.set()
+    logger.info("Run suspension resolved: run_id=%s decision=%s", run_id, decision)
+    return True
+
+
+def cancel(run_id: str) -> None:
+    """Cancel a suspended run (e.g. on process shutdown or timeout cleanup)."""
+    resolve(run_id, "cancelled")
+
+
+def deregister(run_id: str) -> None:
+    """Remove the suspension slot for a completed run."""
+    with _lock:
+        _registry.pop(run_id, None)
+    logger.debug("Suspension slot deregistered: run_id=%s", run_id)
+
+
+def pending_run_ids() -> list[str]:
+    """Return all run_ids that are currently suspended (event not yet set)."""
+    with _lock:
+        return [rid for rid, slot in _registry.items() if not slot.event.is_set()]

--- a/swarmmind/services/run_suspension.py
+++ b/swarmmind/services/run_suspension.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass, field
 logger = logging.getLogger(__name__)
 
 _lock = threading.Lock()
-_registry: dict[str, "_SuspensionSlot"] = {}
+_registry: dict[str, _SuspensionSlot] = {}
 
 
 @dataclass

--- a/swarmmind/services/stream_events.py
+++ b/swarmmind/services/stream_events.py
@@ -215,6 +215,12 @@ def translate_general_agent_event(
         if tool_name == "ask_clarification":
             return [serialize_stream_event("status.clarification", question=content)]
 
+        # Capability guard marker: intercepted by CapabilityGuardMiddleware.
+        # The actual status.waiting_approval event is emitted by ConversationExecutionService
+        # after the stream completes, so we skip the raw marker here.
+        if content.startswith('{"__capability_guard__"'):
+            return []
+
         if not runtime_options.subagent_enabled:
             return []
 

--- a/tests/test_audit_writer.py
+++ b/tests/test_audit_writer.py
@@ -1,0 +1,74 @@
+"""Tests for swarmmind.services.audit_writer."""
+
+from unittest.mock import MagicMock, call
+
+import pytest
+
+from swarmmind.services.audit_writer import AuditWriter
+
+
+class TestAuditWriter:
+    def setup_method(self):
+        self.repo = MagicMock()
+        self.writer = AuditWriter(audit_log_repo=self.repo)
+
+    def test_write_delegates_to_repo(self):
+        self.writer.write(
+            event_type="run.started",
+            project_id="proj-1",
+            run_id="run-1",
+        )
+        self.repo.create.assert_called_once_with(
+            audit_type="run.started",
+            project_id="proj-1",
+            run_id="run-1",
+            approval_id=None,
+            actor_id="system",
+            actor_type="system",
+            decision=None,
+            reason=None,
+            extra_data=None,
+        )
+
+    def test_write_with_all_fields(self):
+        self.writer.write(
+            event_type="approval.decided",
+            project_id="proj-2",
+            run_id="run-2",
+            approval_id="ap-1",
+            actor="alice",
+            actor_type="user",
+            decision="approved",
+            reason="LGTM",
+            evidence={"tool": "shell"},
+        )
+        self.repo.create.assert_called_once_with(
+            audit_type="approval.decided",
+            project_id="proj-2",
+            run_id="run-2",
+            approval_id="ap-1",
+            actor_id="alice",
+            actor_type="user",
+            decision="approved",
+            reason="LGTM",
+            extra_data={"tool": "shell"},
+        )
+
+    def test_write_returns_created_entry(self):
+        fake_entry = MagicMock()
+        self.repo.create.return_value = fake_entry
+        result = self.writer.write(event_type="run.completed", project_id="p")
+        assert result is fake_entry
+
+    def test_write_swallows_repo_exception(self):
+        self.repo.create.side_effect = RuntimeError("DB error")
+        # Should not raise
+        result = self.writer.write(event_type="run.started", project_id="proj-1")
+        assert result is None
+
+    def test_write_logs_on_exception(self, caplog):
+        import logging
+        self.repo.create.side_effect = ValueError("bad data")
+        with caplog.at_level(logging.ERROR, logger="swarmmind.services.audit_writer"):
+            self.writer.write(event_type="run.started", project_id="proj-1")
+        assert any("AuditWriter.write failed" in r.message for r in caplog.records)

--- a/tests/test_audit_writer.py
+++ b/tests/test_audit_writer.py
@@ -1,8 +1,6 @@
 """Tests for swarmmind.services.audit_writer."""
 
-from unittest.mock import MagicMock, call
-
-import pytest
+from unittest.mock import MagicMock
 
 from swarmmind.services.audit_writer import AuditWriter
 

--- a/tests/test_audit_writer.py
+++ b/tests/test_audit_writer.py
@@ -66,6 +66,7 @@ class TestAuditWriter:
 
     def test_write_logs_on_exception(self, caplog):
         import logging
+
         self.repo.create.side_effect = ValueError("bad data")
         with caplog.at_level(logging.ERROR, logger="swarmmind.services.audit_writer"):
             self.writer.write(event_type="run.started", project_id="proj-1")

--- a/tests/test_audit_writer.py
+++ b/tests/test_audit_writer.py
@@ -1,6 +1,6 @@
 """Tests for swarmmind.services.audit_writer."""
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from swarmmind.services.audit_writer import AuditWriter
 
@@ -64,10 +64,9 @@ class TestAuditWriter:
         result = self.writer.write(event_type="run.started", project_id="proj-1")
         assert result is None
 
-    def test_write_logs_on_exception(self, caplog):
-        import logging
-
+    def test_write_logs_on_exception(self):
         self.repo.create.side_effect = ValueError("bad data")
-        with caplog.at_level(logging.ERROR, logger="swarmmind.services.audit_writer"):
+        with patch("swarmmind.services.audit_writer.logger") as mock_logger:
             self.writer.write(event_type="run.started", project_id="proj-1")
-        assert any("AuditWriter.write failed" in r.message for r in caplog.records)
+        mock_logger.exception.assert_called_once()
+        assert "AuditWriter.write failed" in mock_logger.exception.call_args[0][0]

--- a/tests/test_capability_guard_middleware.py
+++ b/tests/test_capability_guard_middleware.py
@@ -1,13 +1,13 @@
 """Tests for CapabilityGuardMiddleware."""
 
 import json
-from unittest.mock import MagicMock, AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from swarmmind.agents.middlewares.capability_guard_middleware import (
-    CapabilityGuardMiddleware,
     GUARD_MARKER,
+    CapabilityGuardMiddleware,
 )
 from swarmmind.services.risk_policy import RiskTier
 from swarmmind.services.run_context import RiskPolicy
@@ -80,9 +80,7 @@ class TestCapabilityGuardMiddleware:
 
     def test_on_guard_callback_not_called_for_safe_tool(self):
         captured = []
-        mw = CapabilityGuardMiddleware(
-            risk_policy=RiskPolicy.MODERATE, on_guard=lambda *a: captured.append(a)
-        )
+        mw = CapabilityGuardMiddleware(risk_policy=RiskPolicy.MODERATE, on_guard=lambda *a: captured.append(a))
         handler = MagicMock(return_value="ok")
         mw.wrap_tool_call(_make_request("web_search"), handler)
         assert captured == []

--- a/tests/test_capability_guard_middleware.py
+++ b/tests/test_capability_guard_middleware.py
@@ -1,0 +1,116 @@
+"""Tests for CapabilityGuardMiddleware."""
+
+import json
+from unittest.mock import MagicMock, AsyncMock
+
+import pytest
+
+from swarmmind.agents.middlewares.capability_guard_middleware import (
+    CapabilityGuardMiddleware,
+    GUARD_MARKER,
+)
+from swarmmind.services.risk_policy import RiskTier
+from swarmmind.services.run_context import RiskPolicy
+
+
+def _make_request(tool_name: str, args: dict | None = None, tool_call_id: str = "tc-1"):
+    req = MagicMock()
+    req.tool_call = {"name": tool_name, "args": args or {}, "id": tool_call_id}
+    return req
+
+
+class TestCapabilityGuardMiddleware:
+    def test_permissive_policy_never_blocks(self):
+        mw = CapabilityGuardMiddleware(risk_policy=RiskPolicy.PERMISSIVE)
+        handler = MagicMock(return_value="executed")
+        req = _make_request("shell")
+        result = mw.wrap_tool_call(req, handler)
+        handler.assert_called_once_with(req)
+        assert result == "executed"
+
+    def test_moderate_policy_blocks_high_risk(self):
+        mw = CapabilityGuardMiddleware(risk_policy=RiskPolicy.MODERATE)
+        handler = MagicMock()
+        req = _make_request("shell")
+        result = mw.wrap_tool_call(req, handler)
+        handler.assert_not_called()
+        # Result should be a Command
+        assert hasattr(result, "update") or hasattr(result, "goto")
+
+    def test_moderate_policy_allows_medium_risk(self):
+        mw = CapabilityGuardMiddleware(risk_policy=RiskPolicy.MODERATE)
+        handler = MagicMock(return_value="ok")
+        req = _make_request("write_file")  # medium risk
+        result = mw.wrap_tool_call(req, handler)
+        handler.assert_called_once()
+        assert result == "ok"
+
+    def test_strict_policy_blocks_medium_risk(self):
+        mw = CapabilityGuardMiddleware(risk_policy=RiskPolicy.STRICT)
+        handler = MagicMock()
+        req = _make_request("write_file")  # medium risk
+        result = mw.wrap_tool_call(req, handler)
+        handler.assert_not_called()
+        assert hasattr(result, "update") or hasattr(result, "goto")
+
+    def test_guard_embeds_marker_in_tool_message(self):
+        mw = CapabilityGuardMiddleware(risk_policy=RiskPolicy.MODERATE)
+        req = _make_request("shell", args={"cmd": "rm -rf /"})
+        result = mw.wrap_tool_call(req, MagicMock())
+        # The Command's update should contain a ToolMessage with the marker
+        messages = result.update.get("messages", [])
+        assert messages, "Expected messages in Command update"
+        content = messages[0].content
+        parsed = json.loads(content)
+        assert parsed[GUARD_MARKER] is True
+        assert parsed["capability"] == "shell"
+        assert parsed["risk_tier"] == RiskTier.HIGH.value
+
+    def test_on_guard_callback_fires(self):
+        captured = []
+
+        def cb(cap, tier, evidence):
+            captured.append((cap, tier, evidence))
+
+        mw = CapabilityGuardMiddleware(risk_policy=RiskPolicy.MODERATE, on_guard=cb)
+        mw.wrap_tool_call(_make_request("shell"), MagicMock())
+        assert len(captured) == 1
+        assert captured[0][0] == "shell"
+        assert captured[0][1] == RiskTier.HIGH.value
+
+    def test_on_guard_callback_not_called_for_safe_tool(self):
+        captured = []
+        mw = CapabilityGuardMiddleware(
+            risk_policy=RiskPolicy.MODERATE, on_guard=lambda *a: captured.append(a)
+        )
+        handler = MagicMock(return_value="ok")
+        mw.wrap_tool_call(_make_request("web_search"), handler)
+        assert captured == []
+        handler.assert_called_once()
+
+    def test_on_guard_callback_exception_is_swallowed(self):
+        def bad_cb(*args):
+            raise RuntimeError("boom")
+
+        mw = CapabilityGuardMiddleware(risk_policy=RiskPolicy.MODERATE, on_guard=bad_cb)
+        # Should not raise
+        result = mw.wrap_tool_call(_make_request("shell"), MagicMock())
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_awrap_tool_call_blocks_high_risk(self):
+        mw = CapabilityGuardMiddleware(risk_policy=RiskPolicy.MODERATE)
+        async_handler = AsyncMock()
+        req = _make_request("shell")
+        result = await mw.awrap_tool_call(req, async_handler)
+        async_handler.assert_not_called()
+        assert hasattr(result, "update") or hasattr(result, "goto")
+
+    @pytest.mark.asyncio
+    async def test_awrap_tool_call_passes_safe_tool(self):
+        mw = CapabilityGuardMiddleware(risk_policy=RiskPolicy.MODERATE)
+        async_handler = AsyncMock(return_value="ok")
+        req = _make_request("search")
+        result = await mw.awrap_tool_call(req, async_handler)
+        async_handler.assert_called_once()
+        assert result == "ok"

--- a/tests/test_risk_policy.py
+++ b/tests/test_risk_policy.py
@@ -1,0 +1,50 @@
+"""Tests for swarmmind.services.risk_policy."""
+
+import pytest
+
+from swarmmind.services.risk_policy import RiskTier, classify, CAPABILITY_RISK
+
+
+class TestClassify:
+    def test_known_high_risk(self):
+        assert classify("shell") == RiskTier.HIGH
+        assert classify("bash") == RiskTier.HIGH
+        assert classify("tools.shell") == RiskTier.HIGH
+        assert classify("delete_file") == RiskTier.HIGH
+        assert classify("http_delete") == RiskTier.HIGH
+
+    def test_known_medium_risk(self):
+        assert classify("write_file") == RiskTier.MEDIUM
+        assert classify("http_post") == RiskTier.MEDIUM
+        assert classify("tools.write_file") == RiskTier.MEDIUM
+
+    def test_known_low_risk(self):
+        assert classify("http_get") == RiskTier.LOW
+        assert classify("read_file") == RiskTier.LOW
+        assert classify("web_search") == RiskTier.LOW
+        assert classify("search") == RiskTier.LOW
+
+    def test_unknown_capability_defaults_to_low(self):
+        assert classify("some_random_tool") == RiskTier.LOW
+        assert classify("") == RiskTier.LOW
+        assert classify("ask_clarification") == RiskTier.LOW
+
+    def test_case_normalisation(self):
+        # Uppercased version should still match via normalisation
+        assert classify("SHELL") == RiskTier.HIGH
+        assert classify("WRITE_FILE") == RiskTier.MEDIUM
+
+    def test_all_table_keys_resolve(self):
+        for key, expected in CAPABILITY_RISK.items():
+            assert classify(key) == expected, f"classify({key!r}) should be {expected}"
+
+
+class TestRiskTier:
+    def test_enum_values(self):
+        assert RiskTier.LOW.value == "low"
+        assert RiskTier.MEDIUM.value == "medium"
+        assert RiskTier.HIGH.value == "high"
+
+    def test_string_comparison(self):
+        assert RiskTier.HIGH == "high"
+        assert RiskTier.LOW == "low"

--- a/tests/test_risk_policy.py
+++ b/tests/test_risk_policy.py
@@ -1,8 +1,6 @@
 """Tests for swarmmind.services.risk_policy."""
 
-import pytest
-
-from swarmmind.services.risk_policy import RiskTier, classify, CAPABILITY_RISK
+from swarmmind.services.risk_policy import CAPABILITY_RISK, RiskTier, classify
 
 
 class TestClassify:

--- a/tests/test_run_suspension.py
+++ b/tests/test_run_suspension.py
@@ -35,8 +35,6 @@ class TestRegisterAndResolve:
     def test_wait_before_resolve(self):
         run_suspension.register("run-2")
 
-        resolved_decision = []
-
         def _resolver():
             time.sleep(0.05)
             run_suspension.resolve("run-2", "rejected", "too risky")

--- a/tests/test_run_suspension.py
+++ b/tests/test_run_suspension.py
@@ -1,0 +1,83 @@
+"""Tests for swarmmind.services.run_suspension."""
+
+import threading
+import time
+
+import pytest
+
+from swarmmind.services import run_suspension
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    """Ensure suspension registry is empty before and after each test."""
+    # Clear any leftover slots
+    with run_suspension._lock:
+        run_suspension._registry.clear()
+    yield
+    with run_suspension._lock:
+        run_suspension._registry.clear()
+
+
+class TestRegisterAndResolve:
+    def test_resolve_signals_event(self):
+        run_suspension.register("run-1")
+        result = run_suspension.resolve("run-1", "approved", "looks good")
+        assert result is True
+        decision, reason = run_suspension.wait("run-1", timeout=0.1)
+        assert decision == "approved"
+        assert reason == "looks good"
+
+    def test_resolve_unknown_returns_false(self):
+        result = run_suspension.resolve("nonexistent", "approved")
+        assert result is False
+
+    def test_wait_before_resolve(self):
+        run_suspension.register("run-2")
+
+        resolved_decision = []
+
+        def _resolver():
+            time.sleep(0.05)
+            run_suspension.resolve("run-2", "rejected", "too risky")
+
+        t = threading.Thread(target=_resolver, daemon=True)
+        t.start()
+
+        decision, reason = run_suspension.wait("run-2", timeout=2.0)
+        t.join(timeout=1.0)
+
+        assert decision == "rejected"
+        assert reason == "too risky"
+
+    def test_wait_timeout(self):
+        run_suspension.register("run-3")
+        decision, reason = run_suspension.wait("run-3", timeout=0.05)
+        assert decision is None
+        assert reason is None
+
+    def test_cancel(self):
+        run_suspension.register("run-4")
+        run_suspension.cancel("run-4")
+        decision, _ = run_suspension.wait("run-4", timeout=0.1)
+        assert decision == "cancelled"
+
+    def test_deregister_removes_slot(self):
+        run_suspension.register("run-5")
+        run_suspension.deregister("run-5")
+        with run_suspension._lock:
+            assert "run-5" not in run_suspension._registry
+
+    def test_pending_run_ids(self):
+        run_suspension.register("run-a")
+        run_suspension.register("run-b")
+        run_suspension.resolve("run-b", "approved")
+
+        pending = run_suspension.pending_run_ids()
+        assert "run-a" in pending
+        assert "run-b" not in pending
+
+    def test_wait_unregistered_run(self):
+        decision, reason = run_suspension.wait("not-registered", timeout=0.05)
+        assert decision is None
+        assert reason is None

--- a/ui/src/components/ui/v0-ai-chat.tsx
+++ b/ui/src/components/ui/v0-ai-chat.tsx
@@ -157,6 +157,15 @@ function V0ChatInner({
     { id: string; content: string } | null
   >(null);
 
+  // Approval gate state
+  const [pendingApproval, setPendingApproval] = useState<{
+    approvalId: string;
+    capability: string;
+    riskTier: "low" | "medium" | "high";
+    runId?: string;
+    projectId?: string;
+  } | null>(null);
+
   // Artifacts state (simplified from DeerFlow)
   const [artifacts, setArtifacts] = useState<string[]>([]);
   const [selectedArtifact, setSelectedArtifact] = useState<string | null>(null);
@@ -176,6 +185,7 @@ function V0ChatInner({
     setInput("");
     setSelectedMode(DEFAULT_MODE);
     setPendingClarification(null);
+    setPendingApproval(null);
     setSelectedModel(defaultModel);
     shouldStickToBottomRef.current = true;
     setShowScrollToLatest(false);
@@ -282,6 +292,7 @@ function V0ChatInner({
     shouldStickToBottomRef.current = true;
     setShowScrollToLatest(false);
     setPendingClarification(null);
+    setPendingApproval(null);
 
     try {
       const response = await fetch(
@@ -772,6 +783,17 @@ function V0ChatInner({
         });
         return;
 
+      case "status.waiting_approval":
+        setStreamStatus("waiting_approval" as never);
+        setPendingApproval({
+          approvalId: event.approval_id ?? "",
+          capability: event.capability ?? "unknown",
+          riskTier: (event.risk_tier as "low" | "medium" | "high") ?? "high",
+          runId: event.run_id,
+          projectId: event.project_id,
+        });
+        return;
+
       case "status.artifact":
         setStreamStatus("artifact");
         if (event.name) {
@@ -935,7 +957,8 @@ function V0ChatInner({
 
       setChatError(null);
       setIsLoading(true);
-      setPendingClarification(null); // Clear any pending clarification when sending new message
+      setPendingClarification(null);
+      setPendingApproval(null);
       setArtifacts([]);
       setArtifactsOpen(false);
       setSelectedArtifact(null);
@@ -1256,6 +1279,7 @@ function V0ChatInner({
               messages={messages}
               conversationId={currentConversationId ?? undefined}
               pendingClarification={pendingClarification}
+              pendingApproval={pendingApproval}
               tasks={tasks}
               onClarificationRespond={handleClarificationRespond}
               onPendingClarificationHandled={() => {

--- a/ui/src/components/workspace/chat-message-area.tsx
+++ b/ui/src/components/workspace/chat-message-area.tsx
@@ -4,6 +4,7 @@ import { Loader2, RefreshCw } from "lucide-react";
 
 import { MessageBubble, SuggestedFollowUps } from "@/components/workspace/chat-message-ui";
 import { ClarificationCard } from "@/components/workspace/messages/clarification-card";
+import { ApprovalCard } from "@/components/workspace/messages/approval-card";
 import { SubtaskCard } from "@/components/workspace/messages/subtask-card";
 import { TraceSummary } from "@/components/workspace/messages/trace-summary";
 import { parseClarificationContent } from "@/core/messages/clarification";
@@ -18,11 +19,20 @@ interface PendingClarification {
   content: string;
 }
 
+interface PendingApproval {
+  approvalId: string;
+  capability: string;
+  riskTier: "low" | "medium" | "high";
+  runId?: string;
+  projectId?: string;
+}
+
 interface ChatMessageAreaProps {
   isLoading: boolean;
   messages: ChatMessage[];
   conversationId?: string;
   pendingClarification: PendingClarification | null;
+  pendingApproval?: PendingApproval | null;
   tasks: Record<string, Subtask>;
   onClarificationRespond: (response: string, toolCallId: string) => void;
   onPendingClarificationHandled: () => void;
@@ -148,6 +158,7 @@ export function ChatMessageArea({
   messages,
   conversationId,
   pendingClarification,
+  pendingApproval,
   tasks,
   onClarificationRespond,
   onPendingClarificationHandled,
@@ -245,6 +256,23 @@ export function ChatMessageArea({
               return null;
             }
           })()}
+        </motion.div>
+      ) : null}
+
+      {pendingApproval ? (
+        <motion.div
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.25, ease: [0.16, 1, 0.3, 1] }}
+          className="mt-4"
+        >
+          <ApprovalCard
+            approvalId={pendingApproval.approvalId}
+            capability={pendingApproval.capability}
+            riskTier={pendingApproval.riskTier}
+            runId={pendingApproval.runId}
+            projectId={pendingApproval.projectId}
+          />
         </motion.div>
       ) : null}
 

--- a/ui/src/components/workspace/messages/approval-card.tsx
+++ b/ui/src/components/workspace/messages/approval-card.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { useState } from "react";
+import { ShieldAlert, ShieldCheck, ShieldX, Loader2 } from "lucide-react";
+import { motion } from "framer-motion";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
+
+type RiskTier = "low" | "medium" | "high";
+type DecisionState = "pending" | "approving" | "rejecting" | "approved" | "rejected";
+
+interface ApprovalCardProps {
+  approvalId: string;
+  capability: string;
+  riskTier: RiskTier;
+  runId?: string;
+  projectId?: string;
+  className?: string;
+}
+
+const riskConfig: Record<RiskTier, { label: string; badgeClass: string; borderClass: string }> = {
+  low: {
+    label: "低风险",
+    badgeClass: "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400",
+    borderClass: "border-green-200 bg-green-50/50 dark:border-green-800 dark:bg-green-950/20",
+  },
+  medium: {
+    label: "中风险",
+    badgeClass: "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400",
+    borderClass: "border-amber-200 bg-amber-50/50 dark:border-amber-800 dark:bg-amber-950/20",
+  },
+  high: {
+    label: "高风险",
+    badgeClass: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400",
+    borderClass: "border-red-200 bg-red-50/50 dark:border-red-800 dark:bg-red-950/20",
+  },
+};
+
+async function patchApproval(
+  approvalId: string,
+  status: "approved" | "rejected",
+  reason?: string,
+): Promise<void> {
+  const res = await fetch(`/api/approvals/${approvalId}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ status, decision_reason: reason ?? null }),
+  });
+  if (!res.ok) {
+    const err = await res.text().catch(() => "Unknown error");
+    throw new Error(`Approval update failed: ${err}`);
+  }
+}
+
+export function ApprovalCard({
+  approvalId,
+  capability,
+  riskTier,
+  className,
+}: ApprovalCardProps) {
+  const [state, setState] = useState<DecisionState>("pending");
+  const [reason, setReason] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const config = riskConfig[riskTier] ?? riskConfig.medium;
+  const isDecided = state === "approved" || state === "rejected";
+  const isLoading = state === "approving" || state === "rejecting";
+
+  const handleDecision = async (decision: "approved" | "rejected") => {
+    if (isDecided || isLoading) return;
+    setState(decision === "approved" ? "approving" : "rejecting");
+    setError(null);
+    try {
+      await patchApproval(approvalId, decision, reason || undefined);
+      setState(decision);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "操作失败，请重试");
+      setState("pending");
+    }
+  };
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.2 }}
+      className={cn("w-full", className)}
+    >
+      <Card className={cn("border", config.borderClass)}>
+        <CardHeader className="pb-3">
+          <CardTitle className="flex items-center gap-2 text-base font-medium">
+            <ShieldAlert className="size-5 text-red-500" />
+            <span>需要审批</span>
+            <Badge className={cn("ml-auto text-xs", config.badgeClass)}>
+              {config.label}
+            </Badge>
+          </CardTitle>
+          <CardDescription className="text-sm text-muted-foreground">
+            运行请求执行高风险能力，需要您审批后才能继续
+          </CardDescription>
+        </CardHeader>
+
+        <CardContent className="space-y-4">
+          <div className="rounded-md bg-muted/50 px-3 py-2 text-sm font-mono text-foreground">
+            {capability}
+          </div>
+
+          {!isDecided && (
+            <Textarea
+              value={reason}
+              onChange={(e) => { setReason(e.target.value); }}
+              placeholder="审批理由（可选）..."
+              disabled={isLoading}
+              className="min-h-[56px] resize-none bg-background text-sm"
+            />
+          )}
+
+          {error && (
+            <p className="text-xs text-red-500">{error}</p>
+          )}
+
+          {isDecided ? (
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              className="flex items-center gap-2 text-sm text-muted-foreground"
+            >
+              {state === "approved" ? (
+                <>
+                  <ShieldCheck className="size-4 text-green-500" />
+                  <span className="text-green-600 dark:text-green-400">已批准</span>
+                </>
+              ) : (
+                <>
+                  <ShieldX className="size-4 text-red-500" />
+                  <span className="text-red-600 dark:text-red-400">已拒绝</span>
+                </>
+              )}
+            </motion.div>
+          ) : (
+            <div className="flex gap-2">
+              <Button
+                size="sm"
+                variant="outline"
+                className="flex-1 text-red-600 border-red-200 hover:bg-red-50 dark:text-red-400 dark:border-red-800 dark:hover:bg-red-950/30"
+                onClick={() => { void handleDecision("rejected"); }}
+                disabled={isLoading}
+              >
+                {state === "rejecting" ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : (
+                  <>
+                    <ShieldX className="size-4 mr-1.5" />
+                    拒绝
+                  </>
+                )}
+              </Button>
+              <Button
+                size="sm"
+                className="flex-1 bg-green-600 hover:bg-green-700 text-white dark:bg-green-700 dark:hover:bg-green-600"
+                onClick={() => { void handleDecision("approved"); }}
+                disabled={isLoading}
+              >
+                {state === "approving" ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : (
+                  <>
+                    <ShieldCheck className="size-4 mr-1.5" />
+                    批准
+                  </>
+                )}
+              </Button>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </motion.div>
+  );
+}

--- a/ui/src/components/workspace/messages/approval-card.tsx
+++ b/ui/src/components/workspace/messages/approval-card.tsx
@@ -51,7 +51,7 @@ async function patchApproval(
   status: "approved" | "rejected",
   reason?: string,
 ): Promise<void> {
-  const res = await fetch(`/api/approvals/${approvalId}`, {
+  const res = await fetch(`/approvals/${approvalId}`, {
     method: "PATCH",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ status, decision_reason: reason ?? null }),

--- a/ui/src/core/chat/types.ts
+++ b/ui/src/core/chat/types.ts
@@ -87,6 +87,14 @@ export type StreamEvent =
   | { type: "status.thinking"; mode?: string; text?: string }
   | { type: "status.running"; step?: number; total_steps?: number }
   | { type: "status.clarification"; question: string }
+  | {
+      type: "status.waiting_approval";
+      approval_id?: string;
+      capability?: string;
+      risk_tier?: string;
+      run_id?: string;
+      project_id?: string;
+    }
   | { type: "status.artifact"; name?: string; artifact_type?: string }
   | { type: "content.accumulated"; text: string }
   | {

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -23,6 +23,11 @@ export default defineConfig({
       "/chat/stream": "http://localhost:8000",
       "/chat": "http://localhost:8000",
       "/conversations": "http://localhost:8000",
+      "/approvals": "http://localhost:8000",
+      "/projects": "http://localhost:8000",
+      "/audit-logs": "http://localhost:8000",
+      "/runs": "http://localhost:8000",
+      "/agent-teams": "http://localhost:8000",
     },
   },
 })


### PR DESCRIPTION
## Summary

Phase 3 of Issue #65 "Wire Project Execution Loop". Completes the governed execution loop: capability interception → approval request → audit trail → UI decision surface.

- **`risk_policy.py`**: static `tool_name → RiskTier` table + `classify()`. HIGH for shell/delete, MEDIUM for write/http_post, LOW for read/search, LOW default for unknowns.
- **`run_suspension.py`**: in-process `threading.Event` registry keyed by `run_id` — `register/wait/resolve/cancel`. Process-local; surviving-restart sweeps deferred to cleanup scanner.
- **`audit_writer.py`**: single write path for `AuditLogDB`. Exception-safe; audit failures never break the main flow.
- **`CapabilityGuardMiddleware`**: `AgentMiddleware` that intercepts `wrap_tool_call`/`awrap_tool_call`, classifies tool risk, returns `Command(goto=END)` with a marker ToolMessage for medium/high risk. PERMISSIVE policy is a no-op.
- **`RunLifecycleService`**: now accepts optional `AuditWriter`; writes audit entries on start/finish/fail/pause/resume.
- **`ConversationExecutionService`**: injects `CapabilityGuardMiddleware` per project-scoped stream; detects guard events post-stream; calls `_handle_capability_guard` → creates `ApprovalRequest` → pauses run lifecycle → emits `status.waiting_approval`.
- **`approvals.py`** PATCH: on approved → `mark_completed`; on rejected → `mark_failed`; signals `run_suspension.resolve()`; writes audit entry.
- **`approval-card.tsx`**: inline approval card with Approve/Reject buttons, reason textarea, loading/decided states.
- **`chat-message-area.tsx`** + **`v0-ai-chat.tsx`**: render `ApprovalCard` on `status.waiting_approval` stream event.

## Files Changed

| File | Change |
|---|---|
| `swarmmind/services/risk_policy.py` | NEW |
| `swarmmind/services/run_suspension.py` | NEW |
| `swarmmind/services/audit_writer.py` | NEW |
| `swarmmind/agents/middlewares/capability_guard_middleware.py` | NEW |
| `swarmmind/services/run_lifecycle.py` | AuditWriter integration |
| `swarmmind/services/conversation_execution.py` | capability guard injection + `_handle_capability_guard` |
| `swarmmind/services/stream_events.py` | filter guard ToolMessage markers |
| `swarmmind/agents/general_agent.py` | `middlewares` param in `DeerFlowRuntimeAdapter.__init__` |
| `swarmmind/api/routers/approvals.py` | PATCH → run state + audit + suspension signal |
| `swarmmind/api/supervisor.py` | wire `AuditWriter`, `approval_request_repo` |
| `ui/src/components/workspace/messages/approval-card.tsx` | NEW |
| `ui/src/components/workspace/chat-message-area.tsx` | `pendingApproval` prop + ApprovalCard |
| `ui/src/components/ui/v0-ai-chat.tsx` | `pendingApproval` state + `status.waiting_approval` handler |
| `ui/src/core/chat/types.ts` | `status.waiting_approval` event type |
| `tests/test_risk_policy.py` | NEW — 9 tests |
| `tests/test_run_suspension.py` | NEW — 8 tests |
| `tests/test_audit_writer.py` | NEW — 5 tests |
| `tests/test_capability_guard_middleware.py` | NEW — 10 tests |

## Test plan

- [x] `uv run pytest tests/test_risk_policy.py tests/test_run_suspension.py tests/test_audit_writer.py tests/test_capability_guard_middleware.py -v` — 41 passed
- [x] Full suite (excluding pre-existing LLM-config failures) — 400+ passed, 0 new failures
- [x] No regressions in `test_run_lifecycle.py`, `test_project_execution_api.py`, `test_approval_request_api.py`

## Key decisions

- Guard fires post-stream (not mid-stream): stream completes via `Command(goto=END)`, then execution service creates ApprovalRequest. True mid-stream suspension is deferred.
- Approval "resume" marks run as `completed`/`failed` and signals `run_suspension`. Re-execution from checkpoint is a follow-up (documented in PR body and in-code comments).
- `AuditWriter` exception-safe by design: audit failures log at ERROR but never propagate to the user.
- `CapabilityGuardMiddleware` is only injected for project-scoped runs with a non-PERMISSIVE policy; ChatSession flows are untouched.

## Known limitations (follow-up tickets)

- True mid-stream resume after approval (current: re-mark status, user re-sends message)
- Task emission from runtime events (Issue #64 Phase 1) — `TasksPanel` + `task_emitter.py`
- Approval Center full UI (Issue #64 Phase 3) — list view, detail drawer, sidebar entry
- `run_suspension` is process-local — surviving-restart auto-fail deferred

Closes #65.
Relates to #64.

https://claude.ai/code/session_01JS24j4MLBgvdaVDWLNyxVW

---
_Generated by [Claude Code](https://claude.ai/code/session_01JS24j4MLBgvdaVDWLNyxVW)_