### PR TITLE
feat: introduce Connector concept with Feishu CLI as first implementation

### DIFF
--- a/docs/connector-design.md
+++ b/docs/connector-design.md
@@ -1,0 +1,238 @@
+# SwarmMind Connector Architecture
+
+> Version: v1.0
+> Date: 2026-05-17
+> Status: Design + Initial Implementation (Feishu CLI)
+
+## 1. 背景与调研结论
+
+### 竞品对比
+
+| 平台 | 集成方式 | 特点 |
+|---|---|---|
+| **Manus** | Connector = MCP 客户端 + 凭证管理层 | 每个 Connector 绑定到 Project，通过 UID 引用；用户一次性授权，凭证存在平台侧；Phase 1 目标：Connector + Skills 深度组合实现 SOP |
+| **LangChain** | `@tool` 装饰器 / `BaseTool` 子类 | 工具是 Python 函数，docstring 即描述，schema 自动推导 |
+| **CrewAI** | 同 LangChain 模式，但独立实现 | Agent 初始化时绑定 tools；框架根据描述路由 |
+| **Agent Skills (Anthropic)** | SKILL.md 文件标准 | 32 个平台支持；会话启动只读 metadata（30 tokens），任务匹配才加载全文（800 tokens）；解决 MCP 的 token 爆炸问题 |
+
+### CLI vs MCP Token 成本对比
+
+MCP 的核心问题：大型 MCP 服务器（如 GitHub MCP）有 93 个工具定义，仅 schema 就消耗 ~55,000 tokens。  
+lark-cli 等 CLI 工具：~200 tokens（model 知道如何调用 `--help`），按需加载。
+
+**最佳实践（Claude Code 自身的选择）**：  
+- CLI/Shell → 本地操作（git, gh, 文件操作）
+- MCP → 结构化外部服务集成（远程 API，结构化 I/O）  
+- Agent Skills → 程序性知识层（叠加在 CLI 和 MCP 之上）
+
+### 飞书 CLI (lark-cli) 调研
+
+- **仓库**: `github.com/larksuite/cli`，Go 编写，npm 分发（`@larksuite/cli`）
+- **规模**: 200+ 命令，17 个业务域，覆盖 2500+ OpenAPI 接口
+- **三层抽象**: Shortcuts（`+agenda`）→ API 命令（1:1 对应接口）→ Raw API（`lark-cli api GET ...`）
+- **24 个 AI Agent Skills**: `lark-calendar`, `lark-im`, `lark-doc`, `lark-task`, `lark-event`（WebSocket 事件订阅）等
+- **Agent 友好**: NDJSON 输出，`--no-wait`，`--as user/bot`，`--dry-run`，OS keychain 存凭证
+- **并行方案**: `lark-openapi-mcp`（Node.js MCP 服务器，包装 Feishu OpenAPI），Beta 阶段，不支持文件上传/云文档直接编辑
+
+**选择 CLI 连接器（而非 MCP 连接器）的原因**:  
+`lark-cli` 专为 AI Agent 设计，命令经过真实 Agent 测试，有预置 Skills；`lark-openapi-mcp` 仍是 Beta。CLI 是第一个连接器的最稳健基础。
+
+---
+
+## 2. Connector 概念定义
+
+**连接器（Connector）** 是 SwarmMind 的一等集成单元，将外部系统（协作平台、SaaS 工具、数据源）双向桥接到 SwarmMind 控制面：
+
+```
+外部系统
+    ↓ (事件: webhook / WebSocket / polling)
+    │
+[Connector 进程]                    ← 独立进程，不嵌入 API Server
+    ├── Ingress Adapter  →  SwarmMind REST API (dispatch / chat)
+    ├── MCP Tool Server  ←  DeerFlow agents via RuntimeProfile.mcp_servers
+    └── Heartbeat        →  SwarmMind REST API (connector status)
+    │
+SwarmMind 控制面
+    ├── ConnectorDB       (配置, 加密凭证, 状态)
+    ├── Connectors API    (CRUD, heartbeat)
+    └── CLI               (swarmmind connector ...)
+```
+
+### 两个方向
+
+1. **Ingress（外部 → SwarmMind）**: 飞书消息 → 创建 SwarmMind 对话 / dispatch 目标  
+2. **Tool Provider（SwarmMind Agents → 外部）**: Agent 调用飞书 API（发消息、建文档、查日历）via MCP tools
+
+---
+
+## 3. 设计原则
+
+1. **独立进程，控制面归属** — Connector 是独立进程（类似 DeerFlow），SwarmMind 存储元数据和凭证，不托管 Connector 的执行逻辑。
+
+2. **HTTP-first** — Connector 调用 SwarmMind REST API，不直接访问数据库。
+
+3. **MCP-native 工具暴露** — Connector 通过 FastMCP 暴露 MCP Server，DeerFlow Agents 通过 RuntimeProfile 的 `mcp_servers` 配置消费。
+
+4. **事件驱动 Ingress** — Connector 订阅外部事件流（WebSocket / webhook），翻译为 SwarmMind dispatch 调用。
+
+5. **凭证主权** — 外部 API 凭证存储在 SwarmMind 的 ConnectorDB（Fernet 加密），运行时通过环境变量注入 Connector 进程，不经由 DeerFlow 或 Agent。
+
+6. **Manifest 驱动** — 每个 Connector 声明机器可读的 Manifest，描述能力、配置 schema、传输协议、版本。
+
+7. **渐进式集成** — 不强制要求 Connector 同时支持 ingress 和 tool_provider；可以只做其中一种。
+
+---
+
+## 4. Connector Manifest
+
+```yaml
+name: feishu-cli
+version: 1.0.0
+description: Bridges Feishu/Lark to SwarmMind via lark-cli
+transport: mcp_http
+capabilities:
+  - ingest         # 接收飞书事件，dispatch 到 SwarmMind
+  - tool_provider  # 暴露飞书 API 为 MCP tools，供 Agents 使用
+config_schema:
+  - name: app_id
+    description: Feishu app ID (from Feishu Open Platform)
+    required: true
+    secret: false
+  - name: app_secret
+    description: Feishu app secret
+    required: true
+    secret: true
+  - name: mcp_port
+    description: Port for the MCP tool server
+    required: false
+    default: "7070"
+  - name: event_bot_name
+    description: Bot name to filter @mentions
+    required: false
+    default: ""
+```
+
+---
+
+## 5. 飞书 CLI 连接器设计
+
+### 5.1 MCP Tool Bridge
+
+Connector 启动一个 FastMCP 服务器（`streamable-http` 或 `stdio`），每个 tool 对应一条 `lark-cli` 子进程调用：
+
+| MCP Tool | lark-cli 命令 | 说明 |
+|---|---|---|
+| `feishu_send_message` | `lark-cli im message +send` | 发送消息到指定 chat |
+| `feishu_list_messages` | `lark-cli im message list` | 列出 chat 消息 |
+| `feishu_get_chat_info` | `lark-cli im chat get` | 获取 chat 信息 |
+| `feishu_create_doc` | `lark-cli doc documents create` | 创建飞书文档 |
+| `feishu_get_doc` | `lark-cli doc documents get` | 获取文档内容 |
+| `feishu_search` | `lark-cli search +query` | 全局搜索 |
+| `feishu_get_agenda` | `lark-cli calendar +agenda` | 获取日历议程 |
+| `feishu_create_task` | `lark-cli task tasks create` | 创建任务 |
+| `feishu_list_tasks` | `lark-cli task tasks list` | 列出任务 |
+| `feishu_run_command` | `lark-cli <cmd>` | 执行任意 lark-cli 命令（高级用法） |
+
+**每次 tool call 启动一个短生命周期子进程**（lark-cli 是无状态 CLI，开销可接受）。  
+凭证由 `lark-cli` 自身通过 OS keychain 管理。
+
+### 5.2 事件监听器（Ingress）
+
+```
+[lark-cli event +listen --format ndjson]  ← 长生命周期子进程
+         ↓ NDJSON lines
+[FeishuEventListener]
+         ↓ 解析 im.message.receive_v1 等事件
+[SwarmMindClient.dispatch() / create_conversation()]
+         ↓ 异步等待结果
+[lark-cli im message +send] ← 回复到原 chat
+```
+
+事件路由规则（可配置）：
+- `@bot mention` → `dispatch(goal=message_text)`
+- Direct Message → `create_conversation` + `send_message`
+- 其他类型 → ignore / log
+
+### 5.3 与 DeerFlow RuntimeProfile 集成
+
+Connector 启动后上报 `mcp_url`，SwarmMind 可自动在 RuntimeProfile 的 `mcp_servers` 中注册该 Connector：
+
+```yaml
+# DeerFlow config.yaml fragment（由 RuntimeProfile bootstrap 生成）
+mcp_servers:
+  - name: feishu
+    url: http://localhost:7070/mcp
+    transport: streamable-http
+```
+
+---
+
+## 6. 数据模型
+
+```python
+class ConnectorDB(SQLModel, table=True):
+    connector_id: str      # primary key ("feishu-prod")
+    name: str              # human label
+    connector_type: str    # "feishu-cli" | "slack-mcp" | ...
+    version: str
+    status: str            # "inactive" | "running" | "error"
+    config_json: str       # JSON; secret fields Fernet-encrypted
+    mcp_url: str | None    # http://host:port/mcp when running
+    last_heartbeat: datetime | None
+    created_at: datetime
+    updated_at: datetime
+```
+
+---
+
+## 7. API Endpoints
+
+```
+GET    /connectors                          列出所有连接器
+POST   /connectors                          注册连接器
+GET    /connectors/{connector_id}           获取连接器详情
+PATCH  /connectors/{connector_id}           更新配置
+DELETE /connectors/{connector_id}           删除连接器
+POST   /connectors/{connector_id}/heartbeat 连接器上报健康状态
+```
+
+---
+
+## 8. CLI 命令
+
+```
+swarmmind connector list                       列出所有连接器
+swarmmind connector add <type> --id <id>       交互式注册连接器
+swarmmind connector status <id>                查看连接器状态
+swarmmind connector remove <id>                删除连接器
+
+# 飞书专用命令
+swarmmind connector feishu serve-tools [--id <id>] [--port 7070]
+    启动 MCP tool 服务器（供 DeerFlow agents 使用）
+
+swarmmind connector feishu listen-events [--id <id>]
+    启动事件监听器（飞书消息 → SwarmMind dispatch）
+```
+
+---
+
+## 9. 安全考虑
+
+- **凭证存储**: `app_secret` 等敏感字段通过 Fernet 加密存储在 ConnectorDB
+- **进程隔离**: Connector 是独立进程，不共享 API Server 内存
+- **权限最小化**: `lark-cli auth login --domain im,doc,task` 只授权所需 scope
+- **注入防护**: `lark-cli` 内置输入注入保护
+- **无直接 DB 访问**: Connector 只调用 SwarmMind REST API
+
+---
+
+## 10. 未来连接器 Roadmap
+
+| 连接器 | 类型 | 优先级 |
+|---|---|---|
+| `feishu-cli` | CLI connector | **P0（当前）** |
+| `slack-mcp` | MCP connector | P1 |
+| `github-mcp` | MCP connector | P1 |
+| `notion-mcp` | MCP connector | P2 |
+| `email-smtp` | Webhook connector | P2 |
+| `custom-webhook` | Webhook connector | P2 |

