### PR TITLE
Add local users and CLI auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ CLI is a first-class interface alongside the Supervisor UI. Use it for API-drive
 
 ```bash
 swarmmind health
+swarmmind user create ada@example.com --password "change-me-now" --role admin
+swarmmind auth login ada@example.com --password "change-me-now"
 swarmmind chat new "Map the CRM MVP risks" --mode pro
 swarmmind project list --json
 ```

--- a/alembic/versions/d2e3f4a5b6c7_users_and_tokens.py
+++ b/alembic/versions/d2e3f4a5b6c7_users_and_tokens.py
@@ -1,0 +1,67 @@
+"""Add local users and API tokens.
+
+Revision ID: d2e3f4a5b6c7
+Revises: c1d2e3f4a5b6
+Create Date: 2026-05-17
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "d2e3f4a5b6c7"
+down_revision = "c1d2e3f4a5b6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Apply users and tokens schema."""
+    op.create_table(
+        "users",
+        sa.Column("user_id", sa.String(), nullable=False),
+        sa.Column("email", sa.String(), nullable=False),
+        sa.Column("display_name", sa.String(), nullable=True),
+        sa.Column("password_hash", sa.String(), nullable=True),
+        sa.Column("role", sa.String(), nullable=False),
+        sa.Column("status", sa.String(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=True),
+        sa.Column("updated_at", sa.DateTime(), nullable=True),
+        sa.Column("last_login_at", sa.DateTime(), nullable=True),
+        sa.PrimaryKeyConstraint("user_id"),
+    )
+    op.create_index("idx_users_email", "users", ["email"], unique=True)
+    op.create_index("idx_users_role", "users", ["role"], unique=False)
+    op.create_index("idx_users_status", "users", ["status"], unique=False)
+
+    op.create_table(
+        "user_tokens",
+        sa.Column("token_id", sa.String(), nullable=False),
+        sa.Column("user_id", sa.String(), nullable=False),
+        sa.Column("token_hash", sa.String(), nullable=False),
+        sa.Column("name", sa.String(), nullable=True),
+        sa.Column("status", sa.String(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=True),
+        sa.Column("last_used_at", sa.DateTime(), nullable=True),
+        sa.Column("expires_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["users.user_id"]),
+        sa.PrimaryKeyConstraint("token_id"),
+    )
+    op.create_index("idx_user_tokens_hash", "user_tokens", ["token_hash"], unique=True)
+    op.create_index("idx_user_tokens_status", "user_tokens", ["status"], unique=False)
+    op.create_index("idx_user_tokens_user", "user_tokens", ["user_id"], unique=False)
+
+
+def downgrade() -> None:
+    """Drop users and tokens schema."""
+    op.drop_index("idx_user_tokens_user", table_name="user_tokens")
+    op.drop_index("idx_user_tokens_status", table_name="user_tokens")
+    op.drop_index("idx_user_tokens_hash", table_name="user_tokens")
+    op.drop_table("user_tokens")
+
+    op.drop_index("idx_users_status", table_name="users")
+    op.drop_index("idx_users_role", table_name="users")
+    op.drop_index("idx_users_email", table_name="users")
+    op.drop_table("users")

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -73,6 +73,12 @@ swarmmind chat respond-clarification <conversation_id> <tool_call_id> "answer"
 Governance:
 
 ```bash
+swarmmind user create ada@example.com --password "change-me-now" --display-name "Ada" --role admin
+swarmmind user list
+swarmmind auth login ada@example.com --password "change-me-now" --token-name laptop
+swarmmind --api-token <token> auth me
+swarmmind --api-token <token> auth logout
+
 swarmmind project list --limit 20
 swarmmind project create "CRM MVP" --goal "Validate enterprise wedge"
 swarmmind project update <project_id> --phase "planning" --risk-level medium

--- a/swarmmind/api/routers/mappers.py
+++ b/swarmmind/api/routers/mappers.py
@@ -21,6 +21,7 @@ from swarmmind.models import (
     Run,
     Task,
     TeamRole,
+    User,
 )
 from swarmmind.services.artifact_content import (
     is_virtual_user_data_path,
@@ -216,6 +217,20 @@ def db_to_project_membership(member) -> ProjectMembership:
         capabilities=project_role_capabilities(member.role) if member.status == "active" else [],
         created_at=member.created_at.isoformat() if member.created_at else "",
         updated_at=member.updated_at.isoformat() if member.updated_at else "",
+    )
+
+
+def db_to_user(user) -> User:
+    """Map a UserDB row to a public User model."""
+    return User(
+        user_id=user.user_id,
+        email=user.email,
+        display_name=user.display_name,
+        role=user.role,
+        status=user.status,
+        created_at=user.created_at.isoformat() if user.created_at else "",
+        updated_at=user.updated_at.isoformat() if user.updated_at else "",
+        last_login_at=user.last_login_at.isoformat() if user.last_login_at else None,
     )
 
 

--- a/swarmmind/api/routers/users.py
+++ b/swarmmind/api/routers/users.py
@@ -1,0 +1,112 @@
+"""Local users and token authentication routes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+from swarmmind.api.routers.mappers import db_to_user
+from swarmmind.models import (
+    AuthToken,
+    CurrentUserResponse,
+    DeleteUserResponse,
+    LoginRequest,
+    LogoutResponse,
+    User,
+    UserCreateRequest,
+    UserListResponse,
+    UserUpdateRequest,
+)
+from swarmmind.repositories.user import UserRepository
+from swarmmind.services.auth import generate_api_token, hash_api_token
+
+bearer_scheme = HTTPBearer(auto_error=False)
+
+
+@dataclass(frozen=True)
+class UsersRouterDeps:
+    """Dependencies for the users/auth router."""
+
+    user_repo: UserRepository
+
+
+def build_users_router(deps: UsersRouterDeps) -> APIRouter:
+    """Return an APIRouter for local users and API tokens."""
+    router = APIRouter()
+
+    def current_token(credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme)) -> tuple[Any, Any]:  # noqa: B008
+        if credentials is None or credentials.scheme.lower() != "bearer":
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing bearer token")
+        return deps.user_repo.resolve_token(credentials.credentials)
+
+    @router.get("/users", tags=["users"])
+    def list_users() -> UserListResponse:
+        """List local users."""
+        rows = deps.user_repo.list_all()
+        return UserListResponse(items=[db_to_user(row) for row in rows], total=len(rows))
+
+    @router.post("/users", response_model=User, tags=["users"], status_code=status.HTTP_201_CREATED)
+    def create_user(body: UserCreateRequest) -> User:
+        """Create a local user."""
+        row = deps.user_repo.create(
+            email=body.email,
+            password=body.password,
+            display_name=body.display_name,
+            role=body.role.value,
+            status=body.status.value,
+        )
+        return db_to_user(row)
+
+    @router.get("/users/{user_id}", tags=["users"])
+    def get_user(user_id: str) -> User:
+        """Get a local user."""
+        return db_to_user(deps.user_repo.get(user_id))
+
+    @router.patch("/users/{user_id}", tags=["users"])
+    def update_user(user_id: str, body: UserUpdateRequest) -> User:
+        """Update a local user."""
+        row = deps.user_repo.update(
+            user_id,
+            email=body.email,
+            password=body.password,
+            display_name=body.display_name,
+            role=body.role.value if body.role else None,
+            status=body.status.value if body.status else None,
+        )
+        return db_to_user(row)
+
+    @router.delete("/users/{user_id}", tags=["users"])
+    def disable_user(user_id: str) -> DeleteUserResponse:
+        """Disable a local user and revoke its tokens."""
+        deps.user_repo.disable(user_id)
+        return DeleteUserResponse(user_id=user_id)
+
+    @router.post("/auth/login", tags=["auth"])
+    def login(body: LoginRequest) -> AuthToken:
+        """Exchange local credentials for a bearer token."""
+        user = deps.user_repo.authenticate(email=body.email, password=body.password)
+        token = generate_api_token()
+        token_row = deps.user_repo.create_token(
+            user_id=user.user_id,
+            token_hash=hash_api_token(token),
+            name=body.token_name,
+        )
+        return AuthToken(token_id=token_row.token_id, token=token, user=db_to_user(user))
+
+    @router.get("/auth/me", tags=["auth"])
+    def me(resolved: tuple[Any, Any] = Depends(current_token)) -> CurrentUserResponse:
+        """Return the user attached to the current bearer token."""
+        user, token = resolved
+        return CurrentUserResponse(user=db_to_user(user), token_id=token.token_id)
+
+    @router.post("/auth/logout", tags=["auth"])
+    def logout(resolved: tuple[Any, Any] = Depends(current_token)) -> LogoutResponse:
+        """Revoke the current bearer token."""
+        _user, token = resolved
+        deps.user_repo.revoke_token(token.token_id)
+        return LogoutResponse(token_id=token.token_id)
+
+    return router

--- a/swarmmind/api/supervisor.py
+++ b/swarmmind/api/supervisor.py
@@ -28,6 +28,7 @@ from swarmmind.api.routers.runtime_models import (
     list_runtime_models,  # noqa: F401  (re-export for tests)
 )
 from swarmmind.api.routers.system import SystemRouterDeps, build_system_router
+from swarmmind.api.routers.users import UsersRouterDeps, build_users_router
 from swarmmind.config import ACTION_TIMEOUT_SECONDS, API_HOST, API_PORT
 from swarmmind.context_broker import derive_situation_tag, dispatch, record_supervisor_decision
 from swarmmind.db import init_db, seed_builtin_agent_teams, seed_default_agents
@@ -58,6 +59,7 @@ from swarmmind.repositories.project_team import ProjectTeamInstanceRepository
 from swarmmind.repositories.run import RunRepository
 from swarmmind.repositories.strategy import StrategyRepository
 from swarmmind.repositories.task import TaskRepository
+from swarmmind.repositories.user import UserRepository
 from swarmmind.runtime import ensure_default_runtime_instance
 from swarmmind.runtime.catalog import sync_env_runtime_model
 from swarmmind.services.conversation_execution import ConversationExecutionService
@@ -101,6 +103,7 @@ agent_team_repo = AgentTeamRepository()
 project_team_repo = ProjectTeamInstanceRepository()
 task_repo = TaskRepository()
 audit_log_repo = AuditLogRepository()
+user_repo = UserRepository()
 
 conversation_support = ConversationSupportService(
     conversation_repo=conversation_repo,
@@ -373,6 +376,8 @@ export_conversation = conversation_handlers.export_conversation
 # ---- Include all routers ----
 
 app.include_router(conversation_router)
+
+app.include_router(build_users_router(UsersRouterDeps(user_repo=user_repo)))
 
 app.include_router(
     build_system_router(

--- a/swarmmind/cli/__main__.py
+++ b/swarmmind/cli/__main__.py
@@ -10,6 +10,7 @@ import typer
 from swarmmind import __version__
 from swarmmind.cli.commands.approval import approval_app
 from swarmmind.cli.commands.audit import audit_app
+from swarmmind.cli.commands.auth import auth_app
 from swarmmind.cli.commands.conversation import chat_app, conversation_app
 from swarmmind.cli.commands.mcp import mcp_app
 from swarmmind.cli.commands.member import member_app
@@ -18,7 +19,8 @@ from swarmmind.cli.commands.project import project_app
 from swarmmind.cli.commands.run import run_app
 from swarmmind.cli.commands.system import register_system_commands
 from swarmmind.cli.commands.task import task_app
-from swarmmind.cli.config import CLIState, resolve_api_url
+from swarmmind.cli.commands.user import user_app
+from swarmmind.cli.config import CLIState, resolve_api_token, resolve_api_url
 
 app = typer.Typer(
     help="SwarmMind CLI: HTTP-first client for the supervisor API.",
@@ -38,6 +40,9 @@ def _version_callback(value: bool) -> bool:
 def main(
     ctx: typer.Context,
     api_url: Annotated[str | None, typer.Option("--api-url", help="Supervisor API URL.")] = None,
+    api_token: Annotated[
+        str | None, typer.Option("--api-token", help="Bearer token for authenticated API calls.")
+    ] = None,
     json_output: Annotated[bool, typer.Option("--json", help="Emit JSON or NDJSON output.")] = False,
     quiet: Annotated[bool, typer.Option("--quiet", "-q", help="Suppress normal output.")] = False,
     version: Annotated[
@@ -47,7 +52,9 @@ def main(
 ) -> None:
     """Resolve global CLI options."""
     _ = version
-    ctx.obj = CLIState(api_url=resolve_api_url(api_url), json_output=json_output, quiet=quiet)
+    ctx.obj = CLIState(
+        api_url=resolve_api_url(api_url), api_token=resolve_api_token(api_token), json_output=json_output, quiet=quiet
+    )
 
 
 def _version() -> str:
@@ -60,6 +67,8 @@ def _version() -> str:
 register_system_commands(app)
 app.add_typer(conversation_app, name="conversation")
 app.add_typer(chat_app, name="chat")
+app.add_typer(auth_app, name="auth")
+app.add_typer(user_app, name="user")
 app.add_typer(project_app, name="project")
 app.add_typer(run_app, name="run")
 app.add_typer(task_app, name="task")

--- a/swarmmind/cli/client.py
+++ b/swarmmind/cli/client.py
@@ -14,6 +14,7 @@ from swarmmind.models import (
     ApprovalRequestListResponse,
     AuditLogEntry,
     AuditLogListResponse,
+    AuthToken,
     Conversation,
     ConversationListResponse,
     ConversationTraceResponse,
@@ -22,14 +23,18 @@ from swarmmind.models import (
     CreateConversationRequest,
     CreateRunRequest,
     CreateTaskRequest,
+    CurrentUserResponse,
     DeleteApprovalResponse,
     DeleteAuditLogResponse,
     DeleteConversationResponse,
     DeleteProjectResponse,
     DeleteTaskResponse,
+    DeleteUserResponse,
     DispatchResponse,
     GoalRequest,
     HealthResponse,
+    LoginRequest,
+    LogoutResponse,
     MemoryEntry,
     MemoryListResponse,
     Project,
@@ -54,6 +59,10 @@ from swarmmind.models import (
     UpdateApprovalRequest,
     UpdateRunRequest,
     UpdateTaskRequest,
+    User,
+    UserCreateRequest,
+    UserListResponse,
+    UserUpdateRequest,
 )
 
 T = TypeVar("T", bound=BaseModel)
@@ -98,12 +107,15 @@ class ParameterError(SwarmMindCLIError):
 class SwarmMindClient:
     """Thin HTTP client for the supervisor REST API."""
 
-    def __init__(self, api_url: str, timeout: float = 30.0) -> None:
+    def __init__(self, api_url: str, timeout: float = 30.0, api_token: str | None = None) -> None:
         self.api_url = api_url.rstrip("/")
+        headers = {"Accept": "application/json"}
+        if api_token:
+            headers["Authorization"] = f"Bearer {api_token}"
         self._client = httpx.Client(
             base_url=self.api_url,
             timeout=httpx.Timeout(timeout, connect=5.0),
-            headers={"Accept": "application/json"},
+            headers=headers,
         )
 
     def close(self) -> None:
@@ -159,6 +171,37 @@ class SwarmMindClient:
 
     def ready(self) -> ReadyResponse:
         return self._list(ReadyResponse, "GET", "/ready")
+
+    # ---- auth / users ----
+
+    def login(self, email: str, password: str, token_name: str | None = None) -> AuthToken:
+        body = LoginRequest(email=email, password=password, token_name=token_name).model_dump(
+            mode="json", exclude_none=True
+        )
+        return self._list(AuthToken, "POST", "/auth/login", json_body=body)
+
+    def me(self) -> CurrentUserResponse:
+        return self._list(CurrentUserResponse, "GET", "/auth/me")
+
+    def logout(self) -> LogoutResponse:
+        return self._list(LogoutResponse, "POST", "/auth/logout")
+
+    def list_users(self) -> UserListResponse:
+        return self._list(UserListResponse, "GET", "/users")
+
+    def create_user(self, **fields) -> User:
+        body = UserCreateRequest(**_compact(fields)).model_dump(mode="json", exclude_none=True)
+        return self._list(User, "POST", "/users", json_body=body)
+
+    def get_user(self, user_id: str) -> User:
+        return self._list(User, "GET", f"/users/{user_id}")
+
+    def update_user(self, user_id: str, **fields) -> User:
+        body = UserUpdateRequest(**_compact(fields)).model_dump(mode="json", exclude_none=True)
+        return self._list(User, "PATCH", f"/users/{user_id}", json_body=body)
+
+    def delete_user(self, user_id: str) -> DeleteUserResponse:
+        return self._list(DeleteUserResponse, "DELETE", f"/users/{user_id}")
 
     # ---- dispatch ----
 

--- a/swarmmind/cli/commands/auth.py
+++ b/swarmmind/cli/commands/auth.py
@@ -1,0 +1,34 @@
+"""Authentication CLI commands."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+import typer
+
+from swarmmind.cli.commands._common import run_client_command
+
+auth_app = typer.Typer(help="Authenticate against the supervisor API.", no_args_is_help=True)
+
+
+@auth_app.command("login")
+def login(
+    ctx: typer.Context,
+    email: Annotated[str, typer.Argument(help="User email.")],
+    password: Annotated[str, typer.Option("--password", "-p", prompt=True, hide_input=True, help="User password.")],
+    token_name: Annotated[str | None, typer.Option("--token-name", help="Human label for this API token.")] = None,
+) -> None:
+    """Exchange email/password for a bearer token."""
+    run_client_command(ctx, lambda client: client.login(email, password, token_name=token_name))
+
+
+@auth_app.command("me")
+def me(ctx: typer.Context) -> None:
+    """Show the current authenticated user."""
+    run_client_command(ctx, lambda client: client.me())
+
+
+@auth_app.command("logout")
+def logout(ctx: typer.Context) -> None:
+    """Revoke the current bearer token."""
+    run_client_command(ctx, lambda client: client.logout())

--- a/swarmmind/cli/commands/user.py
+++ b/swarmmind/cli/commands/user.py
@@ -1,0 +1,74 @@
+"""User management CLI commands."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+import typer
+
+from swarmmind.cli.commands._common import run_client_command
+
+user_app = typer.Typer(help="Manage local users.", no_args_is_help=True)
+
+
+@user_app.command("list")
+def list_users(ctx: typer.Context) -> None:
+    """List local users."""
+    run_client_command(ctx, lambda client: client.list_users())
+
+
+@user_app.command("create")
+def create_user(
+    ctx: typer.Context,
+    email: Annotated[str, typer.Argument(help="User email.")],
+    password: Annotated[str, typer.Option("--password", "-p", prompt=True, hide_input=True, help="Initial password.")],
+    display_name: Annotated[str | None, typer.Option("--display-name", help="Display name.")] = None,
+    role: Annotated[str, typer.Option("--role", help="User role: admin or member.")] = "member",
+) -> None:
+    """Create a local user."""
+    run_client_command(
+        ctx,
+        lambda client: client.create_user(email=email, password=password, display_name=display_name, role=role),
+    )
+
+
+@user_app.command("get")
+def get_user(
+    ctx: typer.Context,
+    user_id: Annotated[str, typer.Argument(help="User ID.")],
+) -> None:
+    """Get a local user."""
+    run_client_command(ctx, lambda client: client.get_user(user_id))
+
+
+@user_app.command("update")
+def update_user(
+    ctx: typer.Context,
+    user_id: Annotated[str, typer.Argument(help="User ID.")],
+    email: Annotated[str | None, typer.Option("--email", help="New email.")] = None,
+    password: Annotated[str | None, typer.Option("--password", "-p", help="New password.")] = None,
+    display_name: Annotated[str | None, typer.Option("--display-name", help="Display name.")] = None,
+    role: Annotated[str | None, typer.Option("--role", help="User role: admin or member.")] = None,
+    status: Annotated[str | None, typer.Option("--status", help="User status: active or disabled.")] = None,
+) -> None:
+    """Update a local user."""
+    run_client_command(
+        ctx,
+        lambda client: client.update_user(
+            user_id,
+            email=email,
+            password=password,
+            display_name=display_name,
+            role=role,
+            status=status,
+        ),
+    )
+
+
+@user_app.command("disable")
+def disable_user(
+    ctx: typer.Context,
+    user_id: Annotated[str, typer.Argument(help="User ID.")],
+) -> None:
+    """Disable a local user and revoke its tokens."""
+    run_client_command(ctx, lambda client: client.delete_user(user_id))

--- a/swarmmind/cli/config.py
+++ b/swarmmind/cli/config.py
@@ -9,6 +9,7 @@ import typer
 
 DEFAULT_API_URL = "http://127.0.0.1:8000"
 API_URL_ENV = "SWARMMIND_API_URL"
+API_TOKEN_ENV = "SWARMMIND_API_TOKEN"  # noqa: S105 - environment variable name, not a token value.
 
 
 @dataclass
@@ -16,6 +17,7 @@ class CLIState:
     """Resolved root CLI state shared by commands."""
 
     api_url: str
+    api_token: str | None = None
     json_output: bool = False
     quiet: bool = False
 
@@ -26,11 +28,16 @@ def resolve_api_url(api_url: str | None = None) -> str:
     return resolved.rstrip("/")
 
 
+def resolve_api_token(api_token: str | None = None) -> str | None:
+    """Resolve bearer token from flag, environment, then no token."""
+    return api_token or os.environ.get(API_TOKEN_ENV)
+
+
 def get_state(ctx: typer.Context) -> CLIState:
     """Return the current CLI state from Typer context."""
     if isinstance(ctx.obj, CLIState):
         return ctx.obj
-    state = CLIState(api_url=resolve_api_url())
+    state = CLIState(api_url=resolve_api_url(), api_token=resolve_api_token())
     ctx.obj = state
     return state
 
@@ -39,4 +46,5 @@ def get_client(ctx: typer.Context):
     """Create an HTTP client for the current CLI invocation."""
     from swarmmind.cli.client import SwarmMindClient
 
-    return SwarmMindClient(api_url=get_state(ctx).api_url)
+    state = get_state(ctx)
+    return SwarmMindClient(api_url=state.api_url, api_token=state.api_token)

--- a/swarmmind/db_models.py
+++ b/swarmmind/db_models.py
@@ -204,6 +204,49 @@ class ProjectDB(SQLModel, table=True):
     )
 
 
+class UserDB(SQLModel, table=True):
+    """Local user identity for CLI/API authentication."""
+
+    __tablename__ = "users"
+
+    user_id: str = Field(primary_key=True)
+    email: str
+    display_name: str | None = None
+    password_hash: str | None = None
+    role: str = Field(default="member")  # 'admin' | 'member'
+    status: str = Field(default="active")  # 'active' | 'disabled'
+    created_at: datetime | None = Field(default_factory=utc_now)
+    updated_at: datetime | None = Field(default_factory=utc_now)
+    last_login_at: datetime | None = None
+
+    __table_args__ = (
+        Index("idx_users_email", "email", unique=True),
+        Index("idx_users_status", "status"),
+        Index("idx_users_role", "role"),
+    )
+
+
+class UserTokenDB(SQLModel, table=True):
+    """Hashed bearer token attached to a local user."""
+
+    __tablename__ = "user_tokens"
+
+    token_id: str = Field(primary_key=True)
+    user_id: str = Field(foreign_key="users.user_id")
+    token_hash: str
+    name: str | None = None
+    status: str = Field(default="active")  # 'active' | 'revoked'
+    created_at: datetime | None = Field(default_factory=utc_now)
+    last_used_at: datetime | None = None
+    expires_at: datetime | None = None
+
+    __table_args__ = (
+        Index("idx_user_tokens_user", "user_id"),
+        Index("idx_user_tokens_hash", "token_hash", unique=True),
+        Index("idx_user_tokens_status", "status"),
+    )
+
+
 class ArtifactDB(SQLModel, table=True):
     """Artifact/evidence metadata for runs and conversations."""
 

--- a/swarmmind/models.py
+++ b/swarmmind/models.py
@@ -633,6 +633,99 @@ class ProjectPermissionCheckResponse(BaseModel):
     reason: str
 
 
+class UserRole(str, Enum):
+    """Local user role."""
+
+    ADMIN = "admin"
+    MEMBER = "member"
+
+
+class UserStatus(str, Enum):
+    """Local user status."""
+
+    ACTIVE = "active"
+    DISABLED = "disabled"
+
+
+class User(BaseModel):
+    """Local user identity."""
+
+    user_id: str
+    email: str
+    display_name: str | None = None
+    role: UserRole = UserRole.MEMBER
+    status: UserStatus = UserStatus.ACTIVE
+    created_at: str
+    updated_at: str
+    last_login_at: str | None = None
+
+
+class UserListResponse(BaseModel):
+    """Response containing users."""
+
+    items: list[User]
+    total: int
+
+
+class UserCreateRequest(BaseModel):
+    """Request to create a local user."""
+
+    email: str = Field(..., min_length=3, max_length=320)
+    display_name: str | None = Field(None, max_length=200)
+    password: str = Field(..., min_length=8, max_length=200)
+    role: UserRole = UserRole.MEMBER
+    status: UserStatus = UserStatus.ACTIVE
+
+
+class UserUpdateRequest(BaseModel):
+    """Request to update a local user."""
+
+    email: str | None = Field(None, min_length=3, max_length=320)
+    display_name: str | None = Field(None, max_length=200)
+    password: str | None = Field(None, min_length=8, max_length=200)
+    role: UserRole | None = None
+    status: UserStatus | None = None
+
+
+class DeleteUserResponse(BaseModel):
+    """Response after disabling a local user."""
+
+    status: str = "disabled"
+    user_id: str
+
+
+class LoginRequest(BaseModel):
+    """Request to exchange credentials for an API token."""
+
+    email: str = Field(..., min_length=3, max_length=320)
+    password: str = Field(..., min_length=1, max_length=200)
+    token_name: str | None = Field(None, max_length=200)
+
+
+class AuthToken(BaseModel):
+    """API token returned once after login or token creation."""
+
+    token_id: str
+    token: str
+    token_type: str = "bearer"  # noqa: S105 - token type label, not a secret.
+    user: User
+
+
+class CurrentUserResponse(BaseModel):
+    """Current authenticated user and token context."""
+
+    user: User
+    token_id: str | None = None
+    authenticated: bool = True
+
+
+class LogoutResponse(BaseModel):
+    """Response after revoking the current token."""
+
+    status: str = "revoked"
+    token_id: str
+
+
 class AttachTeamRequest(BaseModel):
     """Request to attach a team template to a project."""
 

--- a/swarmmind/repositories/user.py
+++ b/swarmmind/repositories/user.py
@@ -1,0 +1,196 @@
+"""Local user and token repository."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from fastapi import HTTPException
+from sqlalchemy.exc import IntegrityError
+from sqlmodel import select
+
+from swarmmind.db import session_scope
+from swarmmind.db_models import UserDB, UserTokenDB
+from swarmmind.services.auth import hash_api_token, hash_password, normalize_email, verify_password
+from swarmmind.time_utils import utc_now
+
+
+class UserRepository:
+    """Repository for local users and bearer tokens."""
+
+    def list_all(self) -> list[UserDB]:
+        """List users ordered by creation time."""
+        with session_scope() as session:
+            rows = session.exec(select(UserDB).order_by(UserDB.created_at.asc())).all()
+            for row in rows:
+                session.expunge(row)
+            return list(rows)
+
+    def get(self, user_id: str) -> UserDB:
+        """Get a user by ID or raise 404."""
+        with session_scope() as session:
+            row = session.get(UserDB, user_id)
+            if row is None:
+                raise HTTPException(status_code=404, detail="User not found")
+            session.expunge(row)
+            return row
+
+    def get_by_email(self, email: str) -> UserDB:
+        """Get a user by normalized email or raise 404."""
+        normalized = normalize_email(email)
+        with session_scope() as session:
+            row = session.exec(select(UserDB).where(UserDB.email == normalized)).first()
+            if row is None:
+                raise HTTPException(status_code=404, detail="User not found")
+            session.expunge(row)
+            return row
+
+    def create(
+        self,
+        *,
+        email: str,
+        password: str,
+        display_name: str | None = None,
+        role: str = "member",
+        status: str = "active",
+    ) -> UserDB:
+        """Create a local user."""
+        with session_scope() as session:
+            row = UserDB(
+                user_id=str(uuid.uuid4()),
+                email=normalize_email(email),
+                display_name=display_name,
+                password_hash=hash_password(password),
+                role=role,
+                status=status,
+            )
+            session.add(row)
+            try:
+                session.commit()
+            except IntegrityError as exc:
+                session.rollback()
+                raise HTTPException(status_code=409, detail="User email already exists") from exc
+            session.refresh(row)
+            session.expunge(row)
+            return row
+
+    def update(
+        self,
+        user_id: str,
+        *,
+        email: str | None = None,
+        password: str | None = None,
+        display_name: str | None = None,
+        role: str | None = None,
+        status: str | None = None,
+    ) -> UserDB:
+        """Update a local user."""
+        with session_scope() as session:
+            row = session.get(UserDB, user_id)
+            if row is None:
+                raise HTTPException(status_code=404, detail="User not found")
+            if email is not None:
+                row.email = normalize_email(email)
+            if password is not None:
+                row.password_hash = hash_password(password)
+            if display_name is not None:
+                row.display_name = display_name
+            if role is not None:
+                row.role = role
+            if status is not None:
+                row.status = status
+            row.updated_at = utc_now()
+            try:
+                session.commit()
+            except IntegrityError as exc:
+                session.rollback()
+                raise HTTPException(status_code=409, detail="User email already exists") from exc
+            session.refresh(row)
+            session.expunge(row)
+            return row
+
+    def disable(self, user_id: str) -> None:
+        """Disable a user and revoke all active tokens."""
+        with session_scope() as session:
+            row = session.get(UserDB, user_id)
+            if row is None:
+                raise HTTPException(status_code=404, detail="User not found")
+            row.status = "disabled"
+            row.updated_at = utc_now()
+            tokens = session.exec(select(UserTokenDB).where(UserTokenDB.user_id == user_id)).all()
+            for token in tokens:
+                token.status = "revoked"
+            session.commit()
+
+    def authenticate(self, *, email: str, password: str) -> UserDB:
+        """Validate user credentials and return the user."""
+        normalized = normalize_email(email)
+        with session_scope() as session:
+            row = session.exec(select(UserDB).where(UserDB.email == normalized)).first()
+            if row is None or not verify_password(password, row.password_hash):
+                raise HTTPException(status_code=401, detail="Invalid email or password")
+            if row.status != "active":
+                raise HTTPException(status_code=403, detail="User is disabled")
+            row.last_login_at = utc_now()
+            row.updated_at = utc_now()
+            session.commit()
+            session.refresh(row)
+            session.expunge(row)
+            return row
+
+    def create_token(
+        self,
+        *,
+        user_id: str,
+        token_hash: str,
+        name: str | None = None,
+        expires_at: datetime | None = None,
+    ) -> UserTokenDB:
+        """Store a hashed bearer token."""
+        with session_scope() as session:
+            user = session.get(UserDB, user_id)
+            if user is None:
+                raise HTTPException(status_code=404, detail="User not found")
+            row = UserTokenDB(
+                token_id=str(uuid.uuid4()),
+                user_id=user_id,
+                token_hash=token_hash,
+                name=name,
+                expires_at=expires_at,
+            )
+            session.add(row)
+            session.commit()
+            session.refresh(row)
+            session.expunge(row)
+            return row
+
+    def resolve_token(self, token: str) -> tuple[UserDB, UserTokenDB]:
+        """Resolve a bearer token into active user and token rows."""
+        token_hash = hash_api_token(token)
+        with session_scope() as session:
+            token_row = session.exec(select(UserTokenDB).where(UserTokenDB.token_hash == token_hash)).first()
+            if token_row is None or token_row.status != "active":
+                raise HTTPException(status_code=401, detail="Invalid API token")
+            if token_row.expires_at is not None and token_row.expires_at <= utc_now():
+                token_row.status = "revoked"
+                session.commit()
+                raise HTTPException(status_code=401, detail="API token expired")
+            user = session.get(UserDB, token_row.user_id)
+            if user is None or user.status != "active":
+                raise HTTPException(status_code=403, detail="User is disabled")
+            token_row.last_used_at = utc_now()
+            session.commit()
+            session.refresh(user)
+            session.refresh(token_row)
+            session.expunge(user)
+            session.expunge(token_row)
+            return user, token_row
+
+    def revoke_token(self, token_id: str) -> None:
+        """Revoke a token by ID."""
+        with session_scope() as session:
+            row = session.get(UserTokenDB, token_id)
+            if row is None:
+                raise HTTPException(status_code=404, detail="User token not found")
+            row.status = "revoked"
+            session.commit()

--- a/swarmmind/services/auth.py
+++ b/swarmmind/services/auth.py
@@ -1,0 +1,58 @@
+"""Local password and bearer-token helpers."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import secrets
+
+TOKEN_PREFIX = "swm_"  # noqa: S105 - public token prefix, not a token value.
+PASSWORD_SCHEME = "pbkdf2_sha256"  # noqa: S105 - password hash scheme name, not a password.
+PASSWORD_ITERATIONS = 260_000
+
+
+def normalize_email(email: str) -> str:
+    """Normalize user emails for identity lookup."""
+    return email.strip().lower()
+
+
+def hash_password(password: str) -> str:
+    """Hash a password with PBKDF2-HMAC-SHA256."""
+    salt = secrets.token_bytes(16)
+    digest = hashlib.pbkdf2_hmac("sha256", password.encode("utf-8"), salt, PASSWORD_ITERATIONS)
+    salt_b64 = base64.urlsafe_b64encode(salt).decode("ascii").rstrip("=")
+    digest_b64 = base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
+    return f"{PASSWORD_SCHEME}${PASSWORD_ITERATIONS}${salt_b64}${digest_b64}"
+
+
+def verify_password(password: str, stored_hash: str | None) -> bool:
+    """Verify a password against the stored PBKDF2 hash."""
+    if not stored_hash:
+        return False
+    try:
+        scheme, iterations_text, salt_b64, digest_b64 = stored_hash.split("$", 3)
+        if scheme != PASSWORD_SCHEME:
+            return False
+        iterations = int(iterations_text)
+        salt = _urlsafe_b64decode(salt_b64)
+        expected = _urlsafe_b64decode(digest_b64)
+    except (ValueError, TypeError):
+        return False
+    actual = hashlib.pbkdf2_hmac("sha256", password.encode("utf-8"), salt, iterations)
+    return hmac.compare_digest(actual, expected)
+
+
+def generate_api_token() -> str:
+    """Generate a high-entropy API token."""
+    return TOKEN_PREFIX + secrets.token_urlsafe(32)
+
+
+def hash_api_token(token: str) -> str:
+    """Hash an API token for storage and lookup."""
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def _urlsafe_b64decode(value: str) -> bytes:
+    padding = "=" * (-len(value) % 4)
+    return base64.urlsafe_b64decode(value + padding)

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -133,3 +133,79 @@ def test_member_permission_command(monkeypatch) -> None:
 
     assert result.exit_code == 0
     assert json.loads(result.stdout)["allowed"] is True
+
+
+def test_user_create_command(monkeypatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/users"
+        payload = json.loads(request.content.decode())
+        assert payload["email"] == "ada@example.com"
+        assert payload["password"] == "correct horse"  # noqa: S105 - test fixture password.
+        return httpx.Response(
+            201,
+            json={
+                "user_id": "user-1",
+                "email": "ada@example.com",
+                "display_name": "Ada",
+                "role": "admin",
+                "status": "active",
+                "created_at": "2026-05-17T00:00:00",
+                "updated_at": "2026-05-17T00:00:00",
+                "last_login_at": None,
+            },
+        )
+
+    _patch_httpx_client(monkeypatch, handler)
+
+    result = runner.invoke(
+        app,
+        [
+            "--api-url",
+            "http://swarmmind.test",
+            "--json",
+            "user",
+            "create",
+            "ada@example.com",
+            "--password",
+            "correct horse",
+            "--display-name",
+            "Ada",
+            "--role",
+            "admin",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)["user_id"] == "user-1"
+
+
+def test_auth_me_sends_bearer_token(monkeypatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/auth/me"
+        assert request.headers["authorization"] == "Bearer swm_test"
+        return httpx.Response(
+            200,
+            json={
+                "authenticated": True,
+                "token_id": "token-1",
+                "user": {
+                    "user_id": "user-1",
+                    "email": "ada@example.com",
+                    "display_name": "Ada",
+                    "role": "member",
+                    "status": "active",
+                    "created_at": "2026-05-17T00:00:00",
+                    "updated_at": "2026-05-17T00:00:00",
+                    "last_login_at": None,
+                },
+            },
+        )
+
+    _patch_httpx_client(monkeypatch, handler)
+
+    result = runner.invoke(
+        app, ["--api-url", "http://swarmmind.test", "--api-token", "swm_test", "--json", "auth", "me"]
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)["token_id"] == "token-1"  # noqa: S105 - test fixture token ID.

--- a/tests/test_user_api.py
+++ b/tests/test_user_api.py
@@ -1,0 +1,105 @@
+"""User and auth API tests."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from swarmmind.api.supervisor import app
+from swarmmind.db import dispose_engines, init_db
+
+client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def setup_db(monkeypatch, tmp_path):
+    db_path = tmp_path / "user_api_test.db"
+    monkeypatch.setenv("SWARMMIND_DATABASE_URL", f"sqlite:///{db_path}")
+    dispose_engines()
+    init_db()
+
+
+def _create_user(email: str = "Ada@Example.COM", password: str = "correct horse") -> dict:  # noqa: S107
+    response = client.post(
+        "/users",
+        json={"email": email, "password": password, "display_name": "Ada", "role": "admin"},
+    )
+    assert response.status_code == 201
+    return response.json()
+
+
+def test_create_list_and_get_user() -> None:
+    created = _create_user()
+
+    assert created["email"] == "ada@example.com"
+    assert created["display_name"] == "Ada"
+    assert created["role"] == "admin"
+    assert "password_hash" not in created
+
+    listed = client.get("/users")
+    assert listed.status_code == 200
+    assert listed.json()["total"] == 1
+
+    fetched = client.get(f"/users/{created['user_id']}")
+    assert fetched.status_code == 200
+    assert fetched.json()["email"] == "ada@example.com"
+
+
+def test_duplicate_email_returns_409() -> None:
+    _create_user()
+
+    response = client.post("/users", json={"email": "ada@example.com", "password": "correct horse"})
+
+    assert response.status_code == 409
+
+
+def test_login_me_and_logout_token_cycle() -> None:
+    _create_user()
+
+    login = client.post(
+        "/auth/login", json={"email": "ada@example.com", "password": "correct horse", "token_name": "cli"}
+    )
+
+    assert login.status_code == 200
+    token_data = login.json()
+    assert token_data["token"].startswith("swm_")
+    assert token_data["user"]["email"] == "ada@example.com"
+
+    headers = {"Authorization": f"Bearer {token_data['token']}"}
+    me = client.get("/auth/me", headers=headers)
+    assert me.status_code == 200
+    assert me.json()["user"]["email"] == "ada@example.com"
+    assert me.json()["token_id"] == token_data["token_id"]
+
+    logout = client.post("/auth/logout", headers=headers)
+    assert logout.status_code == 200
+    assert logout.json()["status"] == "revoked"
+
+    revoked = client.get("/auth/me", headers=headers)
+    assert revoked.status_code == 401
+
+
+def test_login_rejects_wrong_password_and_disabled_user() -> None:
+    user = _create_user()
+
+    wrong = client.post("/auth/login", json={"email": "ada@example.com", "password": "wrong"})
+    assert wrong.status_code == 401
+
+    disabled = client.delete(f"/users/{user['user_id']}")
+    assert disabled.status_code == 200
+
+    login = client.post("/auth/login", json={"email": "ada@example.com", "password": "correct horse"})
+    assert login.status_code == 403
+
+
+def test_disabling_user_revokes_active_tokens() -> None:
+    user = _create_user()
+    login = client.post("/auth/login", json={"email": "ada@example.com", "password": "correct horse"})
+    token = login.json()["token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    assert client.get("/auth/me", headers=headers).status_code == 200
+    assert client.delete(f"/users/{user['user_id']}").status_code == 200
+
+    response = client.get("/auth/me", headers=headers)
+    assert response.status_code == 401


### PR DESCRIPTION
## Summary
- add local users and hashed bearer token storage with Alembic migration
- add /users and /auth login/me/logout API routes
- add CLI auth/user commands and --api-token support
- document CLI auth loop in README and docs/cli.md

## Tests
- .venv/bin/ruff check pyproject.toml swarmmind tests alembic/versions/d2e3f4a5b6c7_users_and_tokens.py
- .venv/bin/python -m pytest tests/test_user_api.py tests/test_cli_commands.py tests/test_cli_client.py -v --no-cov
- make test
- CLI/API smoke against temporary SQLite DB