### PR TITLE
feat: close user auth functional loop

### DIFF
--- a/swarmmind/api/routers/users.py
+++ b/swarmmind/api/routers/users.py
@@ -10,6 +10,8 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from swarmmind.api.routers.mappers import db_to_user
 from swarmmind.models import (
+    AuthSetupRequest,
+    AuthStatusResponse,
     AuthToken,
     CurrentUserResponse,
     DeleteUserResponse,
@@ -22,6 +24,9 @@ from swarmmind.models import (
 )
 from swarmmind.repositories.user import UserRepository
 from swarmmind.services.auth import generate_api_token, hash_api_token
+from swarmmind.time_utils import utc_now
+
+_TOKEN_EXPIRY_DAYS = 30
 
 bearer_scheme = HTTPBearer(auto_error=False)
 
@@ -84,15 +89,52 @@ def build_users_router(deps: UsersRouterDeps) -> APIRouter:
         deps.user_repo.disable(user_id)
         return DeleteUserResponse(user_id=user_id)
 
+    @router.get("/auth/status", tags=["auth"])
+    def auth_status() -> AuthStatusResponse:
+        """Return whether any users exist — used by the frontend for first-run setup."""
+        return AuthStatusResponse(has_users=deps.user_repo.count_users() > 0)
+
+    @router.post("/auth/setup", tags=["auth"], status_code=status.HTTP_201_CREATED)
+    def auth_setup(body: AuthSetupRequest) -> AuthToken:
+        """Create the first admin user and return a bearer token.
+
+        Returns 409 if users already exist; the normal login endpoint should be
+        used instead.
+        """
+        if deps.user_repo.count_users() > 0:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Setup already complete. Use /auth/login to authenticate.",
+            )
+        user = deps.user_repo.create(
+            email=body.email,
+            password=body.password,
+            display_name=body.display_name,
+            role="admin",
+        )
+        token = generate_api_token()
+        from datetime import timedelta
+        expires_at = utc_now() + timedelta(days=_TOKEN_EXPIRY_DAYS)
+        token_row = deps.user_repo.create_token(
+            user_id=user.user_id,
+            token_hash=hash_api_token(token),
+            name="setup",
+            expires_at=expires_at,
+        )
+        return AuthToken(token_id=token_row.token_id, token=token, user=db_to_user(user))
+
     @router.post("/auth/login", tags=["auth"])
     def login(body: LoginRequest) -> AuthToken:
-        """Exchange local credentials for a bearer token."""
+        """Exchange local credentials for a bearer token (30-day expiry)."""
+        from datetime import timedelta
         user = deps.user_repo.authenticate(email=body.email, password=body.password)
         token = generate_api_token()
+        expires_at = utc_now() + timedelta(days=_TOKEN_EXPIRY_DAYS)
         token_row = deps.user_repo.create_token(
             user_id=user.user_id,
             token_hash=hash_api_token(token),
             name=body.token_name,
+            expires_at=expires_at,
         )
         return AuthToken(token_id=token_row.token_id, token=token, user=db_to_user(user))
 

--- a/swarmmind/api/routers/users.py
+++ b/swarmmind/api/routers/users.py
@@ -114,6 +114,7 @@ def build_users_router(deps: UsersRouterDeps) -> APIRouter:
         )
         token = generate_api_token()
         from datetime import timedelta