--- a/swarmmind/api/routers/connectors.py
+++ b/swarmmind/api/routers/connectors.py
@@ -1,0 +1,90 @@
+"""REST API endpoints for connector management."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+
+from swarmmind.models import (
+    ConnectorCreateRequest,
+    ConnectorHeartbeatRequest,
+    ConnectorListResponse,
+    ConnectorResponse,
+    ConnectorUpdateRequest,
+    DeleteConnectorResponse,
+)
+from swarmmind.repositories.connector import ConnectorRepository
+
+router = APIRouter(prefix="/connectors", tags=["connectors"])
+
+_repo = ConnectorRepository()
+
+
+def _to_response(db) -> ConnectorResponse:  # type: ignore[no-untyped-def]
+    """Convert ConnectorDB row to ConnectorResponse with masked secrets."""
+    return ConnectorResponse(
+        connector_id=db.connector_id,
+        name=db.name,
+        connector_type=db.connector_type,
+        version=db.version,
+        status=db.status,
+        config=_repo.get_config_masked(db.connector_id),
+        mcp_url=db.mcp_url,
+        last_heartbeat=db.last_heartbeat,
+        created_at=db.created_at,
+        updated_at=db.updated_at,
+    )
+
+
+@router.get("", response_model=ConnectorListResponse)
+def list_connectors() -> ConnectorListResponse:
+    """List all registered connectors."""
+    items = _repo.list_all()
+    return ConnectorListResponse(items=[_to_response(c) for c in items], total=len(items))
+
+
+@router.post("", response_model=ConnectorResponse, status_code=201)
+def create_connector(body: ConnectorCreateRequest) -> ConnectorResponse:
+    """Register a new connector."""
+    db = _repo.create(
+        connector_id=body.connector_id,
+        name=body.name,
+        connector_type=body.connector_type,
+        config=body.config,
+    )
+    return _to_response(db)
+
+
+@router.get("/{connector_id}", response_model=ConnectorResponse)
+def get_connector(connector_id: str) -> ConnectorResponse:
+    """Get connector details."""
+    db = _repo.get(connector_id)
+    if db is None:
+        raise HTTPException(status_code=404, detail=f"Connector '{connector_id}' not found.")
+    return _to_response(db)
+
+
+@router.patch("/{connector_id}", response_model=ConnectorResponse)
+def update_connector(connector_id: str, body: ConnectorUpdateRequest) -> ConnectorResponse:
+    """Update connector name or configuration."""
+    db = _repo.update(connector_id, name=body.name, config=body.config)
+    if db is None:
+        raise HTTPException(status_code=404, detail=f"Connector '{connector_id}' not found.")
+    return _to_response(db)
+
+
+@router.delete("/{connector_id}", response_model=DeleteConnectorResponse)
+def delete_connector(connector_id: str) -> DeleteConnectorResponse:
+    """Remove a connector registration."""
+    deleted = _repo.delete(connector_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail=f"Connector '{connector_id}' not found.")
+    return DeleteConnectorResponse(connector_id=connector_id, deleted=True)
+
+
+@router.post("/{connector_id}/heartbeat", response_model=ConnectorResponse)
+def connector_heartbeat(connector_id: str, body: ConnectorHeartbeatRequest) -> ConnectorResponse:
+    """Connector reports its runtime status and MCP URL to the control plane."""
+    db = _repo.record_heartbeat(connector_id, status=body.status, mcp_url=body.mcp_url)
+    if db is None:
+        raise HTTPException(status_code=404, detail=f"Connector '{connector_id}' not found.")
+    return _to_response(db)

--- a/swarmmind/api/supervisor.py
+++ b/swarmmind/api/supervisor.py
@@ -490,9 +490,11 @@ app.include_router(
 
 from swarmmind.api.llm_gateway_routes import router as _gateway_router
 from swarmmind.api.llm_provider_routes import router as _provider_router
+from swarmmind.api.routers.connectors import router as _connectors_router
 
 app.include_router(_gateway_router)
 app.include_router(_provider_router)
+app.include_router(_connectors_router)
 
 # ---- Run ----
 

--- a/swarmmind/cli/__main__.py
+++ b/swarmmind/cli/__main__.py
@@ -11,6 +11,7 @@ from swarmmind import __version__
 from swarmmind.cli.commands.approval import approval_app
 from swarmmind.cli.commands.audit import audit_app
 from swarmmind.cli.commands.auth import auth_app
+from swarmmind.cli.commands.connector import connector_app
 from swarmmind.cli.commands.conversation import chat_app, conversation_app
 from swarmmind.cli.commands.mcp import mcp_app
 from swarmmind.cli.commands.member import member_app
@@ -65,6 +66,7 @@ def _version() -> str:
 
 
 register_system_commands(app)
+app.add_typer(connector_app, name="connector")
 app.add_typer(conversation_app, name="conversation")
 app.add_typer(chat_app, name="chat")
 app.add_typer(auth_app, name="auth")

--- a/swarmmind/cli/client.py
+++ b/swarmmind/cli/client.py
@@ -15,6 +15,11 @@ from swarmmind.models import (
     AuditLogEntry,
     AuditLogListResponse,
     AuthToken,
+    ConnectorCreateRequest,
+    ConnectorHeartbeatRequest,
+    ConnectorListResponse,
+    ConnectorResponse,
+    ConnectorUpdateRequest,
     Conversation,
     ConversationListResponse,
     ConversationTraceResponse,
@@ -26,6 +31,7 @@ from swarmmind.models import (
     CurrentUserResponse,
     DeleteApprovalResponse,
     DeleteAuditLogResponse,
+    DeleteConnectorResponse,
     DeleteConversationResponse,
     DeleteProjectResponse,
     DeleteTaskResponse,
@@ -458,6 +464,58 @@ class SwarmMindClient:
 
     def get_memory(self, key: str, *, layer: str, scope_id: str) -> MemoryEntry:
         return self._list(MemoryEntry, "GET", f"/memory/{key}", params={"layer": layer, "scope_id": scope_id})
+
+    # ---- stream ----
+
+    # ---- connectors ----
+
+    def list_connectors(self) -> ConnectorListResponse:
+        """List all registered connectors."""
+        return self._list(ConnectorListResponse, "GET", "/connectors")
+
+    def create_connector(
+        self,
+        connector_type: str,
+        name: str,
+        config: dict[str, Any] | None = None,
+        connector_id: str | None = None,
+    ) -> ConnectorResponse:
+        """Register a new connector."""
+        body = ConnectorCreateRequest(
+            connector_id=connector_id,
+            name=name,
+            connector_type=connector_type,
+            config=config or {},
+        ).model_dump(mode="json", exclude_none=True)
+        return self._list(ConnectorResponse, "POST", "/connectors", json_body=body)
+
+    def get_connector(self, connector_id: str) -> ConnectorResponse:
+        """Get connector details."""
+        return self._list(ConnectorResponse, "GET", f"/connectors/{connector_id}")
+
+    def update_connector(
+        self,
+        connector_id: str,
+        name: str | None = None,
+        config: dict[str, Any] | None = None,
+    ) -> ConnectorResponse:
+        """Update connector name or config."""
+        body = ConnectorUpdateRequest(name=name, config=config).model_dump(mode="json", exclude_none=True)
+        return self._list(ConnectorResponse, "PATCH", f"/connectors/{connector_id}", json_body=body)
+
+    def delete_connector(self, connector_id: str) -> DeleteConnectorResponse:
+        """Delete a connector."""
+        return self._list(DeleteConnectorResponse, "DELETE", f"/connectors/{connector_id}")
+
+    def connector_heartbeat(
+        self,
+        connector_id: str,
+        status: str,
+        mcp_url: str | None = None,
+    ) -> ConnectorResponse:
+        """Report connector health to the control plane."""
+        body = ConnectorHeartbeatRequest(status=status, mcp_url=mcp_url).model_dump(mode="json", exclude_none=True)
+        return self._list(ConnectorResponse, "POST", f"/connectors/{connector_id}/heartbeat", json_body=body)
 
     # ---- stream ----
 

--- a/swarmmind/cli/commands/connector.py
+++ b/swarmmind/cli/commands/connector.py
@@ -144,7 +144,7 @@ def feishu_serve_tools(
 
         try:
             with SwarmMindClient(api_url=state.api_url, api_token=state.api_token) as client:
-                resp = client._request("GET", f"/connectors/{connector_id}")  # noqa: SLF001
+                resp = client._request("GET", f"/connectors/{connector_id}")
                 config = resp.get("config", {}) if isinstance(resp, dict) else {}
         except Exception as exc:
             typer.echo(f"Warning: could not load connector config: {exc}", err=True)
@@ -185,7 +185,7 @@ def feishu_listen_events(
 
         try:
             with SwarmMindClient(api_url=state.api_url, api_token=state.api_token) as client:
-                resp = client._request("GET", f"/connectors/{connector_id}")  # noqa: SLF001
+                resp = client._request("GET", f"/connectors/{connector_id}")
                 config = resp.get("config", {}) if isinstance(resp, dict) else {}
         except Exception as exc:
             typer.echo(f"Warning: could not load connector config: {exc}", err=True)

--- a/swarmmind/cli/commands/connector.py
+++ b/swarmmind/cli/commands/connector.py
@@ -1,0 +1,226 @@
+"""Connector CLI commands."""
+
+from __future__ import annotations
+
+import json
+from typing import Annotated, Any
+
+import typer
+
+from swarmmind.cli.commands._common import run_client_command
+from swarmmind.cli.config import get_state
+
+connector_app = typer.Typer(help="Manage SwarmMind connectors.", no_args_is_help=True)
+feishu_app = typer.Typer(help="Feishu/Lark CLI connector commands.", no_args_is_help=True)
+connector_app.add_typer(feishu_app, name="feishu")
+
+
+# ── Generic connector commands ────────────────────────────────────────────────
+
+
+@connector_app.command("list")
+def list_connectors(ctx: typer.Context) -> None:
+    """List all registered connectors."""
+    run_client_command(ctx, lambda client: client.list_connectors())
+
+
+@connector_app.command("get")
+def get_connector(
+    ctx: typer.Context,
+    connector_id: Annotated[str, typer.Argument(help="Connector ID.")],
+) -> None:
+    """Show details for a connector (secrets masked)."""
+    run_client_command(ctx, lambda client: client.get_connector(connector_id))
+
+
+@connector_app.command("add")
+def add_connector(
+    ctx: typer.Context,
+    connector_type: Annotated[str, typer.Argument(help="Connector type (e.g. feishu-cli).")],
+    connector_id: Annotated[str | None, typer.Option("--id", help="Stable connector ID.")] = None,
+    name: Annotated[str | None, typer.Option("--name", help="Human-readable label.")] = None,
+    config: Annotated[str | None, typer.Option("--config", help="Config as a JSON string.")] = None,
+) -> None:
+    """Register a new connector.
+
+    Example:
+        swarmmind connector add feishu-cli --id feishu-prod --config '{"bot_name":"SwarmBot"}'
+    """
+    parsed_config: dict[str, Any] = {}
+    if config:
+        try:
+            parsed_config = json.loads(config)
+        except json.JSONDecodeError as exc:
+            typer.echo(f"Error: --config is not valid JSON: {exc}", err=True)
+            raise typer.Exit(2) from exc
+
+    display_name = name or connector_type
+    run_client_command(
+        ctx,
+        lambda client: client.create_connector(
+            connector_type=connector_type,
+            connector_id=connector_id,
+            name=display_name,
+            config=parsed_config,
+        ),
+    )
+
+
+@connector_app.command("update")
+def update_connector(
+    ctx: typer.Context,
+    connector_id: Annotated[str, typer.Argument(help="Connector ID.")],
+    name: Annotated[str | None, typer.Option("--name")] = None,
+    config: Annotated[str | None, typer.Option("--config", help="Partial config as JSON.")] = None,
+) -> None:
+    """Update connector name or configuration."""
+    parsed_config: dict[str, Any] | None = None
+    if config:
+        try:
+            parsed_config = json.loads(config)
+        except json.JSONDecodeError as exc:
+            typer.echo(f"Error: --config is not valid JSON: {exc}", err=True)
+            raise typer.Exit(2) from exc
+
+    run_client_command(
+        ctx,
+        lambda client: client.update_connector(connector_id, name=name, config=parsed_config),
+    )
+
+
+@connector_app.command("remove")
+def remove_connector(
+    ctx: typer.Context,
+    connector_id: Annotated[str, typer.Argument(help="Connector ID.")],
+    yes: Annotated[bool, typer.Option("--yes", "-y", help="Skip confirmation prompt.")] = False,
+) -> None:
+    """Remove a connector registration."""
+    if not yes:
+        confirmed = typer.confirm(f"Remove connector '{connector_id}'?")
+        if not confirmed:
+            raise typer.Exit(0)
+    run_client_command(ctx, lambda client: client.delete_connector(connector_id))
+
+
+@connector_app.command("status")
+def connector_status(
+    ctx: typer.Context,
+    connector_id: Annotated[str, typer.Argument(help="Connector ID.")],
+) -> None:
+    """Show the runtime status of a connector."""
+    run_client_command(ctx, lambda client: client.get_connector(connector_id))
+
+
+# ── Feishu-specific commands ──────────────────────────────────────────────────
+
+
+@feishu_app.command("serve-tools")
+def feishu_serve_tools(
+    ctx: typer.Context,
+    connector_id: Annotated[str | None, typer.Option("--id", help="Connector ID to load config from.")] = None,
+    port: Annotated[int, typer.Option("--port", help="MCP server port.")] = 7070,
+) -> None:
+    """Start the Feishu MCP tool server for DeerFlow agents.
+
+    The server exposes lark-cli commands as MCP tools on:
+        http://0.0.0.0:<port>/mcp
+
+    Add this URL to your RuntimeProfile's mcp_servers configuration so
+    DeerFlow agents can call Feishu APIs directly.
+
+    Prerequisites:
+        npx @larksuite/cli@latest install
+        lark-cli config init
+        lark-cli auth login --recommend
+    """
+    from swarmmind.connectors.feishu.connector import FeishuCLIConnector
+
+    state = get_state(ctx)
+    config: dict[str, Any] = {}
+
+    if connector_id:
+        # Load config from SwarmMind API
+        from swarmmind.cli.client import SwarmMindClient
+
+        try:
+            with SwarmMindClient(api_url=state.api_url, api_token=state.api_token) as client:
+                resp = client._request("GET", f"/connectors/{connector_id}")  # noqa: SLF001
+                config = resp.get("config", {}) if isinstance(resp, dict) else {}
+        except Exception as exc:
+            typer.echo(f"Warning: could not load connector config: {exc}", err=True)
+
+    typer.echo(f"Starting Feishu MCP tool server on port {port}...")
+    typer.echo(f"  MCP URL: http://0.0.0.0:{port}/mcp")
+    typer.echo("  Add this to your RuntimeProfile mcp_servers to enable Feishu tools for agents.")
+    typer.echo("  Press Ctrl+C to stop.")
+
+    connector = FeishuCLIConnector()
+    connector.run_tool_server_sync(config, port=port)
+
+
+@feishu_app.command("listen-events")
+def feishu_listen_events(
+    ctx: typer.Context,
+    connector_id: Annotated[str | None, typer.Option("--id", help="Connector ID to load config from.")] = None,
+    bot_name: Annotated[str, typer.Option("--bot-name", help="Bot display name for @mention filtering.")] = "",
+    project_id: Annotated[str | None, typer.Option("--project-id", help="Default SwarmMind project ID.")] = None,
+) -> None:
+    """Start the Feishu event listener (bot messages → SwarmMind dispatch).
+
+    Runs lark-cli event +listen and routes inbound Feishu messages to
+    SwarmMind conversations or dispatch. Replies are posted back to Feishu.
+
+    Prerequisites:
+        lark-cli config init
+        lark-cli auth login --domain im
+        lark-cli event setup   # configure bot webhook
+    """
+    from swarmmind.connectors.feishu.connector import FeishuCLIConnector
+
+    state = get_state(ctx)
+    config: dict[str, Any] = {}
+
+    if connector_id:
+        from swarmmind.cli.client import SwarmMindClient
+
+        try:
+            with SwarmMindClient(api_url=state.api_url, api_token=state.api_token) as client:
+                resp = client._request("GET", f"/connectors/{connector_id}")  # noqa: SLF001
+                config = resp.get("config", {}) if isinstance(resp, dict) else {}
+        except Exception as exc:
+            typer.echo(f"Warning: could not load connector config: {exc}", err=True)
+
+    if bot_name:
+        config["bot_name"] = bot_name
+    if project_id:
+        config["default_project_id"] = project_id
+
+    typer.echo("Starting Feishu event listener...")
+    typer.echo(f"  SwarmMind API: {state.api_url}")
+    if config.get("bot_name"):
+        typer.echo(f"  Bot name filter: @{config['bot_name']}")
+    if config.get("default_project_id"):
+        typer.echo(f"  Default project: {config['default_project_id']}")
+    typer.echo("  Press Ctrl+C to stop.")
+
+    connector = FeishuCLIConnector()
+    connector.run_event_listener_sync(config, api_url=state.api_url, api_token=state.api_token)
+
+
+@feishu_app.command("health")
+def feishu_health(ctx: typer.Context) -> None:
+    """Check if lark-cli is installed and accessible."""
+    from swarmmind.connectors.feishu.connector import FeishuCLIConnector
+
+    state = get_state(ctx)
+    connector = FeishuCLIConnector()
+    result = connector.health()
+    if state.json_output:
+        typer.echo(json.dumps(result, ensure_ascii=False, indent=2))
+    else:
+        status = result.get("status", "unknown")
+        if status == "ok":
+            typer.echo(f"✓ lark-cli found at {result.get('lark_cli_path', 'unknown')}")
+        else:
+            typer.echo(f"✗ {result.get('reason', 'lark-cli not available')}", err=True)
+            raise typer.Exit(1)

--- a/swarmmind/connectors/__init__.py
+++ b/swarmmind/connectors/__init__.py
@@ -1,0 +1,12 @@
+"""SwarmMind connector framework.
+
+A connector is a bidirectional integration unit that bridges an external system
+to the SwarmMind control plane:
+
+- **Ingress**: external events → SwarmMind dispatch / conversation
+- **Tool Provider**: SwarmMind agents → external APIs via MCP tools
+"""
+
+from swarmmind.connectors.base import BaseConnector, ConnectorCapability, ConnectorManifest, ConnectorTransport
+
+__all__ = ["BaseConnector", "ConnectorCapability", "ConnectorManifest", "ConnectorTransport"]

--- a/swarmmind/connectors/base.py
+++ b/swarmmind/connectors/base.py
@@ -1,0 +1,73 @@
+"""Base connector interface for SwarmMind."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class ConnectorCapability(str, Enum):
+    """What a connector can do."""
+
+    INGEST = "ingest"
+    EGRESS = "egress"
+    TOOL_PROVIDER = "tool_provider"
+
+
+class ConnectorTransport(str, Enum):
+    """How the connector's tool interface is exposed."""
+
+    MCP_STDIO = "mcp_stdio"
+    MCP_HTTP = "mcp_http"
+    CLI = "cli"
+    WEBHOOK = "webhook"
+
+
+class ConnectorConfigField(BaseModel):
+    """A single configuration field in a connector manifest."""
+
+    name: str
+    description: str
+    required: bool = True
+    secret: bool = False
+    default: str | None = None
+
+
+class ConnectorManifest(BaseModel):
+    """Static descriptor for a connector type — declared by each connector implementation."""
+
+    name: str
+    version: str
+    description: str
+    capabilities: list[ConnectorCapability]
+    transport: ConnectorTransport
+    config_schema: list[ConnectorConfigField] = []
+
+
+class BaseConnector(ABC):
+    """Abstract base for all SwarmMind connectors.
+
+    Concrete connectors implement this interface and are executed as independent
+    processes that call SwarmMind's REST API. They are never embedded in the API
+    server process.
+    """
+
+    @property
+    @abstractmethod
+    def manifest(self) -> ConnectorManifest:
+        """Static manifest describing this connector's capabilities."""
+
+    @abstractmethod
+    async def start_tool_server(self, config: dict[str, Any], port: int) -> None:
+        """Start the MCP tool server that exposes external system APIs to agents."""
+
+    @abstractmethod
+    async def start_event_listener(self, config: dict[str, Any], api_url: str, api_token: str | None) -> None:
+        """Start the event listener that ingests external events into SwarmMind."""
+
+    @abstractmethod
+    def health(self) -> dict[str, Any]:
+        """Return current health status."""

