### PR TITLE
Make CLI a first-class interface

### DIFF
--- a/.github/workflows/auto-merge-owner.yml
+++ b/.github/workflows/auto-merge-owner.yml
@@ -18,7 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     if: >-
       (github.event.pull_request.user.login == 'hawkli-1994'
-       || startsWith(github.head_ref, 'claude/'))
+       || startsWith(github.head_ref, 'claude/')
+       || startsWith(github.head_ref, 'codex/'))
       && github.event.pull_request.draft == false
     steps:
       - name: Enable auto-merge

--- a/.github/workflows/pr-branch-check.yml
+++ b/.github/workflows/pr-branch-check.yml
@@ -17,6 +17,7 @@ jobs:
           # 允许的分支名模式
           # main, release* - 受保护分支，不应该直接创建PR
           # feature/*, fix/*, docs/*, refactor/*, test/*, chore/*, perf/*, hotfix/* - 功能分支
+          # claude/*, codex/* - AI coding agent branches
 
           if [[ "$BRANCH_NAME" =~ ^(main|release.*)$ ]]; then
             echo "❌ ERROR: Branch '$BRANCH_NAME' is a protected branch."
@@ -29,9 +30,9 @@ jobs:
             exit 0
           fi
 
-          # Allow Claude Code agent branches (claude/<any-name>)
-          if [[ "$BRANCH_NAME" =~ ^claude/.+ ]]; then
-            echo "✅ Branch name '$BRANCH_NAME' is a Claude Code agent branch."
+          # Allow AI coding agent branches (claude/<any-name>, codex/<any-name>)
+          if [[ "$BRANCH_NAME" =~ ^(claude|codex)/.+ ]]; then
+            echo "✅ Branch name '$BRANCH_NAME' is an AI coding agent branch."
             exit 0
           fi
 
@@ -49,12 +50,14 @@ jobs:
           echo "  - perf      - Performance improvements"
           echo "  - hotfix    - Emergency fixes"
           echo "  - claude    - Claude Code agent branches"
+          echo "  - codex     - Codex agent branches"
           echo ""
           echo "Examples:"
           echo "  ✅ feature/user-auth"
           echo "  ✅ fix/memory-leak"
           echo "  ✅ docs/api-guide"
           echo "  ✅ claude/my-task"
+          echo "  ✅ codex/my-task"
           echo ""
           echo "See CONTRIBUTING.md for more details."
           exit 1

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL_3.0-blue.svg)](LICENSE)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/)
 
