### PR TITLE
Add project membership CLI and API

### DIFF
--- a/alembic/versions/c1d2e3f4a5b6_project_memberships.py
+++ b/alembic/versions/c1d2e3f4a5b6_project_memberships.py
@@ -1,0 +1,50 @@
+"""Add project memberships
+
+Revision ID: c1d2e3f4a5b6
+Revises: b1c2d3e4f5a6
+Create Date: 2026-05-17
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "c1d2e3f4a5b6"
+down_revision = "b1c2d3e4f5a6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create project_memberships table."""
+    op.create_table(
+        "project_memberships",
+        sa.Column("membership_id", sa.String(), nullable=False),
+        sa.Column("project_id", sa.String(), nullable=False),
+        sa.Column("member_id", sa.String(), nullable=False),
+        sa.Column("display_name", sa.String(), nullable=True),
+        sa.Column("role", sa.String(), nullable=False),
+        sa.Column("status", sa.String(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=True),
+        sa.Column("updated_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(["project_id"], ["projects.project_id"]),
+        sa.PrimaryKeyConstraint("membership_id"),
+    )
+    op.create_index("idx_project_memberships_project", "project_memberships", ["project_id"])
+    op.create_index("idx_project_memberships_member", "project_memberships", ["member_id"])
+    op.create_index("idx_project_memberships_role", "project_memberships", ["role"])
+    op.create_index(
+        "idx_project_memberships_project_member",
+        "project_memberships",
+        ["project_id", "member_id"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    """Drop project_memberships table."""
+    op.drop_index("idx_project_memberships_project_member", table_name="project_memberships")
+    op.drop_index("idx_project_memberships_role", table_name="project_memberships")
+    op.drop_index("idx_project_memberships_member", table_name="project_memberships")
+    op.drop_index("idx_project_memberships_project", table_name="project_memberships")
+    op.drop_table("project_memberships")

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -89,6 +89,12 @@ swarmmind task create <project_id> "Write PRD" --priority high
 swarmmind task update <project_id> <task_id> --status in_progress
 swarmmind task delete <project_id> <task_id>
 
+swarmmind member list <project_id>
+swarmmind member add <project_id> <member_id> --role approver
+swarmmind member update <project_id> <member_id> --role editor
+swarmmind member can <project_id> <member_id> approve_high_risk
+swarmmind member remove <project_id> <member_id>
+
 swarmmind approval list --project-id <project_id>
 swarmmind approval create <project_id> "Approve CRM write" --risk-tier high
 swarmmind approval update <approval_id> --status approved --decision-reason "approved"

--- a/swarmmind/api/routers/mappers.py
+++ b/swarmmind/api/routers/mappers.py
@@ -15,6 +15,8 @@ from swarmmind.models import (
     MemoryScope,
     Project,
     ProjectAgentTeamInstance,
+    ProjectCapability,
+    ProjectMembership,
     RiskTier,
     Run,
     Task,
@@ -171,6 +173,49 @@ def db_to_team_instance(instance, agent_team_repo) -> ProjectAgentTeamInstance:
         status=instance.status,
         created_at=instance.created_at.isoformat() if instance.created_at else "",
         updated_at=instance.updated_at.isoformat() if instance.updated_at else "",
+    )
+
+
+_ROLE_CAPABILITIES: dict[str, list[ProjectCapability]] = {
+    "owner": [
+        ProjectCapability.VIEW_PROJECT,
+        ProjectCapability.RUN_PROJECT,
+        ProjectCapability.MANAGE_PROJECT,
+        ProjectCapability.APPROVE_HIGH_RISK,
+        ProjectCapability.MANAGE_MEMBERS,
+    ],
+    "editor": [
+        ProjectCapability.VIEW_PROJECT,
+        ProjectCapability.RUN_PROJECT,
+        ProjectCapability.MANAGE_PROJECT,
+    ],
+    "approver": [
+        ProjectCapability.VIEW_PROJECT,
+        ProjectCapability.APPROVE_HIGH_RISK,
+    ],
+    "viewer": [
+        ProjectCapability.VIEW_PROJECT,
+    ],
+}
+
+
+def project_role_capabilities(role: str) -> list[ProjectCapability]:
+    """Return capabilities granted to a project role."""
+    return _ROLE_CAPABILITIES.get(role, [])
+
+
+def db_to_project_membership(member) -> ProjectMembership:
+    """Map a ProjectMembershipDB row to a ProjectMembership model."""
+    return ProjectMembership(
+        membership_id=member.membership_id,
+        project_id=member.project_id,
+        member_id=member.member_id,
+        display_name=member.display_name,
+        role=member.role,
+        status=member.status,
+        capabilities=project_role_capabilities(member.role) if member.status == "active" else [],
+        created_at=member.created_at.isoformat() if member.created_at else "",
+        updated_at=member.updated_at.isoformat() if member.updated_at else "",
     )
 
 

--- a/swarmmind/api/routers/project_memberships.py
+++ b/swarmmind/api/routers/project_memberships.py
@@ -1,0 +1,213 @@
+"""Project membership and minimal RBAC routes."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+
+from swarmmind.api.routers.mappers import db_to_project_membership, project_role_capabilities
+from swarmmind.models import (
+    ProjectCapability,
+    ProjectMemberRole,
+    ProjectMembership,
+    ProjectMembershipCreateRequest,
+    ProjectMembershipDeleteResponse,
+    ProjectMembershipListResponse,
+    ProjectMembershipUpdateRequest,
+    ProjectPermissionCheckResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ProjectMembershipRouterDeps:
+    """Dependencies for the project membership router."""
+
+    project_repo: object
+    membership_repo: object
+    audit_writer: Any | None = field(default=None)
+
+
+def build_project_membership_router(deps: ProjectMembershipRouterDeps) -> APIRouter:
+    """Return project membership and permission-check endpoints."""
+    router = APIRouter()
+
+    def _ensure_project(project_id: str) -> None:
+        deps.project_repo.get_by_id(project_id)
+
+    def _write_audit(
+        *,
+        project_id: str,
+        event_type: str,
+        member_id: str,
+        role: str | None = None,
+        status: str | None = None,
+        reason: str | None = None,
+    ) -> None:
+        if deps.audit_writer is None:
+            return
+        try:
+            deps.audit_writer.write(
+                event_type=event_type,
+                project_id=project_id,
+                actor="system",
+                actor_type="system",
+                decision=status,
+                reason=reason,
+                evidence={"member_id": member_id, "role": role, "status": status},
+            )
+        except Exception:
+            logger.exception(
+                "Failed to write project membership audit event: project_id=%s member_id=%s", project_id, member_id
+            )
+
+    @router.get(
+        "/projects/{project_id}/members",
+        tags=["project-members"],
+        responses={404: {"description": "Project not found"}},
+    )
+    def list_project_members(project_id: str) -> ProjectMembershipListResponse:
+        """List project members."""
+        _ensure_project(project_id)
+        rows = deps.membership_repo.list_by_project(project_id)
+        return ProjectMembershipListResponse(items=[db_to_project_membership(row) for row in rows], total=len(rows))
+
+    @router.post(
+        "/projects/{project_id}/members",
+        tags=["project-members"],
+        status_code=201,
+        responses={404: {"description": "Project not found"}, 409: {"description": "Member already exists"}},
+    )
+    def add_project_member(project_id: str, body: ProjectMembershipCreateRequest) -> ProjectMembership:
+        """Add a member to a project."""
+        _ensure_project(project_id)
+        row = deps.membership_repo.create(
+            project_id=project_id,
+            member_id=body.member_id,
+            display_name=body.display_name,
+            role=body.role.value,
+            status=body.status.value,
+        )
+        _write_audit(
+            project_id=project_id,
+            event_type="member.added",
+            member_id=body.member_id,
+            role=body.role.value,
+            status=body.status.value,
+            reason="Project member added",
+        )
+        return db_to_project_membership(row)
+
+    @router.get(
+        "/projects/{project_id}/members/{member_id}",
+        tags=["project-members"],
+        responses={404: {"description": "Project or member not found"}},
+    )
+    def get_project_member(project_id: str, member_id: str) -> ProjectMembership:
+        """Get one project member by project and member ID."""
+        _ensure_project(project_id)
+        return db_to_project_membership(deps.membership_repo.get_by_member(project_id, member_id))
+
+    @router.patch(
+        "/projects/{project_id}/members/{member_id}",
+        tags=["project-members"],
+        responses={404: {"description": "Project or member not found"}},
+    )
+    def update_project_member(
+        project_id: str,
+        member_id: str,
+        body: ProjectMembershipUpdateRequest,
+    ) -> ProjectMembership:
+        """Update project member role, status, or display name."""
+        _ensure_project(project_id)
+        current = deps.membership_repo.get_by_member(project_id, member_id)
+        fields: dict[str, object] = {}
+        if body.display_name is not None:
+            fields["display_name"] = body.display_name
+        if body.role is not None:
+            fields["role"] = body.role.value
+        if body.status is not None:
+            fields["status"] = body.status.value
+        if not fields:
+            return db_to_project_membership(current)
+        row = deps.membership_repo.update(current.membership_id, **fields)
+        _write_audit(
+            project_id=project_id,
+            event_type="member.updated",
+            member_id=member_id,
+            role=row.role,
+            status=row.status,
+            reason="Project member updated",
+        )
+        return db_to_project_membership(row)
+
+    @router.delete(
+        "/projects/{project_id}/members/{member_id}",
+        tags=["project-members"],
+        responses={404: {"description": "Project or member not found"}},
+    )
+    def remove_project_member(project_id: str, member_id: str) -> ProjectMembershipDeleteResponse:
+        """Remove a project member."""
+        _ensure_project(project_id)
+        current = deps.membership_repo.get_by_member(project_id, member_id)
+        deps.membership_repo.delete(current.membership_id)
+        _write_audit(
+            project_id=project_id,
+            event_type="member.removed",
+            member_id=member_id,
+            role=current.role,
+            status="deleted",
+            reason="Project member removed",
+        )
+        return ProjectMembershipDeleteResponse(membership_id=current.membership_id, member_id=member_id)
+
+    @router.get(
+        "/projects/{project_id}/members/{member_id}/permissions/{capability}",
+        tags=["project-members"],
+        responses={404: {"description": "Project not found"}},
+    )
+    def check_project_permission(
+        project_id: str,
+        member_id: str,
+        capability: ProjectCapability,
+    ) -> ProjectPermissionCheckResponse:
+        """Check whether a project member has a capability."""
+        _ensure_project(project_id)
+        try:
+            member = deps.membership_repo.get_by_member(project_id, member_id)
+        except HTTPException as exc:
+            if exc.status_code != 404:
+                raise
+            return ProjectPermissionCheckResponse(
+                project_id=project_id,
+                member_id=member_id,
+                capability=capability,
+                allowed=False,
+                role=None,
+                reason="member_not_found",
+            )
+        if member.status != "active":
+            return ProjectPermissionCheckResponse(
+                project_id=project_id,
+                member_id=member_id,
+                capability=capability,
+                allowed=False,
+                role=ProjectMemberRole(member.role),
+                reason="member_inactive",
+            )
+        capabilities = project_role_capabilities(member.role)
+        allowed = capability in capabilities
+        return ProjectPermissionCheckResponse(
+            project_id=project_id,
+            member_id=member_id,
+            capability=capability,
+            allowed=allowed,
+            role=ProjectMemberRole(member.role),
+            reason="allowed" if allowed else "role_lacks_capability",
+        )
+
+    return router

--- a/swarmmind/api/supervisor.py
+++ b/swarmmind/api/supervisor.py
@@ -16,6 +16,10 @@ from swarmmind.api.routers.approvals import ApprovalsRouterDeps, build_approvals
 from swarmmind.api.routers.audit_logs import AuditLogsRouterDeps, build_audit_logs_router
 from swarmmind.api.routers.legacy_supervisor import LegacySupervisorRouterDeps, build_legacy_supervisor_router
 from swarmmind.api.routers.memory import MemoryRouterDeps, build_memory_router
+from swarmmind.api.routers.project_memberships import (
+    ProjectMembershipRouterDeps,
+    build_project_membership_router,
+)
 from swarmmind.api.routers.projects import ProjectsRouterDeps, build_projects_router
 from swarmmind.api.routers.promotions import PromotionsRouterDeps, build_promotions_router
 from swarmmind.api.routers.runs import RunsRouterDeps, build_runs_router
@@ -49,6 +53,7 @@ from swarmmind.repositories.conversation import ConversationRepository
 from swarmmind.repositories.memory import MemoryRepository
 from swarmmind.repositories.message import MessageRepository
 from swarmmind.repositories.project import ProjectRepository
+from swarmmind.repositories.project_membership import ProjectMembershipRepository
 from swarmmind.repositories.project_team import ProjectTeamInstanceRepository
 from swarmmind.repositories.run import RunRepository
 from swarmmind.repositories.strategy import StrategyRepository
@@ -89,6 +94,7 @@ approval_request_repo = ApprovalRequestRepository()
 strategy_repo = StrategyRepository()
 memory_repo = MemoryRepository()
 project_repo = ProjectRepository()
+project_membership_repo = ProjectMembershipRepository()
 artifact_repo = ArtifactRepository()
 run_repo = RunRepository()
 agent_team_repo = AgentTeamRepository()
@@ -441,6 +447,16 @@ app.include_router(
 )
 
 app.include_router(build_memory_router(MemoryRouterDeps(memory_repo=memory_repo)))
+
+app.include_router(
+    build_project_membership_router(
+        ProjectMembershipRouterDeps(
+            project_repo=project_repo,
+            membership_repo=project_membership_repo,
+            audit_writer=audit_writer,
+        )
+    )
+)
 
 app.include_router(
     build_agent_teams_router(

--- a/swarmmind/cli/__main__.py
+++ b/swarmmind/cli/__main__.py
@@ -12,6 +12,7 @@ from swarmmind.cli.commands.approval import approval_app
 from swarmmind.cli.commands.audit import audit_app
 from swarmmind.cli.commands.conversation import chat_app, conversation_app
 from swarmmind.cli.commands.mcp import mcp_app
+from swarmmind.cli.commands.member import member_app
 from swarmmind.cli.commands.memory import memory_app
 from swarmmind.cli.commands.project import project_app
 from swarmmind.cli.commands.run import run_app
@@ -65,6 +66,7 @@ app.add_typer(task_app, name="task")
 app.add_typer(approval_app, name="approval")
 app.add_typer(audit_app, name="audit")
 app.add_typer(memory_app, name="memory")
+app.add_typer(member_app, name="member")
 app.add_typer(mcp_app, name="mcp")
 
 

--- a/swarmmind/cli/client.py
+++ b/swarmmind/cli/client.py
@@ -33,9 +33,16 @@ from swarmmind.models import (
     MemoryEntry,
     MemoryListResponse,
     Project,
+    ProjectCapability,
     ProjectCreateRequest,
     ProjectListResponse,
+    ProjectMembership,
+    ProjectMembershipCreateRequest,
+    ProjectMembershipDeleteResponse,
+    ProjectMembershipListResponse,
+    ProjectMembershipUpdateRequest,
     ProjectOverviewResponse,
+    ProjectPermissionCheckResponse,
     ProjectUpdateRequest,
     ReadyResponse,
     Run,
@@ -261,6 +268,38 @@ class SwarmMindClient:
     ) -> Iterator[dict[str, Any]]:
         body = _message_body(content, mode=mode, model_name=model_name, reasoning=reasoning)
         yield from self._stream("POST", f"/projects/{project_id}/messages/stream", json_body=body)
+
+    # ---- project members ----
+
+    def list_project_members(self, project_id: str) -> ProjectMembershipListResponse:
+        return self._list(ProjectMembershipListResponse, "GET", f"/projects/{project_id}/members")
+
+    def create_project_member(self, project_id: str, **fields) -> ProjectMembership:
+        body = ProjectMembershipCreateRequest(**_compact(fields)).model_dump(mode="json", exclude_none=True)
+        return self._list(ProjectMembership, "POST", f"/projects/{project_id}/members", json_body=body)
+
+    def get_project_member(self, project_id: str, member_id: str) -> ProjectMembership:
+        return self._list(ProjectMembership, "GET", f"/projects/{project_id}/members/{member_id}")
+
+    def update_project_member(self, project_id: str, member_id: str, **fields) -> ProjectMembership:
+        body = ProjectMembershipUpdateRequest(**_compact(fields)).model_dump(mode="json", exclude_none=True)
+        return self._list(ProjectMembership, "PATCH", f"/projects/{project_id}/members/{member_id}", json_body=body)
+
+    def delete_project_member(self, project_id: str, member_id: str) -> ProjectMembershipDeleteResponse:
+        return self._list(ProjectMembershipDeleteResponse, "DELETE", f"/projects/{project_id}/members/{member_id}")
+
+    def check_project_permission(
+        self,
+        project_id: str,
+        member_id: str,
+        capability: str,
+    ) -> ProjectPermissionCheckResponse:
+        checked = ProjectCapability(capability)
+        return self._list(
+            ProjectPermissionCheckResponse,
+            "GET",
+            f"/projects/{project_id}/members/{member_id}/permissions/{checked.value}",
+        )
 
     # ---- runs ----
 

--- a/swarmmind/cli/commands/member.py
+++ b/swarmmind/cli/commands/member.py
@@ -1,0 +1,92 @@
+"""Project membership commands."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+import typer
+
+from swarmmind.cli.commands._common import run_client_command
+
+member_app = typer.Typer(help="Manage project memberships and minimal RBAC.", no_args_is_help=True)
+
+
+@member_app.command("list")
+def list_members(
+    ctx: typer.Context,
+    project_id: Annotated[str, typer.Argument(help="Project ID.")],
+) -> None:
+    run_client_command(ctx, lambda client: client.list_project_members(project_id))
+
+
+@member_app.command("add")
+def add_member(
+    ctx: typer.Context,
+    project_id: Annotated[str, typer.Argument(help="Project ID.")],
+    member_id: Annotated[str, typer.Argument(help="User/service principal ID.")],
+    role: Annotated[str, typer.Option("--role", help="owner, editor, approver, or viewer.")] = "viewer",
+    display_name: Annotated[str | None, typer.Option("--display-name")] = None,
+    status: Annotated[str, typer.Option("--status", help="active or inactive.")] = "active",
+) -> None:
+    run_client_command(
+        ctx,
+        lambda client: client.create_project_member(
+            project_id,
+            member_id=member_id,
+            display_name=display_name,
+            role=role,
+            status=status,
+        ),
+    )
+
+
+@member_app.command("get")
+def get_member(
+    ctx: typer.Context,
+    project_id: Annotated[str, typer.Argument(help="Project ID.")],
+    member_id: Annotated[str, typer.Argument(help="User/service principal ID.")],
+) -> None:
+    run_client_command(ctx, lambda client: client.get_project_member(project_id, member_id))
+
+
+@member_app.command("update")
+def update_member(
+    ctx: typer.Context,
+    project_id: Annotated[str, typer.Argument(help="Project ID.")],
+    member_id: Annotated[str, typer.Argument(help="User/service principal ID.")],
+    role: Annotated[str | None, typer.Option("--role", help="owner, editor, approver, or viewer.")] = None,
+    display_name: Annotated[str | None, typer.Option("--display-name")] = None,
+    status: Annotated[str | None, typer.Option("--status", help="active or inactive.")] = None,
+) -> None:
+    run_client_command(
+        ctx,
+        lambda client: client.update_project_member(
+            project_id,
+            member_id,
+            role=role,
+            display_name=display_name,
+            status=status,
+        ),
+    )
+
+
+@member_app.command("remove")
+def remove_member(
+    ctx: typer.Context,
+    project_id: Annotated[str, typer.Argument(help="Project ID.")],
+    member_id: Annotated[str, typer.Argument(help="User/service principal ID.")],
+) -> None:
+    run_client_command(ctx, lambda client: client.delete_project_member(project_id, member_id))
+
+
+@member_app.command("can")
+def check_member_permission(
+    ctx: typer.Context,
+    project_id: Annotated[str, typer.Argument(help="Project ID.")],
+    member_id: Annotated[str, typer.Argument(help="User/service principal ID.")],
+    capability: Annotated[
+        str,
+        typer.Argument(help="view_project, run_project, manage_project, approve_high_risk, or manage_members."),
+    ],
+) -> None:
+    run_client_command(ctx, lambda client: client.check_project_permission(project_id, member_id, capability))

--- a/swarmmind/db_models.py
+++ b/swarmmind/db_models.py
@@ -452,6 +452,28 @@ class ProjectAgentTeamInstanceDB(SQLModel, table=True):
     )
 
 
+class ProjectMembershipDB(SQLModel, table=True):
+    """Minimal project membership and RBAC boundary."""
+
+    __tablename__ = "project_memberships"
+
+    membership_id: str = Field(primary_key=True)
+    project_id: str = Field(foreign_key="projects.project_id")
+    member_id: str
+    display_name: str | None = None
+    role: str = Field(default="viewer")  # 'owner' | 'editor' | 'approver' | 'viewer'
+    status: str = Field(default="active")  # 'active' | 'inactive'
+    created_at: datetime | None = Field(default_factory=utc_now)
+    updated_at: datetime | None = Field(default_factory=utc_now)
+
+    __table_args__ = (
+        Index("idx_project_memberships_project", "project_id"),
+        Index("idx_project_memberships_member", "member_id"),
+        Index("idx_project_memberships_role", "role"),
+        sa.Index("idx_project_memberships_project_member", "project_id", "member_id", unique=True),
+    )
+
+
 class ApprovalRequestDB(SQLModel, table=True):
     """Product-layer approval request for high-risk run governance."""
 

--- a/swarmmind/models.py
+++ b/swarmmind/models.py
@@ -550,6 +550,89 @@ class ProjectAgentTeamInstance(BaseModel):
     updated_at: str
 
 
+class ProjectMemberRole(str, Enum):
+    """Minimal project member roles."""
+
+    OWNER = "owner"
+    EDITOR = "editor"
+    APPROVER = "approver"
+    VIEWER = "viewer"
+
+
+class ProjectMemberStatus(str, Enum):
+    """Project membership status."""
+
+    ACTIVE = "active"
+    INACTIVE = "inactive"
+
+
+class ProjectCapability(str, Enum):
+    """Capabilities evaluated by minimal project RBAC."""
+
+    VIEW_PROJECT = "view_project"
+    RUN_PROJECT = "run_project"
+    MANAGE_PROJECT = "manage_project"
+    APPROVE_HIGH_RISK = "approve_high_risk"
+    MANAGE_MEMBERS = "manage_members"
+
+
+class ProjectMembership(BaseModel):
+    """A human or service principal attached to one project."""
+
+    membership_id: str
+    project_id: str
+    member_id: str
+    display_name: str | None = None
+    role: ProjectMemberRole = ProjectMemberRole.VIEWER
+    status: ProjectMemberStatus = ProjectMemberStatus.ACTIVE
+    capabilities: list[ProjectCapability] = []
+    created_at: str
+    updated_at: str
+
+
+class ProjectMembershipListResponse(BaseModel):
+    """Response containing project memberships."""
+
+    items: list[ProjectMembership]
+    total: int
+
+
+class ProjectMembershipCreateRequest(BaseModel):
+    """Request to add a project member."""
+
+    member_id: str = Field(..., min_length=1, max_length=200)
+    display_name: str | None = Field(None, max_length=200)
+    role: ProjectMemberRole = ProjectMemberRole.VIEWER
+    status: ProjectMemberStatus = ProjectMemberStatus.ACTIVE
+
+
+class ProjectMembershipUpdateRequest(BaseModel):
+    """Request to update a project member."""
+
+    display_name: str | None = Field(None, max_length=200)
+    role: ProjectMemberRole | None = None
+    status: ProjectMemberStatus | None = None
+
+
+class ProjectMembershipDeleteResponse(BaseModel):
+    """Response after removing a project member."""
+
+    status: str = "deleted"
+    membership_id: str
+    member_id: str
+
+
+class ProjectPermissionCheckResponse(BaseModel):
+    """Response for a minimal RBAC capability check."""
+
+    project_id: str
+    member_id: str
+    capability: ProjectCapability
+    allowed: bool
+    role: ProjectMemberRole | None = None
+    reason: str
+
+
 class AttachTeamRequest(BaseModel):
     """Request to attach a team template to a project."""
 
@@ -721,6 +804,7 @@ class RunStatus(str, Enum):
     """Run lifecycle status."""
 
     RUNNING = "running"
+    WAITING_APPROVAL = "waiting_approval"
     COMPLETED = "completed"
     FAILED = "failed"
     BLOCKED = "blocked"

--- a/swarmmind/repositories/project_membership.py
+++ b/swarmmind/repositories/project_membership.py
@@ -1,0 +1,112 @@
+"""Project membership repository."""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi import HTTPException
+from sqlalchemy.exc import IntegrityError
+from sqlmodel import select
+
+from swarmmind.db import session_scope
+from swarmmind.db_models import ProjectMembershipDB
+from swarmmind.time_utils import utc_now
+
+
+class ProjectMembershipRepository:
+    """Repository for minimal project membership/RBAC operations."""
+
+    def list_by_project(self, project_id: str) -> list[ProjectMembershipDB]:
+        """List active and inactive members for a project."""
+        with session_scope() as session:
+            rows = session.exec(
+                select(ProjectMembershipDB)
+                .where(ProjectMembershipDB.project_id == project_id)
+                .order_by(ProjectMembershipDB.created_at.asc())
+            ).all()
+            for row in rows:
+                session.expunge(row)
+            return list(rows)
+
+    def get(self, membership_id: str) -> ProjectMembershipDB:
+        """Get a membership by ID or raise 404."""
+        with session_scope() as session:
+            row = session.get(ProjectMembershipDB, membership_id)
+            if row is None:
+                raise HTTPException(status_code=404, detail="Project membership not found")
+            session.expunge(row)
+            return row
+
+    def get_by_member(self, project_id: str, member_id: str) -> ProjectMembershipDB:
+        """Get a project membership by project and member ID or raise 404."""
+        with session_scope() as session:
+            row = session.exec(
+                select(ProjectMembershipDB)
+                .where(ProjectMembershipDB.project_id == project_id)
+                .where(ProjectMembershipDB.member_id == member_id)
+            ).first()
+            if row is None:
+                raise HTTPException(status_code=404, detail="Project membership not found")
+            session.expunge(row)
+            return row
+
+    def create(
+        self,
+        *,
+        project_id: str,
+        member_id: str,
+        display_name: str | None = None,
+        role: str = "viewer",
+        status: str = "active",
+    ) -> ProjectMembershipDB:
+        """Create a project membership."""
+        with session_scope() as session:
+            row = ProjectMembershipDB(
+                membership_id=str(uuid.uuid4()),
+                project_id=project_id,
+                member_id=member_id,
+                display_name=display_name,
+                role=role,
+                status=status,
+            )
+            session.add(row)
+            try:
+                session.commit()
+            except IntegrityError as exc:
+                session.rollback()
+                raise HTTPException(status_code=409, detail="Project member already exists") from exc
+            session.refresh(row)
+            session.expunge(row)
+            return row
+
+    def update(
+        self,
+        membership_id: str,
+        *,
+        display_name: str | None = None,
+        role: str | None = None,
+        status: str | None = None,
+    ) -> ProjectMembershipDB:
+        """Update a project membership."""
+        with session_scope() as session:
+            row = session.get(ProjectMembershipDB, membership_id)
+            if row is None:
+                raise HTTPException(status_code=404, detail="Project membership not found")
+            if display_name is not None:
+                row.display_name = display_name
+            if role is not None:
+                row.role = role
+            if status is not None:
+                row.status = status
+            row.updated_at = utc_now()
+            session.commit()
+            session.refresh(row)
+            session.expunge(row)
+            return row
+
+    def delete(self, membership_id: str) -> None:
+        """Delete a project membership."""
+        with session_scope() as session:
+            row = session.get(ProjectMembershipDB, membership_id)
+            if row is not None:
+                session.delete(row)

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -75,3 +75,61 @@ def test_project_list_limit_command(monkeypatch) -> None:
 
     assert result.exit_code == 0
     assert json.loads(result.stdout) == {"items": [], "total": 0}
+
+
+def test_member_add_command(monkeypatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/projects/proj-1/members"
+        payload = json.loads(request.content.decode())
+        assert payload["member_id"] == "user-1"
+        assert payload["role"] == "approver"
+        return httpx.Response(
+            201,
+            json={
+                "membership_id": "mem-1",
+                "project_id": "proj-1",
+                "member_id": "user-1",
+                "display_name": None,
+                "role": "approver",
+                "status": "active",
+                "capabilities": ["view_project", "approve_high_risk"],
+                "created_at": "2026-05-17T00:00:00",
+                "updated_at": "2026-05-17T00:00:00",
+            },
+        )
+
+    _patch_httpx_client(monkeypatch, handler)
+
+    result = runner.invoke(
+        app,
+        ["--api-url", "http://swarmmind.test", "--json", "member", "add", "proj-1", "user-1", "--role", "approver"],
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)["role"] == "approver"
+
+
+def test_member_permission_command(monkeypatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/projects/proj-1/members/user-1/permissions/run_project"
+        return httpx.Response(
+            200,
+            json={
+                "project_id": "proj-1",
+                "member_id": "user-1",
+                "capability": "run_project",
+                "allowed": True,
+                "role": "editor",
+                "reason": "allowed",
+            },
+        )
+
+    _patch_httpx_client(monkeypatch, handler)
+
+    result = runner.invoke(
+        app,
+        ["--api-url", "http://swarmmind.test", "--json", "member", "can", "proj-1", "user-1", "run_project"],
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)["allowed"] is True

--- a/tests/test_project_membership_api.py
+++ b/tests/test_project_membership_api.py
@@ -1,0 +1,103 @@
+"""Project membership API tests."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from swarmmind.api.supervisor import app
+from swarmmind.db import dispose_engines, init_db
+
+client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def setup_db(monkeypatch, tmp_path):
+    db_path = tmp_path / "project_membership_api_test.db"
+    monkeypatch.setenv("SWARMMIND_DATABASE_URL", f"sqlite:///{db_path}")
+    dispose_engines()
+    init_db()
+
+
+def _project_id() -> str:
+    response = client.post("/projects", json={"title": "Governed Project"})
+    assert response.status_code == 200
+    return response.json()["project_id"]
+
+
+def test_add_list_and_get_project_member() -> None:
+    project_id = _project_id()
+
+    created = client.post(
+        f"/projects/{project_id}/members",
+        json={"member_id": "user-1", "display_name": "User One", "role": "owner"},
+    )
+
+    assert created.status_code == 201
+    data = created.json()
+    assert data["member_id"] == "user-1"
+    assert data["role"] == "owner"
+    assert "manage_members" in data["capabilities"]
+
+    listed = client.get(f"/projects/{project_id}/members")
+    assert listed.status_code == 200
+    assert listed.json()["total"] == 1
+
+    fetched = client.get(f"/projects/{project_id}/members/user-1")
+    assert fetched.status_code == 200
+    assert fetched.json()["membership_id"] == data["membership_id"]
+
+
+def test_duplicate_project_member_returns_409() -> None:
+    project_id = _project_id()
+    body = {"member_id": "user-1", "role": "viewer"}
+    assert client.post(f"/projects/{project_id}/members", json=body).status_code == 201
+
+    response = client.post(f"/projects/{project_id}/members", json=body)
+
+    assert response.status_code == 409
+
+
+def test_update_member_and_permission_check() -> None:
+    project_id = _project_id()
+    client.post(f"/projects/{project_id}/members", json={"member_id": "approver-1", "role": "viewer"})
+
+    denied = client.get(f"/projects/{project_id}/members/approver-1/permissions/approve_high_risk")
+    assert denied.status_code == 200
+    assert denied.json()["allowed"] is False
+
+    updated = client.patch(f"/projects/{project_id}/members/approver-1", json={"role": "approver"})
+    assert updated.status_code == 200
+    assert updated.json()["role"] == "approver"
+
+    allowed = client.get(f"/projects/{project_id}/members/approver-1/permissions/approve_high_risk")
+    assert allowed.status_code == 200
+    assert allowed.json()["allowed"] is True
+
+
+def test_inactive_member_loses_capabilities() -> None:
+    project_id = _project_id()
+    client.post(f"/projects/{project_id}/members", json={"member_id": "editor-1", "role": "editor"})
+
+    updated = client.patch(f"/projects/{project_id}/members/editor-1", json={"status": "inactive"})
+
+    assert updated.status_code == 200
+    assert updated.json()["capabilities"] == []
+    response = client.get(f"/projects/{project_id}/members/editor-1/permissions/run_project")
+    assert response.json()["allowed"] is False
+    assert response.json()["reason"] == "member_inactive"
+
+
+def test_member_changes_write_audit_log() -> None:
+    project_id = _project_id()
+
+    client.post(f"/projects/{project_id}/members", json={"member_id": "user-1", "role": "viewer"})
+    client.patch(f"/projects/{project_id}/members/user-1", json={"role": "editor"})
+    client.delete(f"/projects/{project_id}/members/user-1")
+
+    audit = client.get(f"/projects/{project_id}/audit")
+    assert audit.status_code == 200
+    audit_types = [item["audit_type"] for item in audit.json()["items"]]
+    assert "member.added" in audit_types
+    assert "member.updated" in audit_types
+    assert "member.removed" in audit_types


### PR DESCRIPTION
## Summary
- add project membership persistence, migration, repository, and REST API
- add CLI member commands for list/add/get/update/remove/can
- wire role capability checks and audit events for member changes

## Tests
- .venv/bin/ruff check pyproject.toml swarmmind tests alembic/versions/c1d2e3f4a5b6_project_memberships.py
- make test
- CLI/API smoke against temporary SQLite DB