--- a/swarmmind/connectors/feishu/__init__.py
+++ b/swarmmind/connectors/feishu/__init__.py
@@ -1,0 +1,16 @@
+"""Feishu/Lark CLI connector for SwarmMind.
+
+Bridges Feishu to SwarmMind via the official lark-cli tool:
+- MCP tool server: exposes lark-cli commands as MCP tools for DeerFlow agents
+- Event listener: receives Feishu bot events and dispatches to SwarmMind
+
+Prerequisites:
+    lark-cli must be installed and authenticated:
+        npx @larksuite/cli@latest install
+        lark-cli config init   # configure app_id / app_secret
+        lark-cli auth login --recommend
+"""
+
+from swarmmind.connectors.feishu.connector import FeishuCLIConnector
+
+__all__ = ["FeishuCLIConnector"]

--- a/swarmmind/connectors/feishu/cli_runner.py
+++ b/swarmmind/connectors/feishu/cli_runner.py
@@ -1,0 +1,130 @@
+"""Subprocess runner for lark-cli commands."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from typing import Any
+
+
+class LarkCLINotFoundError(RuntimeError):
+    """Raised when lark-cli is not installed or not on PATH."""
+
+
+class LarkCLIError(RuntimeError):
+    """Raised when a lark-cli command exits with a non-zero return code."""
+
+    def __init__(self, message: str, returncode: int, stderr: str) -> None:
+        """Initialize with message, return code, and stderr output."""
+        super().__init__(message)
+        self.returncode = returncode
+        self.stderr = stderr
+
+
+def check_lark_cli() -> str:
+    """Return the path to lark-cli, or raise LarkCLINotFoundError."""
+    path = shutil.which("lark-cli")
+    if path is None:
+        raise LarkCLINotFoundError(
+            "lark-cli not found on PATH. Install it with:\n"
+            "  npx @larksuite/cli@latest install\n"
+            "Then authenticate:\n"
+            "  lark-cli config init\n"
+            "  lark-cli auth login --recommend"
+        )
+    return path
+
+
+def run_lark_cli(
+    *args: str,
+    timeout: int = 30,
+    output_format: str = "json",
+) -> Any:
+    """Run a lark-cli command and return parsed output.
+
+    Args:
+        *args: Command arguments after ``lark-cli`` (e.g. ``"im", "message", "+send"``).
+        timeout: Subprocess timeout in seconds.
+        output_format: Output format flag passed to lark-cli (``"json"`` or ``"ndjson"``).
+
+    Returns:
+        Parsed JSON output (dict or list), or the raw string if unparseable.
+
+    Raises:
+        LarkCLINotFoundError: lark-cli is not installed.
+        LarkCLIError: The command exited with a non-zero return code.
+    """
+    cli_path = check_lark_cli()
+    cmd = [cli_path, *args, "--format", output_format]
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise LarkCLIError(
+            f"lark-cli command timed out after {timeout}s: {' '.join(args)}",
+            returncode=-1,
+            stderr="",
+        ) from exc
+
+    if result.returncode != 0:
+        raise LarkCLIError(
+            f"lark-cli command failed (exit {result.returncode}): {result.stderr.strip()}",
+            returncode=result.returncode,
+            stderr=result.stderr,
+        )
+
+    stdout = result.stdout.strip()
+    if not stdout:
+        return {}
+
+    try:
+        return json.loads(stdout)
+    except json.JSONDecodeError:
+        return {"raw": stdout}
+
+
+def run_lark_cli_ndjson(
+    *args: str,
+    timeout: int = 30,
+) -> list[dict[str, Any]]:
+    """Run a lark-cli command and return all NDJSON lines as a list."""
+    cli_path = check_lark_cli()
+    cmd = [cli_path, *args, "--format", "ndjson"]
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise LarkCLIError(
+            f"lark-cli command timed out after {timeout}s",
+            returncode=-1,
+            stderr="",
+        ) from exc
+
+    if result.returncode != 0:
+        raise LarkCLIError(
+            f"lark-cli command failed (exit {result.returncode}): {result.stderr.strip()}",
+            returncode=result.returncode,
+            stderr=result.stderr,
+        )
+
+    lines = []
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            lines.append(json.loads(line))
+        except json.JSONDecodeError:
+            lines.append({"raw": line})
+    return lines

--- a/swarmmind/connectors/feishu/cli_runner.py
+++ b/swarmmind/connectors/feishu/cli_runner.py
@@ -49,7 +49,7 @@ def run_lark_cli(
         output_format: Output format flag passed to lark-cli (``"json"`` or ``"ndjson"``).
 
     Returns:
-        Parsed JSON output (dict or list), or the raw string if unparseable.
+        Parsed JSON output (dict or list), or the raw string if unparsable.
 
     Raises:
         LarkCLINotFoundError: lark-cli is not installed.
@@ -59,11 +59,12 @@ def run_lark_cli(
     cmd = [cli_path, *args, "--format", output_format]
 
     try:
-        result = subprocess.run(
+        result = subprocess.run(  # noqa: S603
             cmd,
             capture_output=True,
             text=True,
             timeout=timeout,
+            check=False,
         )
     except subprocess.TimeoutExpired as exc:
         raise LarkCLIError(
@@ -98,11 +99,12 @@ def run_lark_cli_ndjson(
     cmd = [cli_path, *args, "--format", "ndjson"]
 
     try:
-        result = subprocess.run(
+        result = subprocess.run(  # noqa: S603
             cmd,
             capture_output=True,
             text=True,
             timeout=timeout,
+            check=False,
         )
     except subprocess.TimeoutExpired as exc:
         raise LarkCLIError(
@@ -119,12 +121,12 @@ def run_lark_cli_ndjson(
         )
 
     lines = []
-    for line in result.stdout.splitlines():
-        line = line.strip()
-        if not line:
+    for raw_line in result.stdout.splitlines():
+        stripped = raw_line.strip()
+        if not stripped:
             continue
         try:
-            lines.append(json.loads(line))
+            lines.append(json.loads(stripped))
         except json.JSONDecodeError:
-            lines.append({"raw": line})
+            lines.append({"raw": stripped})
     return lines

--- a/swarmmind/connectors/feishu/connector.py
+++ b/swarmmind/connectors/feishu/connector.py
@@ -40,7 +40,7 @@ class FeishuCLIConnector(BaseConnector):
 
         mcp = build_feishu_mcp_server(port=port)
         # FastMCP.run_async with streamable-http transport
-        await mcp.run_async(transport="streamable-http", host="0.0.0.0", port=port)
+        await mcp.run_async(transport="streamable-http", host="0.0.0.0", port=port)  # noqa: S104
 
     async def start_event_listener(
         self,

--- a/swarmmind/connectors/feishu/connector.py
+++ b/swarmmind/connectors/feishu/connector.py
@@ -1,0 +1,90 @@
+"""Feishu CLI connector — orchestrates MCP bridge and event listener."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from swarmmind.connectors.base import BaseConnector, ConnectorManifest
+from swarmmind.connectors.feishu.manifest import FEISHU_CLI_MANIFEST
+
+
+class FeishuCLIConnector(BaseConnector):
+    """Feishu/Lark connector via the official lark-cli tool.
+
+    Provides two modes of operation:
+    - **Tool server**: FastMCP server exposing lark-cli commands as MCP tools
+      for DeerFlow agents (``start_tool_server``).
+    - **Event listener**: Long-running process that ingests Feishu bot events
+      and dispatches them to SwarmMind (``start_event_listener``).
+
+    Both modes require ``lark-cli`` to be installed and authenticated:
+        npx @larksuite/cli@latest install
+        lark-cli config init
+        lark-cli auth login --recommend
+    """
+
+    @property
+    def manifest(self) -> ConnectorManifest:
+        """Return the Feishu CLI connector manifest."""
+        return FEISHU_CLI_MANIFEST
+
+    async def start_tool_server(self, config: dict[str, Any], port: int = 7070) -> None:
+        """Start the MCP tool server on the given port.
+
+        Args:
+            config: Connector configuration (currently unused; lark-cli manages its own auth).
+            port: TCP port to bind (default 7070).
+        """
+        from swarmmind.connectors.feishu.mcp_bridge import build_feishu_mcp_server
+
+        mcp = build_feishu_mcp_server(port=port)
+        # FastMCP.run_async with streamable-http transport
+        await mcp.run_async(transport="streamable-http", host="0.0.0.0", port=port)
+
+    async def start_event_listener(
+        self,
+        config: dict[str, Any],
+        api_url: str,
+        api_token: str | None = None,
+    ) -> None:
+        """Start the Feishu event listener.
+
+        Args:
+            config: Connector configuration dict. Recognized keys:
+                ``bot_name``, ``default_project_id``.
+            api_url: SwarmMind supervisor API base URL.
+            api_token: Bearer token for the SwarmMind API (optional).
+        """
+        from swarmmind.connectors.feishu.event_listener import FeishuEventListener
+
+        listener = FeishuEventListener(
+            api_url=api_url,
+            api_token=api_token,
+            bot_name=config.get("bot_name", ""),
+            default_project_id=config.get("default_project_id", ""),
+        )
+        await listener.run()
+
+    def health(self) -> dict[str, Any]:
+        """Return health status by checking lark-cli availability."""
+        from swarmmind.connectors.feishu.cli_runner import LarkCLINotFoundError, check_lark_cli
+
+        try:
+            path = check_lark_cli()
+            return {"status": "ok", "lark_cli_path": path}
+        except LarkCLINotFoundError as exc:
+            return {"status": "error", "reason": str(exc)}
+
+    def run_tool_server_sync(self, config: dict[str, Any], port: int = 7070) -> None:
+        """Synchronous entry point for the tool server (used by CLI commands)."""
+        asyncio.run(self.start_tool_server(config, port=port))
+
+    def run_event_listener_sync(
+        self,
+        config: dict[str, Any],
+        api_url: str,
+        api_token: str | None = None,
+    ) -> None:
+        """Synchronous entry point for the event listener (used by CLI commands)."""
+        asyncio.run(self.start_event_listener(config, api_url=api_url, api_token=api_token))

