### PR TITLE
feat(phase-c): Task Kanban, Audit Timeline, Approval badge — close #64 deferred items

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -16,7 +16,7 @@ import { Button } from "@/components/ui/button";
 import { ApprovalsPage } from "@/components/workspace/approvals/approvals-page";
 import { ProjectPage } from "@/components/workspace/project/project-page";
 import { ProjectEmptyState } from "@/components/workspace/project/project-empty-state";
-import { promoteConversation } from "@/core/projects/api";
+import { listApprovals, promoteConversation } from "@/core/projects/api";
 import {
   Card,
   CardContent,
@@ -172,6 +172,7 @@ export default function App() {
   const [searchQuery, setSearchQuery] = useState("");
   const [isRecentLoading, setIsRecentLoading] = useState(true);
   const [isPromoting, setIsPromoting] = useState(false);
+  const [pendingApprovalsCount, setPendingApprovalsCount] = useState(0);
 
   const fetchRecentConversations = useCallback(async () => {
     try {
@@ -309,6 +310,17 @@ export default function App() {
     return () => {
       window.removeEventListener("popstate", handlePopState);
     };
+  }, []);
+
+  useEffect(() => {
+    function fetchPendingCount() {
+      listApprovals({ status: "pending" })
+        .then((res) => { setPendingApprovalsCount(res.total); })
+        .catch(() => { /* non-critical; keep stale count */ });
+    }
+    fetchPendingCount();
+    const interval = setInterval(fetchPendingCount, 30000);
+    return () => { clearInterval(interval); };
   }, []);
 
   const handleViewChange = (view: SidebarView) => {
@@ -545,6 +557,7 @@ export default function App() {
         onSearchQueryChange={setSearchQuery}
         isRecentLoading={isRecentLoading}
         activeConversationId={activeConversationId}
+        pendingApprovalsCount={pendingApprovalsCount}
       />
 
       <main

--- a/ui/src/components/ui/sidebar.tsx
+++ b/ui/src/components/ui/sidebar.tsx
@@ -232,6 +232,7 @@ interface SidebarProps {
   onSearchQueryChange?: (query: string) => void
   isRecentLoading?: boolean
   activeConversationId?: string
+  pendingApprovalsCount?: number
 }
 
 export function Sidebar({
@@ -247,6 +248,7 @@ export function Sidebar({
   onSearchQueryChange,
   isRecentLoading = false,
   activeConversationId,
+  pendingApprovalsCount = 0,
 }: SidebarProps) {
   const [isOpen, setIsOpen] = React.useState(false)
   const [deletingConversationId, setDeletingConversationId] = React.useState<string | null>(null)
@@ -374,6 +376,9 @@ export function Sidebar({
                   active={activeView === item.value}
                   icon={item.icon}
                   label={item.label}
+                  badge={item.value === "approvals" && pendingApprovalsCount > 0
+                    ? String(pendingApprovalsCount)
+                    : undefined}
                   onClick={() => { handleSelect(item.value); }}
                 />
               ))}
@@ -510,19 +515,25 @@ export function Sidebar({
 
       <div className="mt-auto flex flex-col items-center gap-3">
         {railBottomItems.map((item) => (
-          <Button
-            key={item.value}
-            variant="ghost"
-            size="icon"
-            onClick={() => { handleSelect(item.value); }}
-            title={item.label}
-            className={cn(
-              "size-11 rounded-2xl border border-transparent text-muted-foreground hover:bg-sidebar-accent/75 hover:text-foreground",
-              activeView === item.value && "bg-sidebar-accent text-foreground",
+          <div key={item.value} className="relative">
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => { handleSelect(item.value); }}
+              title={item.label}
+              className={cn(
+                "size-11 rounded-2xl border border-transparent text-muted-foreground hover:bg-sidebar-accent/75 hover:text-foreground",
+                activeView === item.value && "bg-sidebar-accent text-foreground",
+              )}
+            >
+              {item.icon}
+            </Button>
+            {item.value === "approvals" && pendingApprovalsCount > 0 && (
+              <span className="absolute right-1.5 top-1.5 flex size-4 items-center justify-center rounded-full bg-amber-500 text-[9px] font-bold text-white">
+                {pendingApprovalsCount > 9 ? "9+" : pendingApprovalsCount}
+              </span>
             )}
-          >
-            {item.icon}
-          </Button>
+          </div>
         ))}
       </div>
     </div>

--- a/ui/src/components/workspace/project/audit-timeline.tsx
+++ b/ui/src/components/workspace/project/audit-timeline.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Loader2 } from "lucide-react";
+
+import { getProjectAuditLogs } from "@/core/projects/api";
+import type { RunEvent } from "@/core/projects/types";
+import { cn } from "@/lib/utils";
+
+interface AuditTimelineProps {
+  projectId: string;
+}
+
+function eventLabel(auditType: string): string {
+  const map: Record<string, string> = {
+    "run.started": "运行开始",
+    "run.completed": "运行完成",
+    "run.failed": "运行失败",
+    "run.resumed": "运行恢复",
+    "task.created": "任务创建",
+    "task.started": "任务开始",
+    "task.completed": "任务完成",
+    "task.failed": "任务失败",
+    "task.blocked": "任务阻塞",
+    "approval.requested": "审批请求",
+    "approval.decided": "审批决定",
+    "approval.approved": "审批通过",
+    "approval.rejected": "审批拒绝",
+  };
+  return map[auditType] ?? auditType;
+}
+
+function eventDotClass(auditType: string): string {
+  if (auditType.includes("failed") || auditType.includes("rejected")) {
+    return "bg-red-400 dark:bg-red-600";
+  }
+  if (auditType.includes("completed") || auditType.includes("approved") || auditType.includes("resumed")) {
+    return "bg-green-400 dark:bg-green-600";
+  }
+  if (auditType.includes("approval") || auditType.includes("blocked")) {
+    return "bg-amber-400 dark:bg-amber-600";
+  }
+  return "bg-border";
+}
+
+function eventLabelClass(auditType: string): string {
+  if (auditType.includes("failed") || auditType.includes("rejected")) {
+    return "text-red-600 dark:text-red-400";
+  }
+  if (auditType.includes("completed") || auditType.includes("approved")) {
+    return "text-green-600 dark:text-green-400";
+  }
+  return "text-foreground";
+}
+
+function formatDateTime(isoString: string): string {
+  const date = new Date(isoString);
+  if (Number.isNaN(date.getTime())) return isoString;
+  return new Intl.DateTimeFormat("zh-CN", {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  }).format(date);
+}
+
+function formatDay(isoString: string): string {
+  const date = new Date(isoString);
+  if (Number.isNaN(date.getTime())) return isoString;
+  return new Intl.DateTimeFormat("zh-CN", {
+    month: "long",
+    day: "numeric",
+  }).format(date);
+}
+
+function isSameDay(a: string, b: string): boolean {
+  return new Date(a).toDateString() === new Date(b).toDateString();
+}
+
+export function AuditTimeline({ projectId }: AuditTimelineProps) {
+  const [events, setEvents] = useState<RunEvent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    getProjectAuditLogs(projectId)
+      .then(({ items }) => {
+        if (!cancelled) {
+          setEvents(items);
+          setLoading(false);
+        }
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "加载失败");
+          setLoading(false);
+        }
+      });
+
+    return () => { cancelled = true; };
+  }, [projectId]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-8">
+        <Loader2 className="size-4 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return <p className="text-xs text-destructive">{error}</p>;
+  }
+
+  if (events.length === 0) {
+    return <p className="py-4 text-center text-xs text-muted-foreground">暂无审计记录</p>;
+  }
+
+  return (
+    <ol className="relative space-y-0 border-l border-border pl-5">
+      {events.map((evt, idx) => {
+        const showDayLabel =
+          idx === 0 || !isSameDay(evt.created_at, events[idx - 1]!.created_at);
+
+        return (
+          <li key={evt.audit_id} className="relative pb-4 last:pb-0">
+            {/* Day separator */}
+            {showDayLabel && (
+              <div className="mb-3 -ml-5 pl-5 pt-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/70">
+                {formatDay(evt.created_at)}
+              </div>
+            )}
+
+            {/* Timeline dot */}
+            <span
+              className={cn(
+                "absolute -left-[21px] top-1 size-2.5 rounded-full border-2 border-background",
+                eventDotClass(evt.audit_type),
+              )}
+            />
+
+            {/* Content */}
+            <div className="space-y-0.5">
+              <div className="flex items-baseline gap-2">
+                <span className={cn("text-[12px] font-medium", eventLabelClass(evt.audit_type))}>
+                  {eventLabel(evt.audit_type)}
+                </span>
+                <span className="text-[10px] text-muted-foreground">
+                  {formatDateTime(evt.created_at)}
+                </span>
+              </div>
+
+              {evt.actor_id && (
+                <p className="text-[11px] text-muted-foreground">
+                  操作者: <span className="text-foreground/80">{evt.actor_id}</span>
+                </p>
+              )}
+              {evt.decision && (
+                <p className="text-[11px] text-muted-foreground">
+                  决定: <span className="text-foreground/80">{evt.decision}</span>
+                </p>
+              )}
+              {evt.reason && (
+                <p className="text-[11px] text-muted-foreground line-clamp-2">
+                  {evt.reason}
+                </p>
+              )}
+              {evt.run_id && (
+                <p className="font-mono text-[10px] text-muted-foreground/60">
+                  run:{evt.run_id.slice(0, 8)}
+                </p>
+              )}
+            </div>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}

--- a/ui/src/components/workspace/project/audit-timeline.tsx
+++ b/ui/src/components/workspace/project/audit-timeline.tsx
@@ -123,7 +123,7 @@ export function AuditTimeline({ projectId }: AuditTimelineProps) {
     <ol className="relative space-y-0 border-l border-border pl-5">
       {events.map((evt, idx) => {
         const showDayLabel =
-          idx === 0 || !isSameDay(evt.created_at, events[idx - 1]!.created_at);
+          idx === 0 || !isSameDay(evt.created_at, events[idx - 1].created_at);
 
         return (
           <li key={evt.audit_id} className="relative pb-4 last:pb-0">

--- a/ui/src/components/workspace/project/project-page.tsx
+++ b/ui/src/components/workspace/project/project-page.tsx
@@ -19,6 +19,8 @@ import { ApprovalCard } from "@/components/workspace/messages/approval-card";
 import { ProjectComposer } from "./project-composer";
 import { ProjectActiveRun } from "./project-active-run";
 import { ProjectRunDetail } from "./project-run-detail";
+import { TasksPanel } from "./tasks-panel";
+import { AuditTimeline } from "./audit-timeline";
 
 interface ProjectPageProps {
   projectId: string;
@@ -38,6 +40,7 @@ export function ProjectPage({ projectId }: ProjectPageProps) {
     approvalId: string;
     capability: string;
   } | null>(null);
+  const [taskRefreshTick, setTaskRefreshTick] = useState(0);
 
   useEffect(() => {
     let cancelled = false;
@@ -69,8 +72,9 @@ export function ProjectPage({ projectId }: ProjectPageProps) {
   }
 
   function handleTerminal(status: "completed" | "failed") {
-    void status; // acknowledge the parameter
+    void status;
     setMode("idle");
+    setTaskRefreshTick((t) => t + 1);
     getProjectOverview(projectId).then(setOverview).catch(() => {});
   }
 
@@ -96,7 +100,7 @@ export function ProjectPage({ projectId }: ProjectPageProps) {
     );
   }
 
-  const { project, stats, recent_tasks, recent_artifacts, recent_runs } = overview;
+  const { project, stats, recent_artifacts, recent_runs } = overview;
 
   return (
     <div className="mx-auto max-w-3xl space-y-6 p-6">
@@ -176,20 +180,10 @@ export function ProjectPage({ projectId }: ProjectPageProps) {
         />
       )}
 
-      {/* Recent tasks */}
-      {recent_tasks.length > 0 && (
-        <Section title="近期任务">
-          <ul className="space-y-1.5">
-            {recent_tasks.map((task) => (
-              <li key={task.task_id} className="flex items-center gap-2 text-sm">
-                <StatusDot status={task.status} />
-                <span className="flex-1 truncate">{task.title}</span>
-                <span className="shrink-0 text-[11px] text-muted-foreground">{task.status}</span>
-              </li>
-            ))}
-          </ul>
-        </Section>
-      )}
+      {/* Task Kanban */}
+      <Section title="任务看板">
+        <TasksPanel projectId={projectId} refreshTick={taskRefreshTick} />
+      </Section>
 
       {/* Recent runs */}
       {recent_runs.length > 0 && (
@@ -230,6 +224,11 @@ export function ProjectPage({ projectId }: ProjectPageProps) {
           </ul>
         </Section>
       )}
+
+      {/* Audit timeline */}
+      <Section title="审计时间线">
+        <AuditTimeline projectId={projectId} />
+      </Section>
 
       {/* Run detail drawer */}
       {selectedRun && (

--- a/ui/src/components/workspace/project/tasks-panel.tsx
+++ b/ui/src/components/workspace/project/tasks-panel.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { CheckCircle2, Circle, Clock, Loader2, OctagonX } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { getProjectTasks } from "@/core/projects/api";
+import type { Task } from "@/core/projects/types";
+import { cn } from "@/lib/utils";
+
+interface TasksPanelProps {
+  projectId: string;
+  /** When true the panel refetches tasks (e.g. after a run completes). */
+  refreshTick?: number;
+}
+
+type KanbanColumn = {
+  key: string;
+  label: string;
+  statuses: string[];
+  icon: React.ReactNode;
+  className: string;
+};
+
+const COLUMNS: KanbanColumn[] = [
+  {
+    key: "todo",
+    label: "待办",
+    statuses: ["todo", "pending", "created"],
+    icon: <Circle className="size-3.5 text-muted-foreground" />,
+    className: "border-border bg-muted/30",
+  },
+  {
+    key: "in_progress",
+    label: "进行中",
+    statuses: ["in_progress", "running"],
+    icon: <Clock className="size-3.5 text-blue-500" />,
+    className: "border-blue-200 bg-blue-50/40 dark:border-blue-800 dark:bg-blue-950/20",
+  },
+  {
+    key: "blocked",
+    label: "阻塞",
+    statuses: ["blocked", "awaiting_approval"],
+    icon: <OctagonX className="size-3.5 text-amber-500" />,
+    className: "border-amber-200 bg-amber-50/40 dark:border-amber-800 dark:bg-amber-950/20",
+  },
+  {
+    key: "done",
+    label: "完成",
+    statuses: ["done", "completed", "failed"],
+    icon: <CheckCircle2 className="size-3.5 text-green-500" />,
+    className: "border-green-200 bg-green-50/40 dark:border-green-800 dark:bg-green-950/20",
+  },
+];
+
+function priorityBadgeClass(priority: string): string {
+  switch (priority) {
+    case "high": return "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400";
+    case "medium": return "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400";
+    default: return "bg-secondary text-muted-foreground";
+  }
+}
+
+function TaskCard({ task }: { task: Task }) {
+  return (
+    <div className="rounded-lg border border-border bg-card p-2.5 shadow-sm space-y-1.5">
+      <p className="text-[12px] font-medium leading-5 text-foreground line-clamp-2">{task.title}</p>
+      <div className="flex flex-wrap items-center gap-1.5">
+        {task.priority && task.priority !== "low" && (
+          <Badge className={cn("text-[10px] px-1.5 py-0", priorityBadgeClass(task.priority))}>
+            {task.priority === "high" ? "高" : "中"}
+          </Badge>
+        )}
+        {task.run_id && (
+          <span className="text-[10px] text-muted-foreground font-mono">
+            {task.run_id.slice(0, 6)}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function TasksPanel({ projectId, refreshTick = 0 }: TasksPanelProps) {
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    getProjectTasks(projectId)
+      .then(({ items }) => {
+        if (!cancelled) {
+          setTasks(items);
+          setLoading(false);
+        }
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "加载失败");
+          setLoading(false);
+        }
+      });
+
+    return () => { cancelled = true; };
+  }, [projectId, refreshTick]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-8">
+        <Loader2 className="size-4 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <p className="text-xs text-destructive">{error}</p>
+    );
+  }
+
+  const columns = COLUMNS.map((col) => ({
+    ...col,
+    tasks: tasks.filter((t) => col.statuses.includes(t.status)),
+  }));
+
+  const totalTasks = tasks.length;
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <span className="text-[11px] text-muted-foreground">{totalTasks} 个任务</span>
+      </div>
+
+      {totalTasks === 0 ? (
+        <p className="py-4 text-center text-xs text-muted-foreground">暂无任务</p>
+      ) : (
+        <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+          {columns.map((col) => (
+            <div
+              key={col.key}
+              className={cn("rounded-xl border p-2 space-y-2 min-h-[80px]", col.className)}
+            >
+              <div className="flex items-center gap-1.5">
+                {col.icon}
+                <span className="text-[11px] font-semibold text-foreground">{col.label}</span>
+                <span className="ml-auto text-[10px] text-muted-foreground">{col.tasks.length}</span>
+              </div>
+              <div className="space-y-1.5">
+                {col.tasks.map((task) => (
+                  <TaskCard key={task.task_id} task={task} />
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/workspace/project/tasks-panel.tsx
+++ b/ui/src/components/workspace/project/tasks-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { CheckCircle2, Circle, Clock, Loader2, OctagonX } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
@@ -18,7 +18,7 @@ type KanbanColumn = {
   key: string;
   label: string;
   statuses: string[];
-  icon: React.ReactNode;
+  icon: ReactNode;
   className: string;
 };
 

--- a/ui/src/core/projects/api.ts
+++ b/ui/src/core/projects/api.ts
@@ -100,3 +100,11 @@ export async function patchApproval(approvalId: string, body: { status: string; 
     body: JSON.stringify(body),
   });
 }
+
+export async function getProjectTasks(projectId: string): Promise<{ items: import("./types").Task[]; total: number }> {
+  return fetchJson(`/projects/${projectId}/tasks`);
+}
+
+export async function getProjectAuditLogs(projectId: string): Promise<AuditLogListResponse> {
+  return fetchJson<AuditLogListResponse>(`/audit-logs?project_id=${projectId}`);
+}

--- a/ui/src/core/projects/api.ts
+++ b/ui/src/core/projects/api.ts
@@ -6,6 +6,7 @@ import type {
   ProjectListResponse,
   ProjectOverviewResponse,
   RunEvent,
+  Task,
 } from "./types";
 
 async function fetchJson<T>(path: string, init?: RequestInit): Promise<T> {
@@ -101,8 +102,8 @@ export async function patchApproval(approvalId: string, body: { status: string; 
   });
 }
 
-export async function getProjectTasks(projectId: string): Promise<{ items: import("./types").Task[]; total: number }> {
-  return fetchJson(`/projects/${projectId}/tasks`);
+export async function getProjectTasks(projectId: string): Promise<{ items: Task[]; total: number }> {
+  return fetchJson<{ items: Task[]; total: number }>(`/projects/${projectId}/tasks`);
 }
 
 export async function getProjectAuditLogs(projectId: string): Promise<AuditLogListResponse> {


### PR DESCRIPTION
## Summary

Closes the three deferred items from issue #64 (governed execution loop):

- **Task Kanban** (`tasks-panel.tsx`): 4-column Kanban (待办 / 进行中 / 阻塞 / 完成) that reads `GET /projects/{id}/tasks`, groups by status, and refreshes automatically when a run completes. Replaces the flat `recent_tasks` list on the project page.
- **Audit Timeline** (`audit-timeline.tsx`): Per-project vertical timeline of audit events, grouped by calendar day with colour-coded dots (green = completed/approved, amber = blocked/approval, red = failed/rejected). Reads `GET /audit-logs?project_id=…`.
- **Pending-approvals badge**: `Sidebar` now accepts a `pendingApprovalsCount` prop and renders a count badge on the "审批中心" nav item (expanded view) and an amber dot on the collapsed rail icon. `App.tsx` polls `/approvals?status=pending` every 30s and passes the count down.

## Files Changed

| File | Change |
|------|--------|
| `ui/src/core/projects/api.ts` | Add `getProjectTasks()` + `getProjectAuditLogs()` |
| `ui/src/components/workspace/project/tasks-panel.tsx` | New — Kanban component |
| `ui/src/components/workspace/project/audit-timeline.tsx` | New — timeline component |
| `ui/src/components/workspace/project/project-page.tsx` | Mount `TasksPanel` + `AuditTimeline`; bump `refreshTick` on run terminal |
| `ui/src/components/ui/sidebar.tsx` | `pendingApprovalsCount` prop + badge rendering |
| `ui/src/App.tsx` | Poll pending approvals count; pass to `Sidebar` |

## Test plan

- [ ] Start a project run → verify tasks appear in the Kanban under the correct column as the run progresses
- [ ] After run completes → Kanban auto-refreshes without page reload
- [ ] Trigger a high-risk tool → "阻塞" column shows the blocked task; Approval Center badge appears in sidebar
- [ ] Approve/reject from Approval Center → badge count decrements within 30s
- [ ] Audit Timeline shows all events grouped by day with correct colour coding
- [ ] Collapsed sidebar rail shows amber dot when approvals are pending

Closes #64

https://claude.ai/code/session_01YU98bkBubM8W8LZDUUYi8g

---
_Generated by [Claude Code](https://claude.ai/code/session_01YU98bkBubM8W8LZDUUYi8g)_