+
         expires_at = utc_now() + timedelta(days=_TOKEN_EXPIRY_DAYS)
         token_row = deps.user_repo.create_token(
             user_id=user.user_id,
@@ -127,6 +128,7 @@ def build_users_router(deps: UsersRouterDeps) -> APIRouter:
     def login(body: LoginRequest) -> AuthToken:
         """Exchange local credentials for a bearer token (30-day expiry)."""
         from datetime import timedelta
+
         user = deps.user_repo.authenticate(email=body.email, password=body.password)
         token = generate_api_token()
         expires_at = utc_now() + timedelta(days=_TOKEN_EXPIRY_DAYS)

--- a/swarmmind/models.py
+++ b/swarmmind/models.py
@@ -1193,3 +1193,20 @@ class DeleteConnectorResponse(BaseModel):
 
     connector_id: str
     deleted: bool
+
+
+# ── Auth setup / status models ────────────────────────────────────────────────
+
+
+class AuthStatusResponse(BaseModel):
+    """Reports whether the instance has any registered users."""
+
+    has_users: bool
+
+
+class AuthSetupRequest(BaseModel):
+    """Create the first admin user (only valid when no users exist)."""
+
+    email: str
+    password: str = Field(..., min_length=8)
+    display_name: str | None = None

--- a/swarmmind/repositories/user.py
+++ b/swarmmind/repositories/user.py
@@ -18,6 +18,11 @@ from swarmmind.time_utils import utc_now
 class UserRepository:
     """Repository for local users and bearer tokens."""
 
+    def count_users(self) -> int:
+        """Return the total number of registered users."""
+        with session_scope() as session:
+            return session.exec(select(UserDB)).all().__len__()
+
     def list_all(self) -> list[UserDB]:
         """List users ordered by creation time."""
         with session_scope() as session:

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -13,6 +13,7 @@ import {
 
 import { Workbench } from "@/components/workbench";
 import { Button } from "@/components/ui/button";
+import { LoginPage } from "@/components/auth/login-page";
 import { ApprovalsPage } from "@/components/workspace/approvals/approvals-page";
 import { ProjectPage } from "@/components/workspace/project/project-page";
 import { ProjectEmptyState } from "@/components/workspace/project/project-empty-state";
@@ -27,6 +28,8 @@ import {
 import { Input } from "@/components/ui/input";
 import { Sidebar, type SidebarView, VIEW_LABELS } from "@/components/ui/sidebar";
 import { V0Chat, type ConversationRecord } from "@/components/ui/v0-ai-chat";
+import { AuthProvider, useAuth } from "@/core/auth/context";
+import { apiFetch } from "@/lib/api-client";
 import { cn } from "@/lib/utils";
 import { Toaster } from "sonner";
 
@@ -158,7 +161,8 @@ function PageHeader({
   );
 }
 
-export default function App() {
+function AppShell() {
+  const { user, isLoading, isAuthenticated, logout } = useAuth();
   const [activeView, setActiveView] = useState<SidebarView>("workbench");
   const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
   const [activeConversationId, setActiveConversationId] = useState<
@@ -176,7 +180,7 @@ export default function App() {
 
   const fetchRecentConversations = useCallback(async () => {
     try {
-      const response = await fetch("/conversations");
+      const response = await apiFetch("/conversations");
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}`);
       }
@@ -202,7 +206,7 @@ export default function App() {
       setIsRecentLoading(true);
       try {
         // Try the dedicated recent endpoint first
-        const response = await fetch("/conversations/recent");
+        const response = await apiFetch("/conversations/recent");
         if (!cancelled) {
           if (response.status === 204) {
             // No recent conversation, stay in default view
@@ -346,7 +350,7 @@ export default function App() {
 
   const handleDeleteConversation = useCallback(
     async (conversationId: string) => {
-      const response = await fetch(`/conversations/${conversationId}`, {
+      const response = await apiFetch(`/conversations/${conversationId}`, {
         method: "DELETE",
       });
 
@@ -537,6 +541,18 @@ export default function App() {
     }
   };
 
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <Loader2 className="size-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return <LoginPage />;
+  }
+
   return (
     <div
       className={cn(
@@ -558,6 +574,8 @@ export default function App() {
         isRecentLoading={isRecentLoading}
         activeConversationId={activeConversationId}
         pendingApprovalsCount={pendingApprovalsCount}
+        user={user}
+        onLogout={() => { void logout(); }}
       />
 
       <main
@@ -590,5 +608,13 @@ export default function App() {
       </main>
       <Toaster position="top-right" />
     </div>
+  );
+}
+
+export default function App() {
+  return (
+    <AuthProvider>
+      <AppShell />
+    </AuthProvider>
   );
 }

--- a/ui/src/components/auth/login-page.tsx
+++ b/ui/src/components/auth/login-page.tsx
@@ -1,0 +1,119 @@
+import { type FormEvent, useState } from "react";
+import { Sparkles } from "lucide-react";
+
+import { useAuth } from "@/core/auth/context";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+export function LoginPage() {
+  const { hasUsers, login, setup } = useAuth();
+  const isSetup = hasUsers === false;
+
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setIsSubmitting(true);
+    try {
+      if (isSetup) {
+        await setup(email, password, displayName || undefined);
+      } else {
+        await login(email, password);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "登录失败，请重试");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background px-4">
+      <div className="w-full max-w-sm space-y-8">
+        <div className="flex flex-col items-center gap-3 text-center">
+          <div className="flex size-12 items-center justify-center rounded-2xl border border-border bg-secondary text-foreground">
+            <Sparkles className="size-5" />
+          </div>
+          <div className="space-y-1">
+            <h1 className="text-[24px] font-semibold tracking-[-0.02em] text-foreground">
+              SwarmMind
+            </h1>
+            <p className="text-[13px] text-muted-foreground">
+              {isSetup ? "创建管理员账户以开始使用" : "登录到您的账户"}
+            </p>
+          </div>
+        </div>
+
+        <form onSubmit={(e) => { void handleSubmit(e); }} className="space-y-4">
+          {isSetup && (
+            <div className="space-y-1.5">
+              <label htmlFor="displayName" className="text-[13px] font-medium text-foreground">
+                显示名称
+              </label>
+              <Input
+                id="displayName"
+                type="text"
+                placeholder="你的名字"
+                value={displayName}
+                onChange={(e) => { setDisplayName(e.target.value); }}
+                autoComplete="name"
+              />
+            </div>
+          )}
+
+          <div className="space-y-1.5">
+            <label htmlFor="email" className="text-[13px] font-medium text-foreground">
+              邮箱
+            </label>
+            <Input
+              id="email"
+              type="email"
+              placeholder="you@example.com"
+              value={email}
+              onChange={(e) => { setEmail(e.target.value); }}
+              required
+              autoComplete="email"
+              autoFocus
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <label htmlFor="password" className="text-[13px] font-medium text-foreground">
+              密码
+            </label>
+            <Input
+              id="password"
+              type="password"
+              placeholder="••••••••"
+              value={password}
+              onChange={(e) => { setPassword(e.target.value); }}
+              required
+              autoComplete={isSetup ? "new-password" : "current-password"}
+            />
+          </div>
+
+          {error && (
+            <p className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-[13px] text-destructive">
+              {error}
+            </p>
+          )}
+
+          <Button
+            type="submit"
+            className="w-full"
+            disabled={isSubmitting}
+          >
+            {isSubmitting
+              ? isSetup ? "创建中..." : "登录中..."
+              : isSetup ? "创建账户" : "登录"}
+          </Button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/ui/sidebar.tsx
+++ b/ui/src/components/ui/sidebar.tsx
@@ -3,7 +3,6 @@
 import * as React from "react"
 import { AnimatePresence, motion } from "framer-motion"
 import {
-  Building2,
   BookOpenText,
   Bot,
   Clock3,
@@ -29,6 +28,7 @@ import { Button } from "@/components/ui/button"
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible"
 import { Input } from "@/components/ui/input"
 import type { ConversationRecord } from "@/components/ui/v0-ai-chat"
+import type { AuthUser } from "@/core/auth/context"
 import { cn } from "@/lib/utils"
 
 export type SidebarView =
@@ -233,6 +233,8 @@ interface SidebarProps {
   isRecentLoading?: boolean
   activeConversationId?: string
   pendingApprovalsCount?: number
+  user?: AuthUser | null
+  onLogout?: () => void
 }
 
 export function Sidebar({
@@ -249,6 +251,8 @@ export function Sidebar({
   isRecentLoading = false,
   activeConversationId,
   pendingApprovalsCount = 0,
+  user,
+  onLogout,
 }: SidebarProps) {
   const [isOpen, setIsOpen] = React.useState(false)
   const [deletingConversationId, setDeletingConversationId] = React.useState<string | null>(null)
@@ -457,26 +461,37 @@ export function Sidebar({
         </div>
       </nav>
 
-      <div className="border-t border-sidebar-border/80 px-3 pb-3 pt-3">
-        <button
-          type="button"
-          className="flex w-full items-center gap-3 rounded-md border border-sidebar-border/70 bg-sidebar-accent/55 px-2.5 py-2 text-left transition-colors hover:bg-sidebar-accent"
-        >
-          <div className="flex size-7 shrink-0 items-center justify-center rounded-full border border-sidebar-border bg-sidebar text-[10px] font-medium tracking-[0.08em] text-foreground">
-            KL
+      {user ? (
+        <div className="border-t border-sidebar-border/80 px-3 pb-3 pt-3">
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              className="flex min-w-0 flex-1 items-center gap-2.5 rounded-md border border-sidebar-border/70 bg-sidebar-accent/55 px-2.5 py-2 text-left transition-colors hover:bg-sidebar-accent"
+            >
+              <div className="flex size-7 shrink-0 items-center justify-center rounded-full border border-sidebar-border bg-sidebar text-[10px] font-medium tracking-[0.08em] text-foreground">
+                {(user.display_name ?? user.email).slice(0, 2).toUpperCase()}
+              </div>
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-[12px] leading-5 font-medium tracking-[-0.01em] text-foreground">
+                  {user.display_name ?? user.email}
+                </p>
+                <p className="truncate text-[10px] leading-4 text-muted-foreground">{user.email}</p>
+              </div>
+            </button>
+            {onLogout && (
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                onClick={onLogout}
+                title="退出登录"
+                className="shrink-0 rounded-xl text-muted-foreground hover:text-destructive"
+              >
+                <ChevronRight className="size-3.5 rotate-180" />
+              </Button>
+            )}
           </div>
-          <div className="min-w-0 flex-1">
-            <p className="truncate text-[12px] leading-5 font-medium tracking-[-0.01em] text-foreground">Keran Li</p>
-            <div className="mt-px flex min-w-0 items-center gap-1.5 text-[10px] leading-4 tracking-[0.08em] text-muted-foreground">
-              <Building2 className="size-3 shrink-0" />
-              <span className="truncate">容芯开源组</span>
-            </div>
-          </div>
-          <div className="flex size-6 shrink-0 items-center justify-center rounded-full text-muted-foreground/75 transition-colors group-hover/button:text-foreground">
-            <ChevronRight className="size-3.5" />
-          </div>
-        </button>
-      </div>
+        </div>
+      ) : null}
     </div>
   )
 

--- a/ui/src/components/ui/v0-ai-chat.tsx
+++ b/ui/src/components/ui/v0-ai-chat.tsx
@@ -6,6 +6,7 @@ import { AnimatePresence, motion } from "framer-motion";
 import { ArrowDown } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import { apiFetch } from "@/lib/api-client";
 import { ArtifactsProvider } from "@/components/workspace/artifacts/context";
 import { ChatComposerPanel } from "@/components/workspace/chat-composer-panel";
 import { ChatEmptyState, EMPTY_STATE_PROMPTS } from "@/components/workspace/chat-empty-state";
@@ -222,7 +223,7 @@ function V0ChatInner({
 
     for (let attempt = 1; attempt <= MODEL_FETCH_RETRY_COUNT; attempt += 1) {
       try {
-        const response = await fetch("/models");
+        const response = await apiFetch("/models");
         if (!response.ok) {
           throw new Error(`HTTP ${response.status}`);
         }
@@ -268,7 +269,7 @@ function V0ChatInner({
 
   const fetchConversations = useCallback(async () => {
     try {
-      const response = await fetch("/conversations");
+      const response = await apiFetch("/conversations");
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}`);
       }
@@ -295,7 +296,7 @@ function V0ChatInner({
     setPendingApproval(null);
 
     try {
-      const response = await fetch(
+      const response = await apiFetch(
         `/conversations/${nextConversationId}/messages`,
       );
       if (!response.ok) {
@@ -404,7 +405,7 @@ function V0ChatInner({
 
   const createConversation = useCallback(
     async (goal: string) => {
-      const response = await fetch("/conversations", {
+      const response = await apiFetch("/conversations", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ goal }),
@@ -898,7 +899,7 @@ function V0ChatInner({
         payload.model_name = modelName;
       }
 
-      const response = await fetch(
+      const response = await apiFetch(
         `/conversations/${nextConversationId}/messages/stream`,
         {
           method: "POST",
@@ -1098,7 +1099,7 @@ function V0ChatInner({
   const handleExport = useCallback(async (format: "markdown" | "json" = "markdown") => {
     if (!currentConversationId) return;
     try {
-      const response = await fetch(
+      const response = await apiFetch(
         `/conversations/${currentConversationId}/export?format=${format}`,
       );
       if (!response.ok) throw new Error(`HTTP ${response.status}`);
@@ -1139,7 +1140,7 @@ function V0ChatInner({
 
       try {
         // Send clarification response to backend
-        const res = await fetch(
+        const res = await apiFetch(
           `/conversations/${currentConversationId}/clarification`,
           {
             method: "POST",

--- a/ui/src/core/auth/context.tsx
+++ b/ui/src/core/auth/context.tsx
@@ -1,0 +1,142 @@
+import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
+
+import { apiFetch, apiFetchJson, clearToken, getToken, setToken } from "@/lib/api-client";
+
+export interface AuthUser {
+  user_id: string;
+  email: string;
+  display_name: string | null;
+  role: string;
+  status: string;
+}
+
+interface LoginResponse {
+  token_id: string;
+  token: string;
+  user: AuthUser;
+}
+
+interface MeResponse {
+  user: AuthUser;
+  token_id: string;
+  authenticated: boolean;
+}
+
+interface AuthState {
+  user: AuthUser | null;
+  isLoading: boolean;
+  isAuthenticated: boolean;
+  hasUsers: boolean | null;
+  login: (email: string, password: string) => Promise<void>;
+  logout: () => Promise<void>;
+  setup: (email: string, password: string, displayName?: string) => Promise<void>;
+}
+
+const AuthContext = createContext<AuthState | null>(null);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [hasUsers, setHasUsers] = useState<boolean | null>(null);
+
+  // On mount: check if any users exist, then verify stored token
+  useEffect(() => {
+    async function init() {
+      try {
+        const statusRes = await fetch("/auth/status");
+        if (statusRes.ok) {
+          const { has_users } = (await statusRes.json()) as { has_users: boolean };
+          setHasUsers(has_users);
+          if (!has_users) {
+            setIsLoading(false);
+            return;
+          }
+        }
+      } catch {
+        // network error — assume users exist, let login handle it
+        setHasUsers(true);
+      }
+
+      const token = getToken();
+      if (!token) {
+        setIsLoading(false);
+        return;
+      }
+
+      try {
+        const data = await apiFetchJson<MeResponse>("/auth/me");
+        setUser(data.user);
+      } catch {
+        clearToken();
+      } finally {
+        setIsLoading(false);
+      }
+    }
+
+    void init();
+  }, []);
+
+  // Handle 401s from any request (emitted by apiFetch)
+  useEffect(() => {
+    const handleAuthLogout = () => {
+      setUser(null);
+    };
+    window.addEventListener("auth:logout", handleAuthLogout);
+    return () => {
+      window.removeEventListener("auth:logout", handleAuthLogout);
+    };
+  }, []);
+
+  const login = async (email: string, password: string) => {
+    const data = await apiFetchJson<LoginResponse>("/auth/login", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, password }),
+    });
+    setToken(data.token);
+    setUser(data.user);
+    setHasUsers(true);
+  };
+
+  const logout = async () => {
+    try {
+      await apiFetch("/auth/logout", { method: "POST" });
+    } finally {
+      clearToken();
+      setUser(null);
+    }
+  };
+
+  const setup = async (email: string, password: string, displayName?: string) => {
+    const data = await apiFetchJson<LoginResponse>("/auth/setup", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, password, display_name: displayName ?? null }),
+    });
+    setToken(data.token);
+    setUser(data.user);
+    setHasUsers(true);
+  };
+
+  return (
+    <AuthContext.Provider
+      value={{
+        user,
+        isLoading,
+        isAuthenticated: !!user,
+        hasUsers,
+        login,
+        logout,
+        setup,
+      }}
+    >
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth(): AuthState {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error("useAuth must be used within AuthProvider");
+  return ctx;
+}

--- a/ui/src/core/projects/api.ts
+++ b/ui/src/core/projects/api.ts
@@ -1,4 +1,5 @@
 import { consumeNdjsonStream } from "../chat/stream";
+import { apiFetch, apiFetchJson } from "@/lib/api-client";
 import type {
   ApprovalListResponse,
   AuditLogListResponse,
@@ -9,14 +10,7 @@ import type {
   Task,
 } from "./types";
 
-async function fetchJson<T>(path: string, init?: RequestInit): Promise<T> {
-  const res = await fetch(path, init);
-  if (!res.ok) {
-    const detail = await res.text().catch(() => res.statusText);
-    throw new Error(`HTTP ${res.status}: ${detail}`);
-  }
-  return res.json() as Promise<T>;
-}
+const fetchJson = apiFetchJson;
 
 export async function listProjects(): Promise<ProjectListResponse> {
   return fetchJson<ProjectListResponse>("/projects");
@@ -55,7 +49,7 @@ export async function streamProjectMessage(
   projectId: string,
   request: SendProjectMessageRequest,
 ): Promise<Response> {
-  const res = await fetch(`/projects/${projectId}/messages/stream`, {
+  const res = await apiFetch(`/projects/${projectId}/messages/stream`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(request),
@@ -95,7 +89,7 @@ export async function listApprovals(params?: { project_id?: string; status?: str
 }
 
 export async function patchApproval(approvalId: string, body: { status: string; decision_reason?: string | null }): Promise<void> {
-  await fetch(`/approvals/${approvalId}`, {
+  await apiFetch(`/approvals/${approvalId}`, {
     method: "PATCH",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),

--- a/ui/src/lib/api-client.ts
+++ b/ui/src/lib/api-client.ts
@@ -1,0 +1,51 @@
+/**
+ * Auth-aware fetch wrapper.
+ *
+ * Reads the bearer token from localStorage and injects it into every request.
+ * On 401, clears the stored token and dispatches an "auth:logout" event so the
+ * AuthContext can redirect the user to the login page without circular imports.
+ */
+
+const TOKEN_KEY = "swm_token";
+
+export function getToken(): string | null {
+  return localStorage.getItem(TOKEN_KEY);
+}
+
+export function setToken(token: string): void {
+  localStorage.setItem(TOKEN_KEY, token);
+}
+
+export function clearToken(): void {
+  localStorage.removeItem(TOKEN_KEY);
+}
+
+/**
+ * Drop-in replacement for `fetch` that injects the auth header when a token
+ * is stored. Handles 401 by clearing the token and emitting "auth:logout".
+ */
+export async function apiFetch(input: string | URL, init?: RequestInit): Promise<Response> {
+  const token = getToken();
+  const headers = new Headers(init?.headers);
+  if (token) {
+    headers.set("Authorization", `Bearer ${token}`);
+  }
+  const res = await fetch(input, { ...init, headers });
+  if (res.status === 401) {
+    clearToken();
+    window.dispatchEvent(new Event("auth:logout"));
+  }
+  return res;
+}
+
+/**
+ * Auth-aware JSON fetch. Throws on non-2xx responses.
+ */
+export async function apiFetchJson<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await apiFetch(path, init);
+  if (!res.ok) {
+    const detail = await res.text().catch(() => res.statusText);
+    throw new Error(`HTTP ${res.status}: ${detail}`);
+  }
+  return res.json() as Promise<T>;
+}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Backend**: Added `/auth/status` (first-run check) and `/auth/setup` (create first admin) endpoints; `count_users()` in UserRepository; 30-day token expiry on login; new Pydantic models `AuthStatusResponse` and `AuthSetupRequest`
- **Frontend core**: `api-client.ts` — auth-aware `apiFetch`/`apiFetchJson` wrappers that inject bearer token from `localStorage` and dispatch `auth:logout` event on 401; `AuthContext` with `AuthProvider`/`useAuth` hook that handles init, login, logout, and first-run setup flow
- **Frontend UI**: `LoginPage` component that switches between login and first-admin-setup modes; `App` wrapped in `AuthProvider` with loading spinner and auth gate; `Sidebar` shows real user profile (initials, display name, email) with logout button; all raw `fetch()` calls in `App`, `v0-ai-chat`, and `projects/api` replaced with `apiFetch`

## Test plan

- [ ] First run (no users): `GET /auth/status` returns `{has_users: false}` → frontend shows setup form → POST /auth/setup creates admin, stores token, enters app
- [ ] Subsequent login: `has_users=true` → login form → POST /auth/login → token stored → app loads
- [ ] Stored token: refresh page → `/auth/me` validates token → app loads without login prompt
- [ ] Token expiry / invalid: 401 from any request → `auth:logout` event → user sees login page
- [ ] Logout button: POST /auth/logout → token revoked → login page shown
- [ ] Sidebar shows real user initials, name, and email

https://claude.ai/code/session_01CRG7jrZJYoL4kEZUGz4P88
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CRG7jrZJYoL4kEZUGz4P88)_