--- a/swarmmind/connectors/feishu/event_listener.py
+++ b/swarmmind/connectors/feishu/event_listener.py
@@ -60,7 +60,7 @@ class FeishuEventListener:
             stderr=asyncio.subprocess.PIPE,
         )
 
-        assert self._process.stdout is not None  # noqa: S101
+        assert self._process.stdout is not None
         async for line_bytes in self._process.stdout:
             line = line_bytes.decode("utf-8", errors="replace").strip()
             if not line:
@@ -70,7 +70,7 @@ class FeishuEventListener:
                 if isinstance(event, dict):
                     yield event
             except json.JSONDecodeError:
-                logger.debug("Unparseable event line: %s", line)
+                logger.debug("Unparsable event line: %s", line)
 
     async def _dispatch_to_swarmmind(self, event: dict[str, Any]) -> None:
         """Translate a Feishu event into a SwarmMind API call."""
@@ -170,7 +170,7 @@ class FeishuEventListener:
             self._process.terminate()
             try:
                 await asyncio.wait_for(self._process.wait(), timeout=5.0)
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 self._process.kill()
 
 

--- a/swarmmind/connectors/feishu/event_listener.py
+++ b/swarmmind/connectors/feishu/event_listener.py
@@ -98,7 +98,7 @@ class FeishuEventListener:
 
         # Strip @bot mention if present
         if self._bot_name and text.startswith(f"@{self._bot_name}"):