-[中文文档](README_zh.md) · [Architecture](docs/architecture.md) · [Roadmap](docs/roadmap.md) · [Contributing](#contributing--community)
+[中文文档](README_zh.md) · [Architecture](docs/architecture.md) · [CLI](docs/cli.md) · [Roadmap](docs/roadmap.md) · [Contributing](#contributing--community)
 
 ---
 
@@ -34,7 +34,7 @@ SwarmMind is in production use in real organizational environments.
 
 ---
 
-## Four Pillars
+## Five Pillars
 
 ### 🧠 Organizational Memory
 
@@ -47,6 +47,10 @@ Complex, multi-turn tasks with governance built in. Agents coordinate across pro
 ### 🖥️ Accessible UI
 
 Non-technical users can start a session, explore organizational knowledge, and promote findings into governed projects — in minutes, not days. No API keys, no CLI, no prompt engineering required.
+
+### ⌨️ First-Class CLI
+
+Developers, operators, and AI coding agents can use `swarmmind` as a stable product surface, not a debugging shortcut. The CLI is HTTP-first, shares the same API contracts as the FastAPI backend, supports human-readable and JSON/NDJSON output, and is suitable for local dev loops, automation, smoke tests, CI, and MCP tool exposure.
 
 ### 🔌 Extensible
 
@@ -107,6 +111,16 @@ make dev
 ```
 
 After startup, open [http://localhost:3000](http://localhost:3000). You will see the ChatSession interface — type any natural-language question to start exploring your organizational context.
+
+CLI is a first-class interface alongside the Supervisor UI. Use it for API-driven development, agent workflows, smoke tests, and automation:
+
+```bash
+swarmmind health
+swarmmind chat new "Map the CRM MVP risks" --mode pro
+swarmmind project list --json
+```
+
+See [CLI documentation](docs/cli.md) for commands, JSON/NDJSON output, exit codes, and MCP mode.
 
 <!-- TODO: add screenshot of ChatSession UI -->
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -10,7 +10,7 @@
 [![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL_3.0-blue.svg)](LICENSE)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/)
 
-[English](README.md) · [技术架构](docs/architecture.md) · [路线图](docs/roadmap.md) · [参与贡献](#参与贡献--社区)
+[English](README.md) · [技术架构](docs/architecture.md) · [CLI](docs/cli.md) · [路线图](docs/roadmap.md) · [参与贡献](#参与贡献--社区)
 
 ---
 
@@ -34,7 +34,7 @@ SwarmMind 已在真实的组织环境中生产部署使用。
 
 ---
 
-## 四大核心能力
+## 五大核心能力
 
 ### 🧠 组织记忆
 
@@ -47,6 +47,10 @@ SwarmMind 已在真实的组织环境中生产部署使用。
 ### 🖥️ 开箱即用的界面
 
 非技术人员无需 API 密钥、无需命令行、无需学习 Prompt 工程——打开界面就能开始会话、检索组织知识，并将发现推进为正式项目。
+
+### ⌨️ 一等公民 CLI
+
+开发者、运维人员和 AI Coding Agent 可以把 `swarmmind` 当成稳定的产品界面使用，而不是临时调试入口。CLI 采用 HTTP-first 设计，与 FastAPI 后端共享同一套 API 契约，支持人类可读输出和 JSON/NDJSON 输出，适合本地开发闭环、自动化、smoke test、CI 和 MCP 工具暴露。
 
 ### 🔌 高度可扩展
 
@@ -107,6 +111,16 @@ make dev
 ```
 
 启动后访问 [http://localhost:3000](http://localhost:3000)，你会看到 ChatSession 界面——直接输入自然语言问题即可开始探索你的组织上下文。
+
+CLI 是与 Supervisor UI 并列的一等接口。面向 API 驱动开发、Agent 工作流、smoke test 和自动化，可以直接使用：
+
+```bash
+swarmmind health
+swarmmind chat new "梳理 CRM MVP 风险" --mode pro
+swarmmind project list --json
+```
+
+命令、JSON/NDJSON 输出、退出码与 MCP 模式见 [CLI 文档](docs/cli.md)。
 
 <!-- TODO: add screenshot of ChatSession UI -->
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,114 @@
+# SwarmMind CLI
+
+The `swarmmind` command is a first-class, HTTP-first client for the FastAPI supervisor API. It does not run service-layer business logic in-process; all execution still happens through the API boundary.
+
+## Install And Configure
+
+```bash
+uv sync
+swarmmind --help
+```
+
+API URL resolution order:
+
+1. `--api-url`
+2. `SWARMMIND_API_URL`
+3. `http://127.0.0.1:8000`
+
+Useful startup loop:
+
+```bash
+swarmmind serve --host 127.0.0.1 --port 8000
+swarmmind health
+swarmmind ready --json
+```
+
+## Output Modes
+
+All commands default to human-readable output. Add `--json` for machine-readable JSON.
+
+Streaming commands emit NDJSON in `--json` mode, one event per line:
+
+```bash
+swarmmind --json chat stream <conversation_id> "plan the CRM MVP"
+```
+
+Exit codes:
+
+| Code | Meaning |
+|------|---------|
+| `0` | Success |
+| `1` | API or runtime error |
+| `2` | CLI argument or contract validation error |
+| `3` | Backend unavailable or timed out |
+| `4` | Resource not found |
+
+## Command Surface
+
+System:
+
+```bash
+swarmmind health
+swarmmind ready
+swarmmind serve --host 127.0.0.1 --port 8000
+```
+
+Conversation and chat:
+
+```bash
+swarmmind conversation list
+swarmmind conversation create --title "CRM discovery"
+swarmmind conversation get <conversation_id> --include-messages
+swarmmind conversation messages <conversation_id>
+swarmmind conversation trace <conversation_id>
+swarmmind conversation export <conversation_id> --format markdown
+swarmmind conversation delete <conversation_id>
+
+swarmmind chat send <conversation_id> "hello"
+swarmmind chat stream <conversation_id> "build the plan" --mode pro
+swarmmind chat new "start a governed CRM discovery" --mode ultra
+swarmmind chat respond-clarification <conversation_id> <tool_call_id> "answer"
+```
+
+Governance:
+
+```bash
+swarmmind project list --limit 20
+swarmmind project create "CRM MVP" --goal "Validate enterprise wedge"
+swarmmind project update <project_id> --phase "planning" --risk-level medium
+swarmmind project overview <project_id>
+swarmmind project stream <project_id> "run the next step" --mode pro
+
+swarmmind run list --project-id <project_id>
+swarmmind run get <run_id>
+swarmmind run create --project-id <project_id> --goal "execute plan"
+swarmmind run update <run_id> --status completed --summary "done"
+
+swarmmind task list <project_id>
+swarmmind task create <project_id> "Write PRD" --priority high
+swarmmind task update <project_id> <task_id> --status in_progress
+swarmmind task delete <project_id> <task_id>
+
+swarmmind approval list --project-id <project_id>
+swarmmind approval create <project_id> "Approve CRM write" --risk-tier high
+swarmmind approval update <approval_id> --status approved --decision-reason "approved"
+
+swarmmind audit list --project-id <project_id>
+swarmmind audit get <audit_id>
+```
+
+Dispatch and memory:
+
+```bash
+swarmmind dispatch "route this goal"
+swarmmind memory list --layer L3_project --scope-id <project_id>
+swarmmind memory get decision --layer L3_project --scope-id <project_id>
+```
+
+MCP:
+
+```bash
+swarmmind mcp serve
+```
+
+The MCP server exposes health, dispatch, ChatSession creation/send, project list/create, and memory get tools over stdio.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "anthropic>=0.40.0",
     "pydantic>=2.9.2",
     "httpx>=0.27.2",
+    "typer>=0.24.1",
     "pytest>=8.3.3",
     "pytest-asyncio>=0.24.0",
     "python-dotenv>=1.0.1",
@@ -22,6 +23,21 @@ dependencies = [
     "deerflow-harness @ git+https://github.com/bytedance/deer-flow@main#subdirectory=backend/packages/harness",
     "psycopg2-binary>=2.9.11",
 ]
+
+[project.optional-dependencies]
+mcp = [
+    "mcp>=1.26.0",
+]
+
+[project.scripts]
+swarmmind = "swarmmind.cli.__main__:app"
+
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+include = ["swarmmind*"]
 
 [dependency-groups]
 dev = [
@@ -171,6 +187,7 @@ docstring-code-format = true
 [tool.ruff.lint.per-file-ignores]
 # Test files: allow missing docstrings, allow assert usage (handled above)
 "tests/**/*.py" = ["D", "ANN", "PLR2004"]
+"swarmmind/cli/**/*.py" = ["D", "PLR0913"]
 
 # ============================================
 # Mypy - Static Type Checker (Strict)

--- a/swarmmind/__init__.py
+++ b/swarmmind/__init__.py
@@ -1,3 +1,3 @@
 """SwarmMind — AI Agent Team Operating System."""
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/swarmmind/api/routers/mappers.py
+++ b/swarmmind/api/routers/mappers.py
@@ -10,6 +10,9 @@ from swarmmind.models import (
     ApprovalStatus,
     Artifact,
     AuditLogEntry,
+    MemoryEntry,
+    MemoryLayer,
+    MemoryScope,
     Project,
     ProjectAgentTeamInstance,
     RiskTier,
@@ -112,6 +115,28 @@ def db_to_audit_log_entry(entry) -> AuditLogEntry:
         reason=entry.reason,
         metadata=entry.extra_data or {},
         timestamp=entry.timestamp.isoformat() if entry.timestamp else "",
+    )
+
+
+def db_to_memory_entry(entry) -> MemoryEntry:
+    """Map a MemoryEntryDB row to a MemoryEntry Pydantic model."""
+    tags = entry.tags or []
+    if isinstance(tags, str):
+        try:
+            tags = json.loads(tags)
+        except json.JSONDecodeError:
+            tags = []
+    return MemoryEntry(
+        id=entry.id,
+        scope=MemoryScope(layer=MemoryLayer(entry.layer), scope_id=entry.scope_id),
+        key=entry.key,
+        value=entry.value,
+        tags=tags,
+        created_at=entry.created_at,
+        updated_at=entry.updated_at,
+        ttl=entry.ttl,
+        version=entry.version,
+        last_writer_agent_id=entry.last_writer_agent_id,
     )
 
 

--- a/swarmmind/api/routers/memory.py
+++ b/swarmmind/api/routers/memory.py
@@ -1,0 +1,53 @@
+"""Read-only layered memory routes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Annotated
+
+from fastapi import APIRouter, HTTPException, Query
+
+from swarmmind.api.routers.mappers import db_to_memory_entry
+from swarmmind.models import MemoryEntry, MemoryLayer, MemoryListResponse, MemoryScope
+
+
+@dataclass(frozen=True)
+class MemoryRouterDeps:
+    """Dependencies for the memory router."""
+
+    memory_repo: object
+
+
+def build_memory_router(deps: MemoryRouterDeps) -> APIRouter:
+    """Return read-only layered memory endpoints."""
+    router = APIRouter()
+
+    @router.get("/memory", tags=["memory"])
+    def list_memory(
+        layer: MemoryLayer | None = None,
+        scope_id: str | None = None,
+        tag: Annotated[list[str] | None, Query()] = None,
+        limit: Annotated[int, Query(ge=1, le=500)] = 100,
+    ) -> MemoryListResponse:
+        """List layered-memory entries with optional filters."""
+        rows = deps.memory_repo.list_by_filters(
+            layer=layer.value if layer else None,
+            scope_id=scope_id,
+            tags=tag,
+            limit=limit,
+        )
+        return MemoryListResponse(items=[db_to_memory_entry(row) for row in rows], total=len(rows))
+
+    @router.get("/memory/{key}", tags=["memory"], responses={404: {"description": "Memory entry not found"}})
+    def get_memory(
+        key: str,
+        layer: MemoryLayer,
+        scope_id: str,
+    ) -> MemoryEntry:
+        """Read one layered-memory entry by exact layer, scope, and key."""
+        entry = deps.memory_repo.read(MemoryScope(layer=layer, scope_id=scope_id), key)
+        if entry is None:
+            raise HTTPException(status_code=404, detail="Memory entry not found")
+        return db_to_memory_entry(entry)
+
+    return router

--- a/swarmmind/api/routers/projects.py
+++ b/swarmmind/api/routers/projects.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Annotated
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Query
 from fastapi.responses import StreamingResponse
 
 from swarmmind.api.routers.mappers import (
@@ -99,10 +100,13 @@ def build_projects_router(deps: ProjectsRouterDeps) -> APIRouter:
     # ---- Project CRUD ----
 
     @router.get("/projects", tags=["projects"])
-    def list_projects() -> ProjectListResponse:
+    def list_projects(
+        limit: Annotated[int | None, Query(ge=1, le=500)] = None,
+        offset: Annotated[int, Query(ge=0)] = 0,
+    ) -> ProjectListResponse:
         """List all projects ordered by updated_at descending."""
-        rows = deps.project_repo.list_all()
-        return ProjectListResponse(items=[_db_to_project(r) for r in rows], total=len(rows))
+        rows = deps.project_repo.list_all(limit=limit, offset=offset)
+        return ProjectListResponse(items=[_db_to_project(r) for r in rows], total=deps.project_repo.count_all())
 
     @router.get("/projects/{project_id}", tags=["projects"], responses={404: {"description": "Project not found"}})
     def get_project(project_id: str) -> Project:

--- a/swarmmind/api/supervisor.py
+++ b/swarmmind/api/supervisor.py
@@ -15,6 +15,7 @@ from swarmmind.api.routers.agent_teams import AgentTeamsRouterDeps, build_agent_
 from swarmmind.api.routers.approvals import ApprovalsRouterDeps, build_approvals_router
 from swarmmind.api.routers.audit_logs import AuditLogsRouterDeps, build_audit_logs_router
 from swarmmind.api.routers.legacy_supervisor import LegacySupervisorRouterDeps, build_legacy_supervisor_router
+from swarmmind.api.routers.memory import MemoryRouterDeps, build_memory_router
 from swarmmind.api.routers.projects import ProjectsRouterDeps, build_projects_router
 from swarmmind.api.routers.promotions import PromotionsRouterDeps, build_promotions_router
 from swarmmind.api.routers.runs import RunsRouterDeps, build_runs_router
@@ -438,6 +439,8 @@ app.include_router(
         )
     )
 )
+
+app.include_router(build_memory_router(MemoryRouterDeps(memory_repo=memory_repo)))
 
 app.include_router(
     build_agent_teams_router(

--- a/swarmmind/cli/__init__.py
+++ b/swarmmind/cli/__init__.py
@@ -1,0 +1,1 @@
+"""Command-line interface for SwarmMind."""

--- a/swarmmind/cli/__main__.py
+++ b/swarmmind/cli/__main__.py
@@ -1,0 +1,72 @@
+"""SwarmMind command-line entrypoint."""
+
+from __future__ import annotations
+
+from importlib import metadata
+from typing import Annotated
+
+import typer
+
+from swarmmind import __version__
+from swarmmind.cli.commands.approval import approval_app
+from swarmmind.cli.commands.audit import audit_app
+from swarmmind.cli.commands.conversation import chat_app, conversation_app
+from swarmmind.cli.commands.mcp import mcp_app
+from swarmmind.cli.commands.memory import memory_app
+from swarmmind.cli.commands.project import project_app
+from swarmmind.cli.commands.run import run_app
+from swarmmind.cli.commands.system import register_system_commands
+from swarmmind.cli.commands.task import task_app
+from swarmmind.cli.config import CLIState, resolve_api_url
+
+app = typer.Typer(
+    help="SwarmMind CLI: HTTP-first client for the supervisor API.",
+    no_args_is_help=True,
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
+
+
+def _version_callback(value: bool) -> bool:
+    if value:
+        typer.echo(f"swarmmind {_version()}")
+        raise typer.Exit()
+    return value
+
+
+@app.callback()
+def main(
+    ctx: typer.Context,
+    api_url: Annotated[str | None, typer.Option("--api-url", help="Supervisor API URL.")] = None,
+    json_output: Annotated[bool, typer.Option("--json", help="Emit JSON or NDJSON output.")] = False,
+    quiet: Annotated[bool, typer.Option("--quiet", "-q", help="Suppress normal output.")] = False,
+    version: Annotated[
+        bool,
+        typer.Option("--version", help="Show CLI version and exit.", callback=_version_callback, is_eager=True),
+    ] = False,
+) -> None:
+    """Resolve global CLI options."""
+    _ = version
+    ctx.obj = CLIState(api_url=resolve_api_url(api_url), json_output=json_output, quiet=quiet)
+
+
+def _version() -> str:
+    try:
+        return metadata.version("swarmmind")
+    except metadata.PackageNotFoundError:
+        return __version__
+
+
+register_system_commands(app)
+app.add_typer(conversation_app, name="conversation")
+app.add_typer(chat_app, name="chat")
+app.add_typer(project_app, name="project")
+app.add_typer(run_app, name="run")
+app.add_typer(task_app, name="task")
+app.add_typer(approval_app, name="approval")
+app.add_typer(audit_app, name="audit")
+app.add_typer(memory_app, name="memory")
+app.add_typer(mcp_app, name="mcp")
+
+
+if __name__ == "__main__":
+    app()

--- a/swarmmind/cli/client.py
+++ b/swarmmind/cli/client.py
@@ -1,0 +1,456 @@
+"""HTTP-first SwarmMind supervisor API client used by the CLI."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from typing import Any, TypeVar
+
+import httpx
+from pydantic import BaseModel
+
+from swarmmind.models import (
+    ApprovalRequest,
+    ApprovalRequestListResponse,
+    AuditLogEntry,
+    AuditLogListResponse,
+    Conversation,
+    ConversationListResponse,
+    ConversationTraceResponse,
+    CreateApprovalRequest,
+    CreateAuditLogEntry,
+    CreateConversationRequest,
+    CreateRunRequest,
+    CreateTaskRequest,
+    DeleteApprovalResponse,
+    DeleteAuditLogResponse,
+    DeleteConversationResponse,
+    DeleteProjectResponse,
+    DeleteTaskResponse,
+    DispatchResponse,
+    GoalRequest,
+    HealthResponse,
+    MemoryEntry,
+    MemoryListResponse,
+    Project,
+    ProjectCreateRequest,
+    ProjectListResponse,
+    ProjectOverviewResponse,
+    ProjectUpdateRequest,
+    ReadyResponse,
+    Run,
+    RunListResponse,
+    SendMessageRequest,
+    SendMessageResponse,
+    Task,
+    TaskListResponse,
+    UpdateApprovalRequest,
+    UpdateRunRequest,
+    UpdateTaskRequest,
+)
+
+T = TypeVar("T", bound=BaseModel)
+
+EXIT_ERROR = 1
+EXIT_USAGE = 2
+EXIT_BACKEND_UNAVAILABLE = 3
+EXIT_NOT_FOUND = 4
+
+
+class SwarmMindCLIError(Exception):
+    """Normalized CLI-facing error with a stable exit code."""
+
+    def __init__(self, message: str, *, exit_code: int = EXIT_ERROR, status_code: int | None = None) -> None:
+        super().__init__(message)
+        self.message = message
+        self.exit_code = exit_code
+        self.status_code = status_code
+
+
+class BackendUnavailable(SwarmMindCLIError):
+    """Raised when the supervisor API cannot be reached."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message, exit_code=EXIT_BACKEND_UNAVAILABLE)
+
+
+class ResourceNotFound(SwarmMindCLIError):
+    """Raised for HTTP 404 responses."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message, exit_code=EXIT_NOT_FOUND, status_code=404)
+
+
+class ParameterError(SwarmMindCLIError):
+    """Raised when command input cannot be converted to the shared API contract."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message, exit_code=EXIT_USAGE)
+
+
+class SwarmMindClient:
+    """Thin HTTP client for the supervisor REST API."""
+
+    def __init__(self, api_url: str, timeout: float = 30.0) -> None:
+        self.api_url = api_url.rstrip("/")
+        self._client = httpx.Client(
+            base_url=self.api_url,
+            timeout=httpx.Timeout(timeout, connect=5.0),
+            headers={"Accept": "application/json"},
+        )
+
+    def close(self) -> None:
+        """Close the underlying HTTP client."""
+        self._client.close()
+
+    def __enter__(self) -> SwarmMindClient:
+        return self
+
+    def __exit__(self, *_exc_info) -> None:
+        self.close()
+
+    # ---- low-level request helpers ----
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json_body: dict[str, Any] | None = None,
+        params: dict[str, Any] | None = None,
+    ) -> Any:
+        try:
+            response = self._client.request(method, path, json=json_body, params=_compact(params))
+        except httpx.ConnectError as exc:
+            raise BackendUnavailable(f"Backend unavailable at {self.api_url}: {exc}") from exc
+        except httpx.TimeoutException as exc:
+            raise BackendUnavailable(f"Backend timed out at {self.api_url}: {exc}") from exc
+        except httpx.TransportError as exc:
+            raise BackendUnavailable(f"Backend transport error at {self.api_url}: {exc}") from exc
+
+        if response.status_code == 404:
+            raise ResourceNotFound(_response_error_message(response, fallback="Resource not found"))
+        if response.is_error:
+            raise SwarmMindCLIError(
+                _response_error_message(response, fallback=f"HTTP {response.status_code}"),
+                status_code=response.status_code,
+            )
+        if response.status_code == 204:
+            return None
+        return _response_data(response)
+
+    def _parse(self, model: type[T], data: Any) -> T:
+        return model.model_validate(data)
+
+    def _list(self, model: type[T], method: str, path: str, **kwargs) -> T:
+        return self._parse(model, self._request(method, path, **kwargs))
+
+    # ---- system ----
+
+    def health(self) -> HealthResponse:
+        return self._list(HealthResponse, "GET", "/health")
+
+    def ready(self) -> ReadyResponse:
+        return self._list(ReadyResponse, "GET", "/ready")
+
+    # ---- dispatch ----
+
+    def dispatch(self, goal: str) -> DispatchResponse:
+        body = GoalRequest(goal=goal).model_dump(mode="json")
+        return self._list(DispatchResponse, "POST", "/dispatch", json_body=body)
+
+    # ---- conversations / chat ----
+
+    def list_conversations(self) -> ConversationListResponse:
+        return self._list(ConversationListResponse, "GET", "/conversations")
+
+    def create_conversation(self, title: str | None = None) -> Conversation:
+        body = CreateConversationRequest(title=title).model_dump(mode="json", exclude_none=True)
+        return self._list(Conversation, "POST", "/conversations", json_body=body)
+
+    def recent_conversation(self) -> dict[str, Any] | None:
+        return self._request("GET", "/conversations/recent")
+
+    def search_conversations(self, query: str, limit: int = 20) -> ConversationListResponse:
+        return self._list(ConversationListResponse, "GET", "/conversations/search", params={"q": query, "limit": limit})
+
+    def get_conversation(self, conversation_id: str, *, include_messages: bool = False) -> Conversation:
+        return self._list(
+            Conversation,
+            "GET",
+            f"/conversations/{conversation_id}",
+            params={"include_messages": include_messages},
+        )
+
+    def list_messages(self, conversation_id: str) -> dict[str, Any]:
+        return self._request("GET", f"/conversations/{conversation_id}/messages")
+
+    def send_message(
+        self,
+        conversation_id: str,
+        content: str,
+        *,
+        mode: str | None = None,
+        model_name: str | None = None,
+        reasoning: bool = False,
+    ) -> SendMessageResponse:
+        body = _message_body(content, mode=mode, model_name=model_name, reasoning=reasoning)
+        return self._list(SendMessageResponse, "POST", f"/conversations/{conversation_id}/messages", json_body=body)
+
+    def stream_message(
+        self,
+        conversation_id: str,
+        content: str,
+        *,
+        mode: str | None = None,
+        model_name: str | None = None,
+        reasoning: bool = False,
+    ) -> Iterator[dict[str, Any]]:
+        body = _message_body(content, mode=mode, model_name=model_name, reasoning=reasoning)
+        yield from self._stream("POST", f"/conversations/{conversation_id}/messages/stream", json_body=body)
+
+    def respond_to_clarification(self, conversation_id: str, tool_call_id: str, response: str) -> dict[str, Any]:
+        return self._request(
+            "POST",
+            f"/conversations/{conversation_id}/clarification",
+            json_body={"tool_call_id": tool_call_id, "response": response},
+        )
+
+    def delete_conversation(self, conversation_id: str) -> DeleteConversationResponse:
+        return self._list(DeleteConversationResponse, "DELETE", f"/conversations/{conversation_id}")
+
+    def get_conversation_trace(self, conversation_id: str) -> ConversationTraceResponse:
+        return self._list(ConversationTraceResponse, "GET", f"/conversations/{conversation_id}/trace")
+
+    def export_conversation(self, conversation_id: str, export_format: str = "markdown") -> str:
+        data = self._request("GET", f"/conversations/{conversation_id}/export", params={"format": export_format})
+        if isinstance(data, (dict, list)):
+            return json.dumps(data, ensure_ascii=False, indent=2)
+        return str(data)
+
+    # ---- projects ----
+
+    def list_projects(self, *, limit: int | None = None, offset: int = 0) -> ProjectListResponse:
+        return self._list(ProjectListResponse, "GET", "/projects", params={"limit": limit, "offset": offset})
+
+    def create_project(self, **fields) -> Project:
+        body = ProjectCreateRequest(**_compact(fields)).model_dump(mode="json", exclude_none=True)
+        return self._list(Project, "POST", "/projects", json_body=body)
+
+    def get_project(self, project_id: str) -> Project:
+        return self._list(Project, "GET", f"/projects/{project_id}")
+
+    def update_project(self, project_id: str, **fields) -> Project:
+        body = ProjectUpdateRequest(**_compact(fields)).model_dump(mode="json", exclude_none=True)
+        return self._list(Project, "PATCH", f"/projects/{project_id}", json_body=body)
+
+    def delete_project(self, project_id: str) -> DeleteProjectResponse:
+        return self._list(DeleteProjectResponse, "DELETE", f"/projects/{project_id}")
+
+    def project_overview(self, project_id: str) -> ProjectOverviewResponse:
+        return self._list(ProjectOverviewResponse, "GET", f"/projects/{project_id}/overview")
+
+    def stream_project_message(
+        self,
+        project_id: str,
+        content: str,
+        *,
+        mode: str | None = None,
+        model_name: str | None = None,
+        reasoning: bool = False,
+    ) -> Iterator[dict[str, Any]]:
+        body = _message_body(content, mode=mode, model_name=model_name, reasoning=reasoning)
+        yield from self._stream("POST", f"/projects/{project_id}/messages/stream", json_body=body)
+
+    # ---- runs ----
+
+    def list_runs(self, *, project_id: str | None = None, conversation_id: str | None = None) -> RunListResponse:
+        if project_id:
+            return self._list(RunListResponse, "GET", f"/projects/{project_id}/runs")
+        if conversation_id:
+            return self._list(RunListResponse, "GET", f"/conversations/{conversation_id}/runs")
+        raise SwarmMindCLIError("run list requires --project-id or --conversation-id")
+
+    def get_run(self, run_id: str) -> Run:
+        return self._list(Run, "GET", f"/runs/{run_id}")
+
+    def create_run(self, **fields) -> Run:
+        body = CreateRunRequest(**_compact(fields)).model_dump(mode="json", exclude_none=True)
+        return self._list(Run, "POST", "/runs", json_body=body)
+
+    def update_run(self, run_id: str, **fields) -> Run:
+        body = UpdateRunRequest(**_compact(fields)).model_dump(mode="json", exclude_none=True)
+        return self._list(Run, "PATCH", f"/runs/{run_id}", json_body=body)
+
+    # ---- tasks ----
+
+    def list_tasks(self, project_id: str) -> TaskListResponse:
+        return self._list(TaskListResponse, "GET", f"/projects/{project_id}/tasks")
+
+    def create_task(self, project_id: str, **fields) -> Task:
+        body = CreateTaskRequest(**_compact(fields)).model_dump(mode="json", exclude_none=True)
+        return self._list(Task, "POST", f"/projects/{project_id}/tasks", json_body=body)
+
+    def get_task(self, project_id: str, task_id: str) -> Task:
+        return self._list(Task, "GET", f"/projects/{project_id}/tasks/{task_id}")
+
+    def update_task(self, project_id: str, task_id: str, **fields) -> Task:
+        body = UpdateTaskRequest(**_compact(fields)).model_dump(mode="json", exclude_none=True)
+        return self._list(Task, "PATCH", f"/projects/{project_id}/tasks/{task_id}", json_body=body)
+
+    def delete_task(self, project_id: str, task_id: str) -> DeleteTaskResponse:
+        return self._list(DeleteTaskResponse, "DELETE", f"/projects/{project_id}/tasks/{task_id}")
+
+    # ---- approvals ----
+
+    def list_approvals(
+        self,
+        *,
+        project_id: str | None = None,
+        status: str | None = None,
+        risk_tier: str | None = None,
+    ) -> ApprovalRequestListResponse:
+        return self._list(
+            ApprovalRequestListResponse,
+            "GET",
+            "/approvals",
+            params={"project_id": project_id, "status": status, "risk_tier": risk_tier},
+        )
+
+    def create_approval(self, **fields) -> ApprovalRequest:
+        body = CreateApprovalRequest(**_compact(fields)).model_dump(mode="json", exclude_none=True)
+        return self._list(ApprovalRequest, "POST", "/approvals", json_body=body)
+
+    def get_approval(self, approval_id: str) -> ApprovalRequest:
+        return self._list(ApprovalRequest, "GET", f"/approvals/{approval_id}")
+
+    def update_approval(self, approval_id: str, **fields) -> ApprovalRequest:
+        body = UpdateApprovalRequest(**_compact(fields)).model_dump(mode="json", exclude_none=True)
+        return self._list(ApprovalRequest, "PATCH", f"/approvals/{approval_id}", json_body=body)
+
+    def delete_approval(self, approval_id: str) -> DeleteApprovalResponse:
+        return self._list(DeleteApprovalResponse, "DELETE", f"/approvals/{approval_id}")
+
+    # ---- audit logs ----
+
+    def list_audit_logs(
+        self,
+        *,
+        project_id: str | None = None,
+        run_id: str | None = None,
+        approval_id: str | None = None,
+    ) -> AuditLogListResponse:
+        return self._list(
+            AuditLogListResponse,
+            "GET",
+            "/audit-logs",
+            params={"project_id": project_id, "run_id": run_id, "approval_id": approval_id},
+        )
+
+    def create_audit_log(self, **fields) -> AuditLogEntry:
+        body = CreateAuditLogEntry(**_compact(fields)).model_dump(mode="json", exclude_none=True)
+        return self._list(AuditLogEntry, "POST", "/audit-logs", json_body=body)
+
+    def get_audit_log(self, audit_id: str) -> AuditLogEntry:
+        return self._list(AuditLogEntry, "GET", f"/audit-logs/{audit_id}")
+
+    def delete_audit_log(self, audit_id: str) -> DeleteAuditLogResponse:
+        return self._list(DeleteAuditLogResponse, "DELETE", f"/audit-logs/{audit_id}")
+
+    # ---- memory ----
+
+    def list_memory(
+        self,
+        *,
+        layer: str | None = None,
+        scope_id: str | None = None,
+        tags: list[str] | None = None,
+        limit: int = 100,
+    ) -> MemoryListResponse:
+        return self._list(
+            MemoryListResponse,
+            "GET",
+            "/memory",
+            params={"layer": layer, "scope_id": scope_id, "tag": tags, "limit": limit},
+        )
+
+    def get_memory(self, key: str, *, layer: str, scope_id: str) -> MemoryEntry:
+        return self._list(MemoryEntry, "GET", f"/memory/{key}", params={"layer": layer, "scope_id": scope_id})
+
+    # ---- stream ----
+
+    def _stream(self, method: str, path: str, *, json_body: dict[str, Any]) -> Iterator[dict[str, Any]]:
+        timeout = httpx.Timeout(connect=5.0, read=None, write=30.0, pool=5.0)
+        try:
+            with self._client.stream(method, path, json=json_body, timeout=timeout) as response:
+                if response.status_code == 404:
+                    response.read()
+                    raise ResourceNotFound(_response_error_message(response, fallback="Resource not found"))
+                if response.is_error:
+                    response.read()
+                    raise SwarmMindCLIError(
+                        _response_error_message(response, fallback=f"HTTP {response.status_code}"),
+                        status_code=response.status_code,
+                    )
+                for line in response.iter_lines():
+                    event = _parse_stream_line(line)
+                    if event is not None:
+                        yield event
+        except httpx.ConnectError as exc:
+            raise BackendUnavailable(f"Backend unavailable at {self.api_url}: {exc}") from exc
+        except httpx.TimeoutException as exc:
+            raise BackendUnavailable(f"Backend stream timed out at {self.api_url}: {exc}") from exc
+        except httpx.TransportError as exc:
+            raise BackendUnavailable(f"Backend stream transport error at {self.api_url}: {exc}") from exc
+
+
+def _compact(data: dict[str, Any] | None) -> dict[str, Any] | None:
+    if data is None:
+        return None
+    compacted = {k: v for k, v in data.items() if v is not None}
+    return compacted
+
+
+def _message_body(content: str, *, mode: str | None, model_name: str | None, reasoning: bool) -> dict[str, Any]:
+    body = SendMessageRequest(content=content, mode=mode, model_name=model_name, reasoning=reasoning)
+    return body.model_dump(mode="json", exclude_none=True)
+
+
+def _response_data(response: httpx.Response) -> Any:
+    content_type = response.headers.get("content-type", "")
+    if "application/json" not in content_type:
+        return response.text
+    try:
+        return response.json()
+    except json.JSONDecodeError:
+        return response.text
+
+
+def _response_error_message(response: httpx.Response, *, fallback: str) -> str:
+    try:
+        payload = response.json()
+    except json.JSONDecodeError:
+        text = response.text.strip()
+        return text or fallback
+
+    detail = payload.get("detail") if isinstance(payload, dict) else None
+    if isinstance(detail, str):
+        return detail
+    if detail is not None:
+        return json.dumps(detail, ensure_ascii=False)
+    return fallback
+
+
+def _parse_stream_line(line: str) -> dict[str, Any] | None:
+    stripped = line.strip()
+    if not stripped:
+        return None
+    if stripped.startswith("data:"):
+        stripped = stripped[5:].strip()
+    if stripped == "[DONE]":
+        return {"type": "done"}
+    try:
+        data = json.loads(stripped)
+    except json.JSONDecodeError:
+        return {"type": "raw", "text": stripped}
+    return data if isinstance(data, dict) else {"type": "raw", "data": data}

--- a/swarmmind/cli/commands/_common.py
+++ b/swarmmind/cli/commands/_common.py
@@ -1,0 +1,58 @@
+"""Shared command helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Sequence
+from typing import Any
+
+import typer
+from pydantic import ValidationError
+
+from swarmmind.cli.client import ParameterError, SwarmMindCLIError
+from swarmmind.cli.config import get_client, get_state
+from swarmmind.cli.output import render_error, render_result, render_stream_event
+
+
+def run_client_command(ctx: typer.Context, fn: Callable[[Any], Any]) -> None:
+    """Run a client command with normalized errors and output."""
+    state = get_state(ctx)
+    try:
+        with get_client(ctx) as client:
+            result = fn(client)
+    except ValidationError as exc:
+        normalized = ParameterError(str(exc))
+        render_error(normalized, json_output=state.json_output, quiet=state.quiet)
+        raise typer.Exit(normalized.exit_code) from exc
+    except SwarmMindCLIError as exc:
+        render_error(exc, json_output=state.json_output, quiet=state.quiet)
+        raise typer.Exit(exc.exit_code) from exc
+    render_result(result, json_output=state.json_output, quiet=state.quiet)
+
+
+def run_stream_command(ctx: typer.Context, events_fn: Callable[[Any], Iterable[dict[str, Any]]]) -> None:
+    """Run a stream command and render each event as it arrives."""
+    state = get_state(ctx)
+    try:
+        with get_client(ctx) as client:
+            for event in events_fn(client):
+                render_stream_event(event, json_output=state.json_output)
+    except ValidationError as exc:
+        normalized = ParameterError(str(exc))
+        render_error(normalized, json_output=state.json_output, quiet=state.quiet)
+        raise typer.Exit(normalized.exit_code) from exc
+    except SwarmMindCLIError as exc:
+        render_error(exc, json_output=state.json_output, quiet=state.quiet)
+        raise typer.Exit(exc.exit_code) from exc
+
+
+def joined_message(parts: Sequence[str]) -> str:
+    """Join variadic message parts into the final message text."""
+    return " ".join(parts).strip()
+
+
+def split_csv(value: str | None) -> list[str] | None:
+    """Parse a comma-separated option into a list."""
+    if value is None:
+        return None
+    parts = [item.strip() for item in value.split(",") if item.strip()]
+    return parts or None

--- a/swarmmind/cli/commands/approval.py
+++ b/swarmmind/cli/commands/approval.py
@@ -1,0 +1,94 @@
+"""Approval commands."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+import typer
+
+from swarmmind.cli.commands._common import run_client_command
+
+approval_app = typer.Typer(help="Manage approval requests.", no_args_is_help=True)
+
+
+@approval_app.command("list")
+def list_approvals(
+    ctx: typer.Context,
+    project_id: Annotated[str | None, typer.Option("--project-id")] = None,
+    status: Annotated[str | None, typer.Option("--status")] = None,
+    risk_tier: Annotated[str | None, typer.Option("--risk-tier")] = None,
+) -> None:
+    run_client_command(
+        ctx,
+        lambda client: client.list_approvals(project_id=project_id, status=status, risk_tier=risk_tier),
+    )
+
+
+@approval_app.command("create")
+def create_approval(
+    ctx: typer.Context,
+    project_id: Annotated[str, typer.Argument(help="Project ID.")],
+    title: Annotated[str, typer.Argument(help="Approval title.")],
+    run_id: Annotated[str | None, typer.Option("--run-id")] = None,
+    description: Annotated[str | None, typer.Option("--description")] = None,
+    risk_tier: Annotated[str, typer.Option("--risk-tier")] = "medium",
+    requested_capability: Annotated[str | None, typer.Option("--requested-capability")] = None,
+    evidence: Annotated[str | None, typer.Option("--evidence")] = None,
+    impact: Annotated[str | None, typer.Option("--impact")] = None,
+    approver_role: Annotated[str | None, typer.Option("--approver-role")] = None,
+    recovery_behavior: Annotated[str | None, typer.Option("--recovery-behavior")] = None,
+) -> None:
+    run_client_command(
+        ctx,
+        lambda client: client.create_approval(
+            project_id=project_id,
+            run_id=run_id,
+            title=title,
+            description=description,
+            risk_tier=risk_tier,
+            requested_capability=requested_capability,
+            evidence=evidence,
+            impact=impact,
+            approver_role=approver_role,
+            recovery_behavior=recovery_behavior,
+        ),
+    )
+
+
+@approval_app.command("get")
+def get_approval(
+    ctx: typer.Context,
+    approval_id: Annotated[str, typer.Argument(help="Approval ID.")],
+) -> None:
+    run_client_command(ctx, lambda client: client.get_approval(approval_id))
+
+
+@approval_app.command("update")
+def update_approval(
+    ctx: typer.Context,
+    approval_id: Annotated[str, typer.Argument(help="Approval ID.")],
+    status: Annotated[str | None, typer.Option("--status")] = None,
+    decision_reason: Annotated[str | None, typer.Option("--decision-reason")] = None,
+    title: Annotated[str | None, typer.Option("--title")] = None,
+    description: Annotated[str | None, typer.Option("--description")] = None,
+    risk_tier: Annotated[str | None, typer.Option("--risk-tier")] = None,
+) -> None:
+    run_client_command(
+        ctx,
+        lambda client: client.update_approval(
+            approval_id,
+            status=status,
+            decision_reason=decision_reason,
+            title=title,
+            description=description,
+            risk_tier=risk_tier,
+        ),
+    )
+
+
+@approval_app.command("delete")
+def delete_approval(
+    ctx: typer.Context,
+    approval_id: Annotated[str, typer.Argument(help="Approval ID.")],
+) -> None:
+    run_client_command(ctx, lambda client: client.delete_approval(approval_id))

--- a/swarmmind/cli/commands/audit.py
+++ b/swarmmind/cli/commands/audit.py
@@ -1,0 +1,67 @@
+"""Audit log commands."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+import typer
+
+from swarmmind.cli.commands._common import run_client_command
+
+audit_app = typer.Typer(help="Read and write audit logs.", no_args_is_help=True)
+
+
+@audit_app.command("list")
+def list_audit_logs(
+    ctx: typer.Context,
+    project_id: Annotated[str | None, typer.Option("--project-id")] = None,
+    run_id: Annotated[str | None, typer.Option("--run-id")] = None,
+    approval_id: Annotated[str | None, typer.Option("--approval-id")] = None,
+) -> None:
+    run_client_command(
+        ctx,
+        lambda client: client.list_audit_logs(project_id=project_id, run_id=run_id, approval_id=approval_id),
+    )
+
+
+@audit_app.command("get")
+def get_audit_log(
+    ctx: typer.Context,
+    audit_id: Annotated[str, typer.Argument(help="Audit log ID.")],
+) -> None:
+    run_client_command(ctx, lambda client: client.get_audit_log(audit_id))
+
+
+@audit_app.command("create")
+def create_audit_log(
+    ctx: typer.Context,
+    project_id: Annotated[str, typer.Argument(help="Project ID.")],
+    audit_type: Annotated[str, typer.Option("--audit-type")] = "approval_decision",
+    run_id: Annotated[str | None, typer.Option("--run-id")] = None,
+    approval_id: Annotated[str | None, typer.Option("--approval-id")] = None,
+    actor_id: Annotated[str | None, typer.Option("--actor-id")] = None,
+    actor_type: Annotated[str, typer.Option("--actor-type")] = "user",
+    decision: Annotated[str | None, typer.Option("--decision")] = None,
+    reason: Annotated[str | None, typer.Option("--reason")] = None,
+) -> None:
+    run_client_command(
+        ctx,
+        lambda client: client.create_audit_log(
+            project_id=project_id,
+            audit_type=audit_type,
+            run_id=run_id,
+            approval_id=approval_id,
+            actor_id=actor_id,
+            actor_type=actor_type,
+            decision=decision,
+            reason=reason,
+        ),
+    )
+
+
+@audit_app.command("delete")
+def delete_audit_log(
+    ctx: typer.Context,
+    audit_id: Annotated[str, typer.Argument(help="Audit log ID.")],
+) -> None:
+    run_client_command(ctx, lambda client: client.delete_audit_log(audit_id))

--- a/swarmmind/cli/commands/conversation.py
+++ b/swarmmind/cli/commands/conversation.py
@@ -1,0 +1,167 @@
+"""Conversation and chat commands."""
+
+from __future__ import annotations
+
+import json
+from typing import Annotated
+
+import typer
+from pydantic import ValidationError
+
+from swarmmind.cli.client import ParameterError, SwarmMindCLIError
+from swarmmind.cli.commands._common import joined_message, run_client_command, run_stream_command
+from swarmmind.cli.config import get_client, get_state
+from swarmmind.cli.output import render_error, render_result, render_stream_event
+
+conversation_app = typer.Typer(help="Manage ChatSession records.", no_args_is_help=True)
+chat_app = typer.Typer(help="Send ChatSession messages.", no_args_is_help=True)
+
+
+@conversation_app.command("list")
+def list_conversations(ctx: typer.Context) -> None:
+    run_client_command(ctx, lambda client: client.list_conversations())
+
+
+@conversation_app.command("recent")
+def recent_conversation(ctx: typer.Context) -> None:
+    run_client_command(ctx, lambda client: client.recent_conversation())
+
+
+@conversation_app.command("search")
+def search_conversations(
+    ctx: typer.Context,
+    query: Annotated[str, typer.Argument(help="Search query.")],
+    limit: Annotated[int, typer.Option("--limit", min=1, max=100)] = 20,
+) -> None:
+    run_client_command(ctx, lambda client: client.search_conversations(query, limit=limit))
+
+
+@conversation_app.command("create")
+def create_conversation(
+    ctx: typer.Context,
+    title: Annotated[str | None, typer.Option("--title", "-t", help="Optional conversation title.")] = None,
+) -> None:
+    run_client_command(ctx, lambda client: client.create_conversation(title=title))
+
+
+@conversation_app.command("get")
+def get_conversation(
+    ctx: typer.Context,
+    conversation_id: Annotated[str, typer.Argument(help="Conversation ID.")],
+    include_messages: Annotated[bool, typer.Option("--include-messages", help="Include messages in response.")] = False,
+) -> None:
+    run_client_command(ctx, lambda client: client.get_conversation(conversation_id, include_messages=include_messages))
+
+
+@conversation_app.command("messages")
+def list_messages(
+    ctx: typer.Context,
+    conversation_id: Annotated[str, typer.Argument(help="Conversation ID.")],
+) -> None:
+    run_client_command(ctx, lambda client: client.list_messages(conversation_id))
+
+
+@conversation_app.command("trace")
+def conversation_trace(
+    ctx: typer.Context,
+    conversation_id: Annotated[str, typer.Argument(help="Conversation ID.")],
+) -> None:
+    run_client_command(ctx, lambda client: client.get_conversation_trace(conversation_id))
+
+
+@conversation_app.command("export")
+def export_conversation(
+    ctx: typer.Context,
+    conversation_id: Annotated[str, typer.Argument(help="Conversation ID.")],
+    export_format: Annotated[str, typer.Option("--format", help="markdown or json.")] = "markdown",
+) -> None:
+    run_client_command(ctx, lambda client: client.export_conversation(conversation_id, export_format=export_format))
+
+
+@conversation_app.command("delete")
+def delete_conversation(
+    ctx: typer.Context,
+    conversation_id: Annotated[str, typer.Argument(help="Conversation ID.")],
+) -> None:
+    run_client_command(ctx, lambda client: client.delete_conversation(conversation_id))
+
+
+@chat_app.command("send")
+def send_chat(
+    ctx: typer.Context,
+    conversation_id: Annotated[str, typer.Argument(help="Conversation ID.")],
+    message: Annotated[list[str], typer.Argument(help="Message text.")],
+    mode: Annotated[str | None, typer.Option("--mode", help="flash, thinking, pro, or ultra.")] = None,
+    model_name: Annotated[str | None, typer.Option("--model", help="Runtime model option name.")] = None,
+    reasoning: Annotated[bool, typer.Option("--reasoning", help="Enable legacy reasoning flag.")] = False,
+) -> None:
+    content = joined_message(message)
+    run_client_command(
+        ctx,
+        lambda client: client.send_message(
+            conversation_id, content, mode=mode, model_name=model_name, reasoning=reasoning
+        ),
+    )
+
+
+@chat_app.command("stream")
+def stream_chat(
+    ctx: typer.Context,
+    conversation_id: Annotated[str, typer.Argument(help="Conversation ID.")],
+    message: Annotated[list[str], typer.Argument(help="Message text.")],
+    mode: Annotated[str | None, typer.Option("--mode", help="flash, thinking, pro, or ultra.")] = None,
+    model_name: Annotated[str | None, typer.Option("--model", help="Runtime model option name.")] = None,
+    reasoning: Annotated[bool, typer.Option("--reasoning", help="Enable legacy reasoning flag.")] = False,
+) -> None:
+    content = joined_message(message)
+    run_stream_command(
+        ctx,
+        lambda client: client.stream_message(
+            conversation_id, content, mode=mode, model_name=model_name, reasoning=reasoning
+        ),
+    )
+
+
+@chat_app.command("new")
+def new_chat(
+    ctx: typer.Context,
+    message: Annotated[list[str], typer.Argument(help="First message text.")],
+    title: Annotated[str | None, typer.Option("--title", "-t", help="Optional conversation title.")] = None,
+    mode: Annotated[str | None, typer.Option("--mode", help="flash, thinking, pro, or ultra.")] = None,
+    model_name: Annotated[str | None, typer.Option("--model", help="Runtime model option name.")] = None,
+    reasoning: Annotated[bool, typer.Option("--reasoning", help="Enable legacy reasoning flag.")] = False,
+) -> None:
+    state = get_state(ctx)
+    content = joined_message(message)
+    try:
+        with get_client(ctx) as client:
+            conversation = client.create_conversation(title=title)
+            conversation_event = {"type": "conversation", "conversation": conversation.model_dump(mode="json")}
+            if state.json_output:
+                typer.echo(json.dumps(conversation_event, ensure_ascii=False, separators=(",", ":")))
+            else:
+                render_result(conversation, json_output=False)
+            for event in client.stream_message(
+                conversation.id, content, mode=mode, model_name=model_name, reasoning=reasoning
+            ):
+                render_stream_event(event, json_output=state.json_output)
+    except ValidationError as exc:
+        normalized = ParameterError(str(exc))
+        render_error(normalized, json_output=state.json_output, quiet=state.quiet)
+        raise typer.Exit(normalized.exit_code) from exc
+    except SwarmMindCLIError as exc:
+        render_error(exc, json_output=state.json_output, quiet=state.quiet)
+        raise typer.Exit(exc.exit_code) from exc
+
+
+@chat_app.command("respond-clarification")
+def respond_clarification(
+    ctx: typer.Context,
+    conversation_id: Annotated[str, typer.Argument(help="Conversation ID.")],
+    tool_call_id: Annotated[str, typer.Argument(help="Clarification tool call ID.")],
+    response: Annotated[list[str], typer.Argument(help="Clarification response.")],
+) -> None:
+    run_client_command(
+        ctx,
+        lambda client: client.respond_to_clarification(conversation_id, tool_call_id, joined_message(response)),
+    )

--- a/swarmmind/cli/commands/mcp.py
+++ b/swarmmind/cli/commands/mcp.py
@@ -1,0 +1,18 @@
+"""MCP server commands."""
+
+from __future__ import annotations
+
+import typer
+
+from swarmmind.cli.config import get_state
+
+mcp_app = typer.Typer(help="Expose SwarmMind CLI capabilities over MCP.", no_args_is_help=True)
+
+
+@mcp_app.command("serve")
+def serve_mcp(ctx: typer.Context) -> None:
+    state = get_state(ctx)
+    from swarmmind.cli.mcp_server import build_mcp_server
+
+    server = build_mcp_server(api_url=state.api_url)
+    server.run(transport="stdio")

--- a/swarmmind/cli/commands/memory.py
+++ b/swarmmind/cli/commands/memory.py
@@ -1,0 +1,32 @@
+"""Layered memory commands."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+import typer
+
+from swarmmind.cli.commands._common import run_client_command
+
+memory_app = typer.Typer(help="Read layered memory entries.", no_args_is_help=True)
+
+
+@memory_app.command("list")
+def list_memory(
+    ctx: typer.Context,
+    layer: Annotated[str | None, typer.Option("--layer", help="Memory layer, e.g. L3_project.")] = None,
+    scope_id: Annotated[str | None, typer.Option("--scope-id", help="Scope ID within the layer.")] = None,
+    tag: Annotated[list[str] | None, typer.Option("--tag", help="Repeatable tag filter.")] = None,
+    limit: Annotated[int, typer.Option("--limit", min=1, max=500)] = 100,
+) -> None:
+    run_client_command(ctx, lambda client: client.list_memory(layer=layer, scope_id=scope_id, tags=tag, limit=limit))
+
+
+@memory_app.command("get")
+def get_memory(
+    ctx: typer.Context,
+    key: Annotated[str, typer.Argument(help="Memory key.")],
+    layer: Annotated[str, typer.Option("--layer", help="Memory layer, e.g. L3_project.")],
+    scope_id: Annotated[str, typer.Option("--scope-id", help="Scope ID within the layer.")],
+) -> None:
+    run_client_command(ctx, lambda client: client.get_memory(key, layer=layer, scope_id=scope_id))

--- a/swarmmind/cli/commands/project.py
+++ b/swarmmind/cli/commands/project.py
@@ -1,0 +1,120 @@
+"""Project commands."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+import typer
+
+from swarmmind.cli.commands._common import joined_message, run_client_command, run_stream_command
+
+project_app = typer.Typer(help="Manage governed projects.", no_args_is_help=True)
+
+
+@project_app.command("list")
+def list_projects(
+    ctx: typer.Context,
+    limit: Annotated[int | None, typer.Option("--limit", min=1, max=500)] = None,
+    offset: Annotated[int, typer.Option("--offset", min=0)] = 0,
+) -> None:
+    run_client_command(ctx, lambda client: client.list_projects(limit=limit, offset=offset))
+
+
+@project_app.command("create")
+def create_project(
+    ctx: typer.Context,
+    title: Annotated[str, typer.Argument(help="Project title.")],
+    goal: Annotated[str | None, typer.Option("--goal", help="Project goal.")] = None,
+    scope: Annotated[str | None, typer.Option("--scope", help="Project scope.")] = None,
+    constraints: Annotated[str | None, typer.Option("--constraints", help="Project constraints.")] = None,
+    source_conversation_id: Annotated[str | None, typer.Option("--source-conversation-id")] = None,
+    next_step: Annotated[str | None, typer.Option("--next-step")] = None,
+    phase: Annotated[str | None, typer.Option("--phase")] = None,
+    risk_level: Annotated[str | None, typer.Option("--risk-level")] = None,
+    team_template_id: Annotated[str | None, typer.Option("--team-template-id")] = None,
+) -> None:
+    run_client_command(
+        ctx,
+        lambda client: client.create_project(
+            title=title,
+            goal=goal,
+            scope=scope,
+            constraints=constraints,
+            source_conversation_id=source_conversation_id,
+            next_step=next_step,
+            phase=phase,
+            risk_level=risk_level,
+            team_template_id=team_template_id,
+        ),
+    )
+
+
+@project_app.command("get")
+def get_project(
+    ctx: typer.Context,
+    project_id: Annotated[str, typer.Argument(help="Project ID.")],
+) -> None:
+    run_client_command(ctx, lambda client: client.get_project(project_id))
+
+
+@project_app.command("update")
+def update_project(
+    ctx: typer.Context,
+    project_id: Annotated[str, typer.Argument(help="Project ID.")],
+    title: Annotated[str | None, typer.Option("--title")] = None,
+    goal: Annotated[str | None, typer.Option("--goal")] = None,
+    scope: Annotated[str | None, typer.Option("--scope")] = None,
+    constraints: Annotated[str | None, typer.Option("--constraints")] = None,
+    next_step: Annotated[str | None, typer.Option("--next-step")] = None,
+    phase: Annotated[str | None, typer.Option("--phase")] = None,
+    risk_level: Annotated[str | None, typer.Option("--risk-level")] = None,
+    status: Annotated[str | None, typer.Option("--status")] = None,
+) -> None:
+    run_client_command(
+        ctx,
+        lambda client: client.update_project(
+            project_id,
+            title=title,
+            goal=goal,
+            scope=scope,
+            constraints=constraints,
+            next_step=next_step,
+            phase=phase,
+            risk_level=risk_level,
+            status=status,
+        ),
+    )
+
+
+@project_app.command("overview")
+def project_overview(
+    ctx: typer.Context,
+    project_id: Annotated[str, typer.Argument(help="Project ID.")],
+) -> None:
+    run_client_command(ctx, lambda client: client.project_overview(project_id))
+
+
+@project_app.command("delete")
+def delete_project(
+    ctx: typer.Context,
+    project_id: Annotated[str, typer.Argument(help="Project ID.")],
+) -> None:
+    run_client_command(ctx, lambda client: client.delete_project(project_id))
+
+
+@project_app.command("stream")
+def stream_project(
+    ctx: typer.Context,
+    project_id: Annotated[str, typer.Argument(help="Project ID.")],
+    message: Annotated[list[str], typer.Argument(help="Message text.")],
+    mode: Annotated[str | None, typer.Option("--mode", help="flash, thinking, pro, or ultra.")] = None,
+    model_name: Annotated[str | None, typer.Option("--model", help="Runtime model option name.")] = None,
+    reasoning: Annotated[bool, typer.Option("--reasoning", help="Enable legacy reasoning flag.")] = False,
+) -> None:
+    content = joined_message(message)
+    run_stream_command(
+        ctx,
+        lambda client: client.stream_project_message(
+            project_id, content, mode=mode, model_name=model_name, reasoning=reasoning
+        ),
+    )

--- a/swarmmind/cli/commands/run.py
+++ b/swarmmind/cli/commands/run.py
@@ -1,0 +1,64 @@
+"""Run commands."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+import typer
+
+from swarmmind.cli.commands._common import run_client_command
+
+run_app = typer.Typer(help="Manage execution runs.", no_args_is_help=True)
+
+
+@run_app.command("list")
+def list_runs(
+    ctx: typer.Context,
+    project_id: Annotated[str | None, typer.Option("--project-id", help="List project runs.")] = None,
+    conversation_id: Annotated[str | None, typer.Option("--conversation-id", help="List conversation runs.")] = None,
+) -> None:
+    if bool(project_id) == bool(conversation_id):
+        raise typer.BadParameter("provide exactly one of --project-id or --conversation-id")
+    run_client_command(ctx, lambda client: client.list_runs(project_id=project_id, conversation_id=conversation_id))
+
+
+@run_app.command("get")
+def get_run(
+    ctx: typer.Context,
+    run_id: Annotated[str, typer.Argument(help="Run ID.")],
+) -> None:
+    run_client_command(ctx, lambda client: client.get_run(run_id))
+
+
+@run_app.command("create")
+def create_run(
+    ctx: typer.Context,
+    project_id: Annotated[str | None, typer.Option("--project-id")] = None,
+    conversation_id: Annotated[str | None, typer.Option("--conversation-id")] = None,
+    goal: Annotated[str | None, typer.Option("--goal")] = None,
+    status: Annotated[str, typer.Option("--status")] = "running",
+) -> None:
+    run_client_command(
+        ctx,
+        lambda client: client.create_run(
+            project_id=project_id,
+            conversation_id=conversation_id,
+            goal=goal,
+            status=status,
+        ),
+    )
+
+
+@run_app.command("update")
+def update_run(
+    ctx: typer.Context,
+    run_id: Annotated[str, typer.Argument(help="Run ID.")],
+    project_id: Annotated[str | None, typer.Option("--project-id")] = None,
+    status: Annotated[str | None, typer.Option("--status")] = None,
+    goal: Annotated[str | None, typer.Option("--goal")] = None,
+    summary: Annotated[str | None, typer.Option("--summary")] = None,
+) -> None:
+    run_client_command(
+        ctx,
+        lambda client: client.update_run(run_id, project_id=project_id, status=status, goal=goal, summary=summary),
+    )

--- a/swarmmind/cli/commands/system.py
+++ b/swarmmind/cli/commands/system.py
@@ -1,0 +1,44 @@
+"""Root-level system commands."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+import typer
+
+from swarmmind.cli.commands._common import joined_message, run_client_command
+
+
+def register_system_commands(app: typer.Typer) -> None:
+    """Register system and dispatch commands on the root app."""
+
+    @app.command("health")
+    def health(ctx: typer.Context) -> None:
+        run_client_command(ctx, lambda client: client.health())
+
+    @app.command("ready")
+    def ready(ctx: typer.Context) -> None:
+        run_client_command(ctx, lambda client: client.ready())
+
+    @app.command("dispatch")
+    def dispatch(
+        ctx: typer.Context,
+        goal: Annotated[list[str], typer.Argument(help="Goal text.")],
+    ) -> None:
+        run_client_command(ctx, lambda client: client.dispatch(joined_message(goal)))
+
+    @app.command("serve")
+    def serve(
+        host: Annotated[str, typer.Option("--host", help="API bind host.")] = "127.0.0.1",
+        port: Annotated[int, typer.Option("--port", help="API bind port.")] = 8000,
+        reload: Annotated[bool, typer.Option("--reload", help="Enable uvicorn reload.")] = False,
+    ) -> None:
+        import uvicorn
+
+        if reload:
+            uvicorn.run("swarmmind.api.supervisor:app", host=host, port=port, reload=True)
+            return
+
+        from swarmmind.api.supervisor import app as supervisor_app
+
+        uvicorn.run(supervisor_app, host=host, port=port)

--- a/swarmmind/cli/commands/task.py
+++ b/swarmmind/cli/commands/task.py
@@ -1,0 +1,93 @@
+"""Task commands."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+import typer
+
+from swarmmind.cli.commands._common import run_client_command, split_csv
+
+task_app = typer.Typer(help="Manage project tasks.", no_args_is_help=True)
+
+
+@task_app.command("list")
+def list_tasks(
+    ctx: typer.Context,
+    project_id: Annotated[str, typer.Argument(help="Project ID.")],
+) -> None:
+    run_client_command(ctx, lambda client: client.list_tasks(project_id))
+
+
+@task_app.command("create")
+def create_task(
+    ctx: typer.Context,
+    project_id: Annotated[str, typer.Argument(help="Project ID.")],
+    title: Annotated[str, typer.Argument(help="Task title.")],
+    description: Annotated[str | None, typer.Option("--description")] = None,
+    status: Annotated[str, typer.Option("--status")] = "todo",
+    assignee_role: Annotated[str | None, typer.Option("--assignee-role")] = None,
+    source_workstream: Annotated[str | None, typer.Option("--source-workstream")] = None,
+    artifact_ids: Annotated[str | None, typer.Option("--artifact-ids", help="Comma-separated artifact IDs.")] = None,
+    priority: Annotated[str, typer.Option("--priority")] = "medium",
+) -> None:
+    run_client_command(
+        ctx,
+        lambda client: client.create_task(
+            project_id,
+            title=title,
+            description=description,
+            status=status,
+            assignee_role=assignee_role,
+            source_workstream=source_workstream,
+            artifact_ids=split_csv(artifact_ids),
+            priority=priority,
+        ),
+    )
+
+
+@task_app.command("get")
+def get_task(
+    ctx: typer.Context,
+    project_id: Annotated[str, typer.Argument(help="Project ID.")],
+    task_id: Annotated[str, typer.Argument(help="Task ID.")],
+) -> None:
+    run_client_command(ctx, lambda client: client.get_task(project_id, task_id))
+
+
+@task_app.command("update")
+def update_task(
+    ctx: typer.Context,
+    project_id: Annotated[str, typer.Argument(help="Project ID.")],
+    task_id: Annotated[str, typer.Argument(help="Task ID.")],
+    title: Annotated[str | None, typer.Option("--title")] = None,
+    description: Annotated[str | None, typer.Option("--description")] = None,
+    status: Annotated[str | None, typer.Option("--status")] = None,
+    assignee_role: Annotated[str | None, typer.Option("--assignee-role")] = None,
+    source_workstream: Annotated[str | None, typer.Option("--source-workstream")] = None,
+    artifact_ids: Annotated[str | None, typer.Option("--artifact-ids", help="Comma-separated artifact IDs.")] = None,
+    priority: Annotated[str | None, typer.Option("--priority")] = None,
+) -> None:
+    run_client_command(
+        ctx,
+        lambda client: client.update_task(
+            project_id,
+            task_id,
+            title=title,
+            description=description,
+            status=status,
+            assignee_role=assignee_role,
+            source_workstream=source_workstream,
+            artifact_ids=split_csv(artifact_ids),
+            priority=priority,
+        ),
+    )
+
+
+@task_app.command("delete")
+def delete_task(
+    ctx: typer.Context,
+    project_id: Annotated[str, typer.Argument(help="Project ID.")],
+    task_id: Annotated[str, typer.Argument(help="Task ID.")],
+) -> None:
+    run_client_command(ctx, lambda client: client.delete_task(project_id, task_id))

--- a/swarmmind/cli/config.py
+++ b/swarmmind/cli/config.py
@@ -1,0 +1,42 @@
+"""CLI configuration and context helpers."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+import typer
+
+DEFAULT_API_URL = "http://127.0.0.1:8000"
+API_URL_ENV = "SWARMMIND_API_URL"
+
+
+@dataclass
+class CLIState:
+    """Resolved root CLI state shared by commands."""
+
+    api_url: str
+    json_output: bool = False
+    quiet: bool = False
+
+
+def resolve_api_url(api_url: str | None = None) -> str:
+    """Resolve API URL from flag, environment, then local default."""
+    resolved = api_url or os.environ.get(API_URL_ENV) or DEFAULT_API_URL
+    return resolved.rstrip("/")
+
+
+def get_state(ctx: typer.Context) -> CLIState:
+    """Return the current CLI state from Typer context."""
+    if isinstance(ctx.obj, CLIState):
+        return ctx.obj
+    state = CLIState(api_url=resolve_api_url())
+    ctx.obj = state
+    return state
+
+
+def get_client(ctx: typer.Context):
+    """Create an HTTP client for the current CLI invocation."""
+    from swarmmind.cli.client import SwarmMindClient
+
+    return SwarmMindClient(api_url=get_state(ctx).api_url)

--- a/swarmmind/cli/mcp_server.py
+++ b/swarmmind/cli/mcp_server.py
@@ -1,0 +1,60 @@
+"""MCP stdio server wrapping SwarmMind CLI client capabilities."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from swarmmind.cli.output import to_data
+
+
+def build_mcp_server(api_url: str):
+    """Build a FastMCP server for SwarmMind HTTP capabilities."""
+    try:
+        from mcp.server.fastmcp import FastMCP
+    except ModuleNotFoundError as exc:
+        raise RuntimeError("MCP support is not installed. Install with `pip install 'swarmmind[mcp]'`.") from exc
+
+    from swarmmind.cli.client import SwarmMindClient
+
+    mcp = FastMCP("swarmmind")
+
+    def _client_call(fn):
+        with SwarmMindClient(api_url=api_url) as client:
+            return to_data(fn(client))
+
+    @mcp.tool()
+    def health() -> dict[str, Any]:
+        """Check SwarmMind supervisor API health."""
+        return _client_call(lambda client: client.health())
+
+    @mcp.tool()
+    def dispatch(goal: str) -> dict[str, Any]:
+        """Dispatch a goal through the SwarmMind supervisor router."""
+        return _client_call(lambda client: client.dispatch(goal))
+
+    @mcp.tool()
+    def conversation_create(title: str | None = None) -> dict[str, Any]:
+        """Create a ChatSession."""
+        return _client_call(lambda client: client.create_conversation(title=title))
+
+    @mcp.tool()
+    def chat_send(conversation_id: str, message: str, mode: str | None = None) -> dict[str, Any]:
+        """Send a non-streaming ChatSession message."""
+        return _client_call(lambda client: client.send_message(conversation_id, message, mode=mode))
+
+    @mcp.tool()
+    def project_list() -> dict[str, Any]:
+        """List governed projects."""
+        return _client_call(lambda client: client.list_projects())
+
+    @mcp.tool()
+    def project_create(title: str, goal: str | None = None) -> dict[str, Any]:
+        """Create a governed project."""
+        return _client_call(lambda client: client.create_project(title=title, goal=goal))
+
+    @mcp.tool()
+    def memory_get(key: str, layer: str, scope_id: str) -> dict[str, Any]:
+        """Read one layered-memory entry."""
+        return _client_call(lambda client: client.get_memory(key, layer=layer, scope_id=scope_id))
+
+    return mcp

--- a/swarmmind/cli/output.py
+++ b/swarmmind/cli/output.py
@@ -1,0 +1,174 @@
+"""CLI output renderers for human, JSON, and stream modes."""
+
+from __future__ import annotations
+
+import json
+from enum import Enum
+from typing import Any
+
+import typer
+from pydantic import BaseModel
+
+from swarmmind.cli.client import SwarmMindCLIError
+
+
+def to_data(value: Any) -> Any:
+    """Convert Pydantic and enum values into JSON-serializable data."""
+    if isinstance(value, BaseModel):
+        return value.model_dump(mode="json")
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, list):
+        return [to_data(v) for v in value]
+    if isinstance(value, tuple):
+        return [to_data(v) for v in value]
+    if isinstance(value, dict):
+        return {k: to_data(v) for k, v in value.items()}
+    return value
+
+
+def render_result(value: Any, *, json_output: bool, quiet: bool = False) -> None:
+    """Render a command result to stdout."""
+    if quiet:
+        return
+    data = to_data(value)
+    if json_output:
+        typer.echo(json.dumps(data, ensure_ascii=False, separators=(",", ":")))
+        return
+    typer.echo(render_human(data))
+
+
+def render_error(error: SwarmMindCLIError, *, json_output: bool, quiet: bool = False) -> None:
+    """Render a normalized CLI error to stderr."""
+    if quiet:
+        return
+    if json_output:
+        typer.echo(
+            json.dumps(
+                {
+                    "error": error.message,
+                    "exit_code": error.exit_code,
+                    "status_code": error.status_code,
+                },
+                ensure_ascii=False,
+                separators=(",", ":"),
+            ),
+            err=True,
+        )
+        return
+    typer.echo(f"error: {error.message}", err=True)
+
+
+def render_human(data: Any) -> str:
+    """Render JSON-like data in a compact human-readable form."""
+    if data is None:
+        return "no content"
+    if isinstance(data, str):
+        return data
+    if isinstance(data, list):
+        return "\n".join(_summarize_item(item) for item in data) if data else "no items"
+    if isinstance(data, dict):
+        if "items" in data and isinstance(data["items"], list):
+            lines = [f"total: {data.get('total', len(data['items']))}"]
+            lines.extend(_summarize_item(item) for item in data["items"])
+            return "\n".join(lines)
+        return "\n".join(f"{key}: {_short(value)}" for key, value in data.items())
+    return str(data)
+
+
+def render_stream_event(event: dict[str, Any], *, json_output: bool) -> None:
+    """Render one streaming event."""
+    if json_output:
+        typer.echo(json.dumps(to_data(event), ensure_ascii=False, separators=(",", ":")))
+        return
+    text = stream_event_text(event)
+    if text:
+        typer.echo(text)
+
+
+def stream_event_text(event: dict[str, Any]) -> str | None:
+    """Return a human-readable line for a stream event."""
+    event_type = event.get("type")
+    if event_type == "status":
+        return _first_text(event, "label", "phase")
+    if event_type in {"status.thinking", "status.running"}:
+        return _first_text(event, "text", "label")
+    if event_type == "status.plan_steps":
+        steps = event.get("steps") or []
+        descriptions = [s.get("description") for s in steps if isinstance(s, dict) and s.get("description")]
+        return "plan: " + " | ".join(descriptions) if descriptions else None
+    if event_type == "status.artifact":
+        return f"artifact: {_first_text(event, 'name', 'artifact_type')}"
+    if event_type == "status.clarification":
+        return f"clarification: {_first_text(event, 'question')}"
+    if event_type == "status.waiting_approval":
+        return f"waiting approval: {_first_text(event, 'title', 'approval_id', 'requested_capability')}"
+    if event_type == "content.accumulated":
+        return str(event.get("text") or "")
+    if event_type == "assistant_final":
+        message = event.get("message")
+        if isinstance(message, dict):
+            return str(message.get("content") or "")
+        return None
+    if event_type == "user_message":
+        return None
+    if event_type in {"task_started", "task_running", "task_completed", "task_failed"}:
+        task = event.get("task")
+        if isinstance(task, dict):
+            return f"{event_type}: {_first_text(task, 'description', 'message', 'result', 'error', 'id')}"
+    if event_type == "team_activity":
+        activity = event.get("activity")
+        if isinstance(activity, dict):
+            label = _first_text(activity, "label", "detail")
+            detail = activity.get("detail")
+            return f"{label}: {detail}" if label and detail and label != detail else label
+    if event_type == "title":
+        conversation = event.get("conversation")
+        if isinstance(conversation, dict):
+            return f"title: {conversation.get('title')}"
+    if event_type == "error":
+        return f"error: {_first_text(event, 'message', 'code')}"
+    if event_type == "done":
+        return "done"
+    if event_type == "raw":
+        return str(event.get("text") or event.get("data") or "")
+    return None
+
+
+def _summarize_item(item: Any) -> str:
+    if not isinstance(item, dict):
+        return _short(item)
+    for fields in (
+        ("project_id", "title", "status"),
+        ("id", "title", "updated_at"),
+        ("run_id", "status", "goal"),
+        ("task_id", "title", "status"),
+        ("approval_id", "title", "status"),
+        ("audit_id", "audit_type", "decision"),
+        ("key", "value", "version"),
+        ("agent_id", "status", "action_proposal_id"),
+    ):
+        present = [(field, item.get(field)) for field in fields if item.get(field) is not None]
+        if present:
+            return "  " + " | ".join(f"{field}={_short(value)}" for field, value in present)
+    return "  " + json.dumps(item, ensure_ascii=False, default=str)
+
+
+def _short(value: Any, max_len: int = 140) -> str:
+    data = to_data(value)
+    if isinstance(data, (dict, list)):
+        text = json.dumps(data, ensure_ascii=False, default=str)
+    else:
+        text = str(data)
+    text = text.replace("\n", "\\n")
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 1] + "…"
+
+
+def _first_text(data: dict[str, Any], *keys: str) -> str:
+    for key in keys:
+        value = data.get(key)
+        if value is not None:
+            return _short(value)
+    return ""

--- a/swarmmind/config.py
+++ b/swarmmind/config.py
@@ -9,8 +9,9 @@ import os
 
 from dotenv import load_dotenv
 
-# Load .env file if present (override system env vars so .env takes precedence)
-load_dotenv(override=True)
+# Load .env file if present. Explicit process env vars take precedence so CLI/API
+# smoke tests and deployment overrides can select isolated databases and runtimes.
+load_dotenv(override=False)
 
 # Database
 # Preferred: a full SQLAlchemy URL so deployments can switch dialects by config only.

--- a/swarmmind/models.py
+++ b/swarmmind/models.py
@@ -133,6 +133,13 @@ class MemoryEntry(BaseModel):
     last_writer_agent_id: str | None = None
 
 
+class MemoryListResponse(BaseModel):
+    """Response containing layered-memory entries."""
+
+    items: list[MemoryEntry]
+    total: int
+
+
 class MemoryContext(BaseModel):
     """Carries scope information through a request lifecycle."""
 

--- a/swarmmind/repositories/memory.py
+++ b/swarmmind/repositories/memory.py
@@ -52,6 +52,30 @@ class MemoryRepository:
                 session.expunge(r)
             return list(results)
 
+    def list_by_filters(
+        self,
+        *,
+        layer: str | None = None,
+        scope_id: str | None = None,
+        tags: list[str] | None = None,
+        limit: int = 100,
+    ) -> list[MemoryEntryDB]:
+        """Read memory entries by optional layer, scope, and tag filters."""
+        with session_scope() as session:
+            query = select(MemoryEntryDB)
+            if layer:
+                query = query.where(MemoryEntryDB.layer == layer)
+            if scope_id:
+                query = query.where(MemoryEntryDB.scope_id == scope_id)
+            if tags:
+                for tag in tags:
+                    query = query.where(MemoryEntryDB.tags.contains(tag))
+            query = query.order_by(MemoryEntryDB.updated_at.desc()).limit(limit)
+            results = session.exec(query).all()
+            for r in results:
+                session.expunge(r)
+            return list(results)
+
     def write(
         self,
         scope: MemoryScope,

--- a/swarmmind/repositories/project.py
+++ b/swarmmind/repositories/project.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import uuid
 
 from fastapi import HTTPException
+from sqlalchemy import func
 from sqlmodel import select
 
 from swarmmind.db import session_scope
@@ -15,15 +16,21 @@ from swarmmind.time_utils import utc_now
 class ProjectRepository:
     """Repository for project operations."""
 
-    def list_all(self) -> list[ProjectDB]:
+    def list_all(self, *, limit: int | None = None, offset: int = 0) -> list[ProjectDB]:
         """List all projects ordered by updated_at descending."""
         with session_scope() as session:
-            results = session.exec(
-                select(ProjectDB).order_by(ProjectDB.updated_at.desc()),
-            ).all()
+            statement = select(ProjectDB).order_by(ProjectDB.updated_at.desc()).offset(offset)
+            if limit is not None:
+                statement = statement.limit(limit)
+            results = session.exec(statement).all()
             for r in results:
                 session.expunge(r)
             return list(results)
+
+    def count_all(self) -> int:
+        """Return total project count."""
+        with session_scope() as session:
+            return session.exec(select(func.count(ProjectDB.project_id))).one()
 
     def get_by_id(self, project_id: str) -> ProjectDB:
         """Get a project by ID or raise 404."""

--- a/tests/test_cli_client.py
+++ b/tests/test_cli_client.py
@@ -1,0 +1,71 @@
+"""CLI HTTP client tests."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from swarmmind.cli.client import BackendUnavailable, ResourceNotFound, SwarmMindClient
+from swarmmind.models import HealthResponse
+
+
+def _client_with_transport(transport: httpx.MockTransport) -> SwarmMindClient:
+    client = SwarmMindClient("http://swarmmind.test")
+    client.close()
+    client._client = httpx.Client(base_url="http://swarmmind.test", transport=transport)
+    return client
+
+
+def test_health_parses_shared_model() -> None:
+    transport = httpx.MockTransport(
+        lambda request: httpx.Response(200, json={"status": "ok", "timestamp": "2026-05-17T00:00:00Z"})
+    )
+    client = _client_with_transport(transport)
+
+    result = client.health()
+
+    assert isinstance(result, HealthResponse)
+    assert result.status == "ok"
+
+
+def test_not_found_maps_to_stable_exit_error() -> None:
+    transport = httpx.MockTransport(lambda request: httpx.Response(404, json={"detail": "missing"}))
+    client = _client_with_transport(transport)
+
+    with pytest.raises(ResourceNotFound) as exc_info:
+        client.get_project("missing")
+
+    assert exc_info.value.exit_code == 4
+    assert exc_info.value.message == "missing"
+
+
+def test_transport_error_maps_to_backend_unavailable() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("down", request=request)
+
+    client = _client_with_transport(httpx.MockTransport(handler))
+
+    with pytest.raises(BackendUnavailable) as exc_info:
+        client.health()
+
+    assert exc_info.value.exit_code == 3
+
+
+def test_stream_parses_ndjson_and_sse_lines() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/conversations/conv-1/messages/stream"
+        body = json.loads(request.content.decode())
+        assert body["content"] == "hello"
+        content = b'{"type":"status","label":"accepted"}\ndata: {"type":"done"}\n'
+        return httpx.Response(200, content=content, headers={"content-type": "application/x-ndjson"})
+
+    client = _client_with_transport(httpx.MockTransport(handler))
+
+    events = list(client.stream_message("conv-1", "hello"))
+
+    assert events == [
+        {"type": "status", "label": "accepted"},
+        {"type": "done"},
+    ]

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1,0 +1,77 @@
+"""CLI command smoke tests."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+from typer.testing import CliRunner
+
+from swarmmind.cli import client as cli_client
+from swarmmind.cli.__main__ import app
+
+runner = CliRunner()
+
+
+def _patch_httpx_client(monkeypatch, handler) -> None:
+    real_client = httpx.Client
+    transport = httpx.MockTransport(handler)
+
+    def factory(*args, **kwargs):
+        return real_client(*args, transport=transport, **kwargs)
+
+    monkeypatch.setattr(cli_client.httpx, "Client", factory)
+
+
+def test_health_json_command(monkeypatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/health"
+        return httpx.Response(200, json={"status": "ok", "timestamp": "2026-05-17T00:00:00Z"})
+
+    _patch_httpx_client(monkeypatch, handler)
+
+    result = runner.invoke(app, ["--api-url", "http://swarmmind.test", "--json", "health"])
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)["status"] == "ok"
+
+
+def test_chat_stream_json_command(monkeypatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/conversations/conv-1/messages/stream"
+        payload = json.loads(request.content.decode())
+        assert payload["content"] == "hello world"
+        return httpx.Response(
+            200,
+            content=b'{"type":"status","label":"accepted"}\n{"type":"done"}\n',
+            headers={"content-type": "application/x-ndjson"},
+        )
+
+    _patch_httpx_client(monkeypatch, handler)
+
+    result = runner.invoke(
+        app,
+        ["--api-url", "http://swarmmind.test", "--json", "chat", "stream", "conv-1", "hello", "world"],
+    )
+
+    assert result.exit_code == 0
+    lines = [json.loads(line) for line in result.stdout.splitlines()]
+    assert lines == [{"type": "status", "label": "accepted"}, {"type": "done"}]
+
+
+def test_project_list_limit_command(monkeypatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/projects"
+        assert request.url.params["limit"] == "5"
+        assert request.url.params["offset"] == "2"
+        return httpx.Response(200, json={"items": [], "total": 0})
+
+    _patch_httpx_client(monkeypatch, handler)
+
+    result = runner.invoke(
+        app,
+        ["--api-url", "http://swarmmind.test", "--json", "project", "list", "--limit", "5", "--offset", "2"],
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout) == {"items": [], "total": 0}

--- a/tests/test_memory_api.py
+++ b/tests/test_memory_api.py
@@ -1,0 +1,68 @@
+"""Read-only memory API tests."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from swarmmind.api.supervisor import app
+from swarmmind.db import dispose_engines, init_db
+from swarmmind.models import MemoryLayer, MemoryScope
+from swarmmind.repositories.memory import MemoryRepository
+
+client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def setup_db(monkeypatch, tmp_path):
+    db_path = tmp_path / "memory_api_test.db"
+    monkeypatch.setenv("SWARMMIND_DATABASE_URL", f"sqlite:///{db_path}")
+    dispose_engines()
+    init_db()
+
+
+def test_get_memory_entry_by_scope() -> None:
+    repo = MemoryRepository()
+    repo.write(
+        MemoryScope(layer=MemoryLayer.PROJECT, scope_id="proj-1"),
+        key="decision",
+        value="ship",
+        tags=["release"],
+        ttl=None,
+        agent_id="test",
+    )
+
+    response = client.get("/memory/decision", params={"layer": "L3_project", "scope_id": "proj-1"})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["key"] == "decision"
+    assert data["value"] == "ship"
+    assert data["scope"]["scope_id"] == "proj-1"
+
+
+def test_list_memory_filters_by_layer_and_scope() -> None:
+    repo = MemoryRepository()
+    repo.write(
+        MemoryScope(layer=MemoryLayer.PROJECT, scope_id="proj-1"),
+        key="visible",
+        value="yes",
+        tags=None,
+        ttl=None,
+        agent_id="test",
+    )
+    repo.write(
+        MemoryScope(layer=MemoryLayer.PROJECT, scope_id="proj-2"),
+        key="hidden",
+        value="no",
+        tags=None,
+        ttl=None,
+        agent_id="test",
+    )
+
+    response = client.get("/memory", params={"layer": "L3_project", "scope_id": "proj-1"})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] == 1
+    assert data["items"][0]["key"] == "visible"

--- a/tests/test_project_api.py
+++ b/tests/test_project_api.py
@@ -61,6 +61,18 @@ class TestProjectEndpoints:
         assert "A" in titles
         assert "B" in titles
 
+    def test_list_projects_supports_limit_and_offset(self):
+        client.post("/projects", json={"title": "A"})
+        client.post("/projects", json={"title": "B"})
+        client.post("/projects", json={"title": "C"})
+
+        response = client.get("/projects", params={"limit": 1, "offset": 1})
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 3
+        assert len(data["items"]) == 1
+
     def test_create_project_with_phase_and_risk_level(self):
         response = client.post(
             "/projects",

--- a/uv.lock
+++ b/uv.lock
@@ -3990,7 +3990,7 @@ wheels = [
 [[package]]
 name = "swarmmind"
 version = "0.1.1"
-source = { virtual = "." }
+source = { editable = "." }
 dependencies = [
     { name = "alembic" },
     { name = "anthropic" },
@@ -4005,7 +4005,13 @@ dependencies = [
     { name = "pytest-asyncio" },
     { name = "python-dotenv" },
     { name = "sqlmodel" },
+    { name = "typer" },
     { name = "uvicorn", extra = ["standard"] },
+]
+
+[package.optional-dependencies]
+mcp = [
+    { name = "mcp" },
 ]
 
 [package.dev-dependencies]
@@ -4024,6 +4030,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "httpx", specifier = ">=0.27.2" },
     { name = "litellm", specifier = ">=1.82.6" },
+    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.26.0" },
     { name = "openai", specifier = ">=1.0.0" },
     { name = "psycopg2-binary", specifier = ">=2.9.11" },
     { name = "pydantic", specifier = ">=2.9.2" },
@@ -4031,8 +4038,10 @@ requires-dist = [
     { name = "pytest-asyncio", specifier = ">=0.24.0" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "sqlmodel", specifier = ">=0.0.21" },
+    { name = "typer", specifier = ">=0.24.1" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.6" },
 ]
+provides-extras = ["mcp"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary
- add the HTTP-first swarmmind CLI with health, chat/conversation, project, run, task, approval, audit, memory, serve, and MCP commands
- add read-only memory API endpoints and project list pagination for CLI/API loops
- document CLI as a first-class interface in README and docs/cli.md
- keep explicit environment variables ahead of .env so smoke tests can use isolated databases

## Validation
- uv lock --check
- .venv/bin/ruff check pyproject.toml swarmmind tests
- make test (459 passed)
- installed CLI/API smoke with temporary SQLite database: health, project list/create, memory list