-            text = text[len(self._bot_name) + 1:].strip()
+            text = text[len(self._bot_name) + 1 :].strip()
 
         chat_id = message.get("chat_id", "")
         message_id = message.get("message_id", "")

--- a/swarmmind/connectors/feishu/event_listener.py
+++ b/swarmmind/connectors/feishu/event_listener.py
@@ -1,0 +1,186 @@
+"""Feishu event listener: subscribes to Feishu bot events and dispatches to SwarmMind."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import sys
+from collections.abc import AsyncIterator
+from typing import Any
+
+from swarmmind.connectors.feishu.cli_runner import LarkCLINotFoundError, check_lark_cli
+
+logger = logging.getLogger(__name__)
+
+# Feishu event types we handle
+_INGEST_EVENT_TYPES = {
+    "im.message.receive_v1",
+    "im.message.recalled_v1",
+}
+
+
+class FeishuEventListener:
+    """Subscribes to Feishu events via lark-cli and dispatches them to SwarmMind.
+
+    Runs ``lark-cli event +listen --format ndjson`` as a long-lived subprocess,
+    reads NDJSON lines, and translates message events into SwarmMind API calls.
+
+    Args:
+        api_url: SwarmMind supervisor API base URL.
+        api_token: Bearer token for SwarmMind API (optional).
+        bot_name: Bot display name used to filter @mentions (optional).
+        default_project_id: SwarmMind project to associate messages with (optional).
+    """
+
+    def __init__(
+        self,
+        api_url: str,
+        api_token: str | None = None,
+        bot_name: str = "",
+        default_project_id: str = "",
+    ) -> None:
+        """Initialize the event listener."""
+        self._api_url = api_url.rstrip("/")
+        self._api_token = api_token
+        self._bot_name = bot_name
+        self._default_project_id = default_project_id
+        self._process: asyncio.subprocess.Process | None = None
+        self._running = False
+
+    async def _event_stream(self) -> AsyncIterator[dict[str, Any]]:
+        """Yield parsed NDJSON events from lark-cli event +listen."""
+        cli_path = check_lark_cli()
+        cmd = [cli_path, "event", "+listen", "--format", "ndjson"]
+
+        logger.info("Starting Feishu event stream: %s", " ".join(cmd))
+        self._process = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+
+        assert self._process.stdout is not None  # noqa: S101
+        async for line_bytes in self._process.stdout:
+            line = line_bytes.decode("utf-8", errors="replace").strip()
+            if not line:
+                continue
+            try:
+                event = json.loads(line)
+                if isinstance(event, dict):
+                    yield event
+            except json.JSONDecodeError:
+                logger.debug("Unparseable event line: %s", line)
+
+    async def _dispatch_to_swarmmind(self, event: dict[str, Any]) -> None:
+        """Translate a Feishu event into a SwarmMind API call."""
+        import httpx
+
+        event_type = event.get("event_type", "")
+        if event_type not in _INGEST_EVENT_TYPES:
+            return
+
+        # Extract message text
+        message = event.get("event", {}).get("message", {})
+        msg_type = message.get("message_type", "")
+        if msg_type != "text":
+            logger.debug("Ignoring non-text message type: %s", msg_type)
+            return
+
+        try:
+            body = json.loads(message.get("content", "{}"))
+            text = body.get("text", "").strip()
+        except (json.JSONDecodeError, AttributeError):
+            return
+
+        if not text:
+            return
+
+        # Strip @bot mention if present
+        if self._bot_name and text.startswith(f"@{self._bot_name}"):
+            text = text[len(self._bot_name) + 1:].strip()
+
+        chat_id = message.get("chat_id", "")
+        message_id = message.get("message_id", "")
+
+        logger.info("Received Feishu message [%s] from chat %s: %s", message_id, chat_id, text[:80])
+
+        headers: dict[str, str] = {"Content-Type": "application/json"}
+        if self._api_token:
+            headers["Authorization"] = f"Bearer {self._api_token}"
+
+        async with httpx.AsyncClient(base_url=self._api_url, headers=headers, timeout=60.0) as client:
+            try:
+                if self._default_project_id:
+                    # Route to a fixed project
+                    resp = await client.post(
+                        f"/projects/{self._default_project_id}/messages/stream",
+                        json={"content": text},
+                    )
+                else:
+                    # Free-form dispatch
+                    resp = await client.post("/dispatch", json={"goal": text})
+
+                resp.raise_for_status()
+                result = resp.json()
+                reply = _extract_reply(result)
+            except httpx.HTTPError as exc:
+                logger.error("SwarmMind API error for message %s: %s", message_id, exc)
+                reply = "Sorry, I encountered an error processing your request."
+
+        if reply and chat_id:
+            await self._send_reply(chat_id, reply)
+
+    async def _send_reply(self, chat_id: str, content: str) -> None:
+        """Post a reply to a Feishu chat via lark-cli."""
+        from swarmmind.connectors.feishu.cli_runner import LarkCLIError, run_lark_cli
+
+        try:
+            run_lark_cli("im", "message", "+send", "--chat-id", chat_id, "--content", content)
+        except (LarkCLIError, LarkCLINotFoundError) as exc:
+            logger.error("Failed to send reply to Feishu chat %s: %s", chat_id, exc)
+
+    async def run(self) -> None:
+        """Run the event listener until stopped or until lark-cli exits."""
+        self._running = True
+        try:
+            check_lark_cli()
+        except LarkCLINotFoundError as exc:
+            logger.error("%s", exc)
+            sys.exit(1)
+
+        while self._running:
+            try:
+                async for event in self._event_stream():
+                    if not self._running:
+                        break
+                    await self._dispatch_to_swarmmind(event)
+            except asyncio.CancelledError:
+                break
+            except Exception as exc:
+                logger.exception("Event stream error: %s — restarting in 5s", exc)
+                await asyncio.sleep(5)
+
+        await self.stop()
+
+    async def stop(self) -> None:
+        """Terminate the lark-cli subprocess."""
+        self._running = False
+        if self._process and self._process.returncode is None:
+            self._process.terminate()
+            try:
+                await asyncio.wait_for(self._process.wait(), timeout=5.0)
+            except asyncio.TimeoutError:
+                self._process.kill()
+
+
+def _extract_reply(result: dict[str, Any]) -> str:
+    """Extract a human-readable reply from a SwarmMind API response."""
+    # dispatch response
+    if "response" in result:
+        return str(result["response"])
+    # chat send_message response
+    if "content" in result:
+        return str(result["content"])
+    # minimal fallback
+    return json.dumps(result, ensure_ascii=False)

--- a/swarmmind/connectors/feishu/manifest.py
+++ b/swarmmind/connectors/feishu/manifest.py
@@ -1,0 +1,63 @@
+"""Feishu CLI connector manifest."""
+
+from __future__ import annotations
+
+from swarmmind.connectors.base import (
+    ConnectorCapability,
+    ConnectorConfigField,
+    ConnectorManifest,
+    ConnectorTransport,
+)
+
+FEISHU_CLI_MANIFEST = ConnectorManifest(
+    name="feishu-cli",
+    version="1.0.0",
+    description=(
+        "Bridges Feishu/Lark to SwarmMind via the official lark-cli tool. "
+        "Exposes 200+ Feishu commands as MCP tools for agents, and can ingest "
+        "Feishu bot events (messages, @mentions) into SwarmMind conversations."
+    ),
+    capabilities=[ConnectorCapability.INGEST, ConnectorCapability.TOOL_PROVIDER],
+    transport=ConnectorTransport.MCP_HTTP,
+    config_schema=[
+        ConnectorConfigField(
+            name="app_id",
+            description="Feishu app ID from the Feishu Open Platform developer console.",
+            required=False,
+            secret=False,
+        ),
+        ConnectorConfigField(
+            name="app_secret",
+            description="Feishu app secret. Stored encrypted at rest.",
+            required=False,
+            secret=True,
+        ),
+        ConnectorConfigField(
+            name="mcp_port",
+            description="TCP port for the MCP tool server.",
+            required=False,
+            secret=False,
+            default="7070",
+        ),
+        ConnectorConfigField(
+            name="bot_name",
+            description=(
+                "Display name of the Feishu bot. Used to filter @mentions in group chats. "
+                "Leave empty to process all messages the bot receives."
+            ),
+            required=False,
+            secret=False,
+            default="",
+        ),
+        ConnectorConfigField(
+            name="default_project_id",
+            description=(
+                "SwarmMind project ID to associate inbound Feishu messages with. "
+                "Leave empty to route via dispatch (no fixed project)."
+            ),
+            required=False,
+            secret=False,
+            default="",
+        ),
+    ],
+)

--- a/swarmmind/connectors/feishu/mcp_bridge.py
+++ b/swarmmind/connectors/feishu/mcp_bridge.py
@@ -1,0 +1,232 @@
+"""FastMCP server that exposes lark-cli commands as MCP tools for DeerFlow agents."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from swarmmind.connectors.feishu.cli_runner import LarkCLIError, LarkCLINotFoundError, run_lark_cli
+
+
+def build_feishu_mcp_server(port: int = 7070) -> Any:
+    """Build and return a FastMCP server exposing Feishu tools.
+
+    The server runs on ``http://0.0.0.0:{port}/mcp`` using streamable-http transport.
+    Each tool wraps a ``lark-cli`` subprocess call; lark-cli handles its own
+    authentication via the OS keychain.
+
+    Args:
+        port: TCP port for the MCP server.
+
+    Returns:
+        A configured FastMCP instance.
+
+    Raises:
+        RuntimeError: If the ``mcp`` optional dependency is not installed.
+    """
+    try:
+        from mcp.server.fastmcp import FastMCP
+    except ModuleNotFoundError as exc:
+        raise RuntimeError(
+            "MCP support is not installed. Install with `pip install 'swarmmind[mcp]'`."
+        ) from exc
+
+    mcp = FastMCP("feishu", port=port)
+
+    def _run(*args: str, timeout: int = 30) -> dict[str, Any]:
+        try:
+            result = run_lark_cli(*args, timeout=timeout)
+            if isinstance(result, dict):
+                return result
+            return {"data": result}
+        except LarkCLINotFoundError as exc:
+            return {"error": str(exc), "type": "lark_cli_not_found"}
+        except LarkCLIError as exc:
+            return {"error": str(exc), "type": "lark_cli_error", "returncode": exc.returncode}
+
+    # ── Messaging (im) ──────────────────────────────────────────────────────────
+
+    @mcp.tool()
+    def feishu_send_message(
+        chat_id: str,
+        content: str,
+        message_type: str = "text",
+    ) -> dict[str, Any]:
+        """Send a message to a Feishu chat (group or direct message).
+
+        Args:
+            chat_id: The chat ID (group chat or user open_id/union_id).
+            content: Message content. For text, plain string. For rich_text, markdown.
+            message_type: Message type: ``text``, ``post`` (rich text), or ``interactive``.
+        """
+        return _run("im", "message", "+send", "--chat-id", chat_id, "--content", content, "--type", message_type)
+
+    @mcp.tool()
+    def feishu_list_messages(chat_id: str, limit: int = 20) -> dict[str, Any]:
+        """List recent messages in a Feishu chat.
+
+        Args:
+            chat_id: The chat ID to list messages from.
+            limit: Maximum number of messages to return (default 20).
+        """
+        return _run("im", "message", "list", "--chat-id", chat_id, "--page-limit", str(limit))
+
+    @mcp.tool()
+    def feishu_get_chat_info(chat_id: str) -> dict[str, Any]:
+        """Get metadata for a Feishu chat (name, members, type).
+
+        Args:
+            chat_id: The chat ID.
+        """
+        return _run("im", "chat", "get", "--chat-id", chat_id)
+
+    @mcp.tool()
+    def feishu_list_chats() -> dict[str, Any]:
+        """List all Feishu chats the bot or user belongs to."""
+        return _run("im", "chat", "list")
+
+    # ── Documents (doc) ─────────────────────────────────────────────────────────
+
+    @mcp.tool()
+    def feishu_create_doc(title: str, content: str = "") -> dict[str, Any]:
+        """Create a new Feishu document.
+
+        Args:
+            title: Document title.
+            content: Initial document content in Markdown format.
+        """
+        args = ["doc", "documents", "create", "--title", title]
+        if content:
+            args += ["--content", content]
+        return _run(*args)
+
+    @mcp.tool()
+    def feishu_get_doc(document_id: str) -> dict[str, Any]:
+        """Get the content of a Feishu document.
+
+        Args:
+            document_id: The document token/ID.
+        """
+        return _run("doc", "documents", "get", "--document-id", document_id)
+
+    @mcp.tool()
+    def feishu_list_docs(folder_token: str = "") -> dict[str, Any]:
+        """List documents in a Feishu folder.
+
+        Args:
+            folder_token: Folder token. Leave empty for the root folder.
+        """
+        args = ["doc", "documents", "list"]
+        if folder_token:
+            args += ["--folder-token", folder_token]
+        return _run(*args)
+
+    # ── Search ───────────────────────────────────────────────────────────────────
+
+    @mcp.tool()
+    def feishu_search(query: str, types: str = "docx,wiki,message") -> dict[str, Any]:
+        """Search across Feishu content (docs, wiki, messages).
+
+        Args:
+            query: Search query string.
+            types: Comma-separated list of content types to search.
+                   Options: ``docx``, ``wiki``, ``message``, ``chat``.
+        """
+        return _run("search", "+query", "--query", query, "--types", types)
+
+    # ── Calendar ─────────────────────────────────────────────────────────────────
+
+    @mcp.tool()
+    def feishu_get_agenda(date: str = "", days: int = 7) -> dict[str, Any]:
+        """Get calendar agenda for upcoming days.
+
+        Args:
+            date: Start date in ISO 8601 format (e.g. ``2026-05-17``). Defaults to today.
+            days: Number of days ahead to include (default 7).
+        """
+        args = ["calendar", "+agenda", "--days", str(days)]
+        if date:
+            args += ["--date", date]
+        return _run(*args)
+
+    @mcp.tool()
+    def feishu_create_event(
+        title: str,
+        start_time: str,
+        end_time: str,
+        description: str = "",
+        attendees: str = "",
+    ) -> dict[str, Any]:
+        """Create a calendar event in Feishu.
+
+        Args:
+            title: Event title.
+            start_time: Start time in ISO 8601 format (e.g. ``2026-05-17T14:00:00+08:00``).
+            end_time: End time in ISO 8601 format.
+            description: Event description (optional).
+            attendees: Comma-separated list of attendee emails or open_ids (optional).
+        """
+        args = [
+            "calendar", "calendar_events", "create",
+            "--title", title,
+            "--start-time", start_time,
+            "--end-time", end_time,
+        ]
+        if description:
+            args += ["--description", description]
+        if attendees:
+            args += ["--attendees", attendees]
+        return _run(*args)
+
+    # ── Tasks ────────────────────────────────────────────────────────────────────
+
+    @mcp.tool()
+    def feishu_create_task(
+        title: str,
+        description: str = "",
+        due_date: str = "",
+        assignee: str = "",
+    ) -> dict[str, Any]:
+        """Create a task in Feishu Tasks.
+
+        Args:
+            title: Task title.
+            description: Task description (optional).
+            due_date: Due date in ISO 8601 format (optional).
+            assignee: Assignee open_id or email (optional).
+        """
+        args = ["task", "tasks", "create", "--title", title]
+        if description:
+            args += ["--description", description]
+        if due_date:
+            args += ["--due-date", due_date]
+        if assignee:
+            args += ["--assignee", assignee]
+        return _run(*args)
+
+    @mcp.tool()
+    def feishu_list_tasks(status: str = "todo") -> dict[str, Any]:
+        """List Feishu tasks.
+
+        Args:
+            status: Filter by status: ``todo``, ``done``, or ``all``.
+        """
+        return _run("task", "tasks", "list", "--status", status)
+
+    # ── Generic escape hatch ─────────────────────────────────────────────────────
+
+    @mcp.tool()
+    def feishu_run_command(command: str) -> dict[str, Any]:
+        """Run any lark-cli command and return its output.
+
+        Use this for Feishu operations not covered by the named tools above.
+        The command is the portion after ``lark-cli``, e.g. ``"sheets spreadsheets get --spreadsheet-token abc"``.
+
+        Args:
+            command: Space-separated lark-cli sub-command and arguments.
+        """
+        import shlex
+
+        parts = shlex.split(command)
+        return _run(*parts, timeout=60)
+
+    return mcp

--- a/swarmmind/connectors/feishu/mcp_bridge.py
+++ b/swarmmind/connectors/feishu/mcp_bridge.py
@@ -26,9 +26,7 @@ def build_feishu_mcp_server(port: int = 7070) -> Any:
     try:
         from mcp.server.fastmcp import FastMCP
     except ModuleNotFoundError as exc:
-        raise RuntimeError(
-            "MCP support is not installed. Install with `pip install 'swarmmind[mcp]'`."
-        ) from exc
+        raise RuntimeError("MCP support is not installed. Install with `pip install 'swarmmind[mcp]'`.") from exc
 
     mcp = FastMCP("feishu", port=port)
 
@@ -166,10 +164,15 @@ def build_feishu_mcp_server(port: int = 7070) -> Any:
             attendees: Comma-separated list of attendee emails or open_ids (optional).
         """
         args = [
-            "calendar", "calendar_events", "create",
-            "--title", title,
-            "--start-time", start_time,
-            "--end-time", end_time,
+            "calendar",
+            "calendar_events",
+            "create",
+            "--title",
+            title,
+            "--start-time",
+            start_time,
+            "--end-time",
+            end_time,
         ]
         if description:
             args += ["--description", description]

--- a/swarmmind/db_models.py
+++ b/swarmmind/db_models.py
@@ -517,6 +517,25 @@ class ProjectMembershipDB(SQLModel, table=True):
     )
 
 
+class ConnectorDB(SQLModel, table=True):
+    """Registered external system connectors."""
+
+    __tablename__ = "connectors"
+
+    connector_id: str = Field(primary_key=True)
+    name: str
+    connector_type: str  # e.g. "feishu-cli", "slack-mcp"
+    version: str = Field(default="1.0.0")
+    status: str = Field(default="inactive")  # "inactive" | "running" | "error"
+    config_json: str = Field(default="{}")  # JSON; secret fields Fernet-encrypted
+    mcp_url: str | None = None  # http://host:port/mcp when running
+    last_heartbeat: datetime | None = None
+    created_at: datetime = Field(default_factory=utc_now)
+    updated_at: datetime = Field(default_factory=utc_now)
+
+    __table_args__ = (Index("idx_connectors_type", "connector_type"),)
+
+
 class ApprovalRequestDB(SQLModel, table=True):
     """Product-layer approval request for high-risk run governance."""
 

--- a/swarmmind/models.py
+++ b/swarmmind/models.py
@@ -1193,4 +1193,3 @@ class DeleteConnectorResponse(BaseModel):
 
     connector_id: str
     deleted: bool
-

--- a/swarmmind/models.py
+++ b/swarmmind/models.py
@@ -1138,3 +1138,59 @@ class GatewayStatusResponse(BaseModel):
     model_count: int
     providers: list[dict]
     config: dict
+
+
+# ── Connector models ──────────────────────────────────────────────────────────
+
+
+class ConnectorCreateRequest(BaseModel):
+    """Request to register a new connector."""
+
+    connector_id: str | None = None
+    name: str
+    connector_type: str
+    config: dict = Field(default_factory=dict)
+
+
+class ConnectorUpdateRequest(BaseModel):
+    """Request to update connector configuration."""
+
+    name: str | None = None
+    config: dict | None = None
+
+
+class ConnectorHeartbeatRequest(BaseModel):
+    """Connector reports its runtime status to the control plane."""
+
+    status: str
+    mcp_url: str | None = None
+
+
+class ConnectorResponse(BaseModel):
+    """Connector metadata response (secrets masked)."""
+
+    connector_id: str
+    name: str
+    connector_type: str
+    version: str
+    status: str
+    config: dict
+    mcp_url: str | None
+    last_heartbeat: datetime | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class ConnectorListResponse(BaseModel):
+    """List of connectors."""
+
+    items: list[ConnectorResponse]
+    total: int
+
+
+class DeleteConnectorResponse(BaseModel):
+    """Response after deleting a connector."""
+
+    connector_id: str
+    deleted: bool
+

--- a/swarmmind/repositories/connector.py
+++ b/swarmmind/repositories/connector.py
@@ -1,0 +1,176 @@
+"""Connector repository — CRUD for ConnectorDB with secret-field encryption."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from typing import Any
+
+from sqlmodel import select
+
+from swarmmind.db import session_scope
+from swarmmind.db_models import ConnectorDB
+from swarmmind.time_utils import utc_now
+from swarmmind.utils.crypto import decrypt, encrypt
+
+# Config keys that contain secrets and must be encrypted at rest
+_SECRET_KEYS = {"app_secret", "api_secret", "webhook_secret", "token", "access_token"}
+
+
+def _encrypt_secrets(config: dict[str, Any]) -> str:
+    """Encrypt secret fields in config and return the JSON string."""
+    safe: dict[str, Any] = {}
+    for key, value in config.items():
+        if key in _SECRET_KEYS and isinstance(value, str) and value:
+            safe[key] = encrypt(value)
+        else:
+            safe[key] = value
+    return json.dumps(safe, ensure_ascii=False)
+
+
+def _decrypt_secrets(config_json: str) -> dict[str, Any]:
+    """Decrypt secret fields from the stored JSON string."""
+    raw: dict[str, Any] = json.loads(config_json) if config_json else {}
+    result: dict[str, Any] = {}
+    for key, value in raw.items():
+        if key in _SECRET_KEYS and isinstance(value, str) and value:
+            try:
+                result[key] = decrypt(value)
+            except Exception:
+                result[key] = value  # if decryption fails, return as-is
+        else:
+            result[key] = value
+    return result
+
+
+def _mask_secrets(config: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of config with secret values masked."""
+    return {k: ("***" if k in _SECRET_KEYS and v else v) for k, v in config.items()}
+
+
+class ConnectorRepository:
+    """Repository for connector CRUD operations."""
+
+    def create(
+        self,
+        connector_id: str | None,
+        name: str,
+        connector_type: str,
+        config: dict[str, Any],
+        version: str = "1.0.0",
+    ) -> ConnectorDB:
+        """Create and persist a new connector.
+
+        Args:
+            connector_id: Stable identifier (e.g. ``"feishu-prod"``).
+                          Auto-generated if None.
+            name: Human-readable label.
+            connector_type: Connector type slug (e.g. ``"feishu-cli"``).
+            config: Configuration dict; secret fields are encrypted at rest.
+            version: Connector version string.
+
+        Returns:
+            The persisted ConnectorDB row.
+        """
+        cid = connector_id or str(uuid.uuid4())
+        now = utc_now()
+        with session_scope() as session:
+            db = ConnectorDB(
+                connector_id=cid,
+                name=name,
+                connector_type=connector_type,
+                version=version,
+                status="inactive",
+                config_json=_encrypt_secrets(config),
+                created_at=now,
+                updated_at=now,
+            )
+            session.add(db)
+            session.flush()
+            session.refresh(db)
+            return db
+
+    def list_all(self) -> list[ConnectorDB]:
+        """Return all connectors."""
+        with session_scope() as session:
+            return list(session.exec(select(ConnectorDB)).all())
+
+    def get(self, connector_id: str) -> ConnectorDB | None:
+        """Return a connector by ID, or None if not found."""
+        with session_scope() as session:
+            return session.get(ConnectorDB, connector_id)
+
+    def get_config(self, connector_id: str) -> dict[str, Any]:
+        """Return the decrypted config for a connector."""
+        db = self.get(connector_id)
+        if db is None:
+            return {}
+        return _decrypt_secrets(db.config_json)
+
+    def get_config_masked(self, connector_id: str) -> dict[str, Any]:
+        """Return the config with secret values masked (safe to log/display)."""
+        config = self.get_config(connector_id)
+        return _mask_secrets(config)
+
+    def update(
+        self,
+        connector_id: str,
+        name: str | None = None,
+        config: dict[str, Any] | None = None,
+        status: str | None = None,
+        mcp_url: str | None = None,
+    ) -> ConnectorDB | None:
+        """Update connector fields.
+
+        Returns:
+            Updated ConnectorDB, or None if the connector was not found.
+        """
+        with session_scope() as session:
+            db = session.get(ConnectorDB, connector_id)
+            if db is None:
+                return None
+            if name is not None:
+                db.name = name
+            if config is not None:
+                # Merge with existing config
+                existing = _decrypt_secrets(db.config_json)
+                existing.update(config)
+                db.config_json = _encrypt_secrets(existing)
+            if status is not None:
+                db.status = status
+            if mcp_url is not None:
+                db.mcp_url = mcp_url
+            db.updated_at = utc_now()
+            session.add(db)
+            session.flush()
+            session.refresh(db)
+            return db
+
+    def record_heartbeat(self, connector_id: str, status: str, mcp_url: str | None) -> ConnectorDB | None:
+        """Update heartbeat timestamp and runtime status.
+
+        Returns:
+            Updated ConnectorDB, or None if not found.
+        """
+        with session_scope() as session:
+            db = session.get(ConnectorDB, connector_id)
+            if db is None:
+                return None
+            db.status = status
+            if mcp_url is not None:
+                db.mcp_url = mcp_url
+            db.last_heartbeat = utc_now()
+            db.updated_at = utc_now()
+            session.add(db)
+            session.flush()
+            session.refresh(db)
+            return db
+
+    def delete(self, connector_id: str) -> bool:
+        """Delete a connector. Returns True if deleted, False if not found."""
+        with session_scope() as session:
+            db = session.get(ConnectorDB, connector_id)
+            if db is None:
+                return False
+            session.delete(db)
+            return True


### PR DESCRIPTION
## 调研摘要

在实现之前对飞书 CLI 和竞品做了完整调研，结论记录在 `docs/connector-design.md`：

| 竞品 | 连接器设计 |
|---|---|
| **Manus** | Connector = MCP 客户端 + 凭证管理层；绑定到 Project，通过 UID 引用；Phase 1 目标：Connector + Skills 组合实现 SOP |
| **LangChain/CrewAI** | `@tool` 装饰器 / `BaseTool` 子类；工具是 Python 函数，docstring 即描述 |
| **Agent Skills** | SKILL.md 开放标准；会话启动只读 metadata（30 tokens），任务匹配才加载全文（800 tokens）|

**关键洞察**：大型 MCP 服务器（如 GitHub MCP 93 个工具）消耗 ~55,000 tokens schema；`lark-cli` 等 CLI 工具只需 ~200 tokens。最佳实践是 CLI 做本地操作 + MCP 做远程结构化服务。

**选择 CLI 连接器**（而非 MCP 连接器）：`lark-cli` 专为 AI Agent 设计，命令经过真实 Agent 测试，有 24 个预置 Skills，是更稳健的基础。

---

## 新增：Connector 概念

**连接器**是 SwarmMind 的一等集成单元，双向桥接外部系统：

```
外部系统 (Feishu)
    ↓ 事件 (WebSocket)
[Connector 进程]  ← 独立进程，调 SwarmMind REST API
    ├── Ingress → SwarmMind dispatch / conversation
    └── MCP Server → DeerFlow agents via RuntimeProfile
```

---

## 变更内容

### 连接器框架 (`swarmmind/connectors/`)
- `base.py` — `BaseConnector` ABC + `ConnectorManifest` + `ConnectorCapability/Transport` 枚举
- `feishu/manifest.py` — 飞书 CLI 连接器 manifest（capabilities, config_schema）
- `feishu/cli_runner.py` — `lark-cli` 子进程封装（`run_lark_cli`, `check_lark_cli`）
- `feishu/mcp_bridge.py` — FastMCP 服务器，暴露 10 个飞书工具供 DeerFlow agents 调用
- `feishu/event_listener.py` — 异步事件监听器：`lark-cli event +listen` → SwarmMind dispatch
- `feishu/connector.py` — 协调器，提供 CLI 入口方法

### 控制面集成
- `db_models.py` — 新增 `ConnectorDB`（带 Fernet 加密的 config_json）
- `repositories/connector.py` — CRUD + 密钥加密/脱敏
- `api/routers/connectors.py` — REST 端点（list/create/get/update/delete/heartbeat）
- `models.py` — 新增 Connector Pydantic 模型
- `api/supervisor.py` — 注册 connectors router
- `cli/client.py` — 新增连接器 API 方法
- `cli/commands/connector.py` — CLI 命令
- `cli/__main__.py` — 注册 `connector_app`

### 文档
- `docs/connector-design.md` — 完整设计文档（调研、架构、安全、Roadmap）

---

## MCP Tool 列表（飞书 CLI 连接器）

| Tool | lark-cli 命令 |
|---|---|
| `feishu_send_message` | `lark-cli im message +send` |
| `feishu_list_messages` | `lark-cli im message list` |
| `feishu_get_chat_info` | `lark-cli im chat get` |
| `feishu_list_chats` | `lark-cli im chat list` |
| `feishu_create_doc` | `lark-cli doc documents create` |
| `feishu_get_doc` | `lark-cli doc documents get` |
| `feishu_list_docs` | `lark-cli doc documents list` |
| `feishu_search` | `lark-cli search +query` |
| `feishu_get_agenda` | `lark-cli calendar +agenda` |
| `feishu_create_event` | `lark-cli calendar calendar_events create` |
| `feishu_create_task` | `lark-cli task tasks create` |
| `feishu_list_tasks` | `lark-cli task tasks list` |
| `feishu_run_command` | 任意 `lark-cli` 命令（escape hatch）|

---

## 使用方式

**前置条件**（用户需先安装和认证）：
```bash
npx @larksuite/cli@latest install
lark-cli config init
lark-cli auth login --recommend
```

**注册连接器**：
```bash
swarmmind connector add feishu-cli --id feishu-prod --config '{"bot_name":"SwarmBot"}'
```

**启动 MCP Tool Server**（供 DeerFlow agents 调用飞书 API）：
```bash
swarmmind connector feishu serve-tools --id feishu-prod --port 7070
# MCP URL: http://0.0.0.0:7070/mcp → 加入 RuntimeProfile.mcp_servers
```

**启动事件监听器**（飞书消息 → SwarmMind dispatch）：
```bash
swarmmind connector feishu listen-events --id feishu-prod
```

---

## 测试计划

- [ ] `swarmmind connector list/get/add/update/remove` 端到端 API 测试
- [ ] `swarmmind connector feishu health` 在有/无 lark-cli 时的输出
- [ ] 加密 round-trip：config 存入后 `app_secret` 脱敏显示，内部正确解密
- [ ] MCP bridge：安装 lark-cli 后，在 Claude Code 中注册 MCP server 验证工具调用
- [ ] 事件监听器：模拟 lark-cli NDJSON 输出，验证 SwarmMind dispatch 调用

https://claude.ai/code/session_01CRG7jrZJYoL4kEZUGz4P88

---
_Generated by [Claude Code](https://claude.ai/code/session_01CRG7jrZJYoL4kEZUGz4P88)_