### PR TITLE
feat(connectors): Phase 1 — Registry, config validation, /connectors/types

### DIFF
--- a/swarmmind/api/routers/connectors.py
+++ b/swarmmind/api/routers/connectors.py
@@ -2,13 +2,20 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from fastapi import APIRouter, HTTPException
 
+from swarmmind.connectors.config_validation import validate_config
+from swarmmind.connectors.registry import REGISTRY
 from swarmmind.models import (
+    ConnectorConfigFieldInfo,
     ConnectorCreateRequest,
     ConnectorHeartbeatRequest,
     ConnectorListResponse,
     ConnectorResponse,
+    ConnectorTypeInfo,
+    ConnectorTypesResponse,
     ConnectorUpdateRequest,
     DeleteConnectorResponse,
 )
@@ -19,7 +26,7 @@ router = APIRouter(prefix="/connectors", tags=["connectors"])
 _repo = ConnectorRepository()
 
 
-def _to_response(db) -> ConnectorResponse:  # type: ignore[no-untyped-def]
+def _to_response(db: Any) -> ConnectorResponse:
     """Convert ConnectorDB row to ConnectorResponse with masked secrets."""
     return ConnectorResponse(
         connector_id=db.connector_id,
@@ -35,6 +42,58 @@ def _to_response(db) -> ConnectorResponse:  # type: ignore[no-untyped-def]
     )
 
 
+def _manifest_to_type_info(manifest: Any) -> ConnectorTypeInfo:
+    """Convert a ConnectorManifest to the API response shape."""
+    return ConnectorTypeInfo(
+        name=manifest.name,
+        version=manifest.version,
+        description=manifest.description,
+        capabilities=[c.value for c in manifest.capabilities],
+        transport=manifest.transport.value,
+        config_schema=[
+            ConnectorConfigFieldInfo(
+                name=f.name,
+                description=f.description,
+                required=f.required,
+                secret=f.secret,
+                default=f.default,
+            )
+            for f in manifest.config_schema
+        ],
+    )
+
+
+def _validate_type_and_config(connector_type: str, config: dict[str, Any]) -> None:
+    """Reject unknown connector_type (HTTP 422) or invalid config (HTTP 422)."""
+    manifest = REGISTRY.get_manifest(connector_type)
+    if manifest is None:
+        known = ", ".join(REGISTRY.list_types()) or "(none)"
+        raise HTTPException(
+            status_code=422,
+            detail=f"Unknown connector type '{connector_type}'. Known types: {known}.",
+        )
+    errors = validate_config(manifest, config)
+    if errors:
+        raise HTTPException(
+            status_code=422,
+            detail={"message": "Connector config validation failed.", "errors": errors},
+        )
+
+
+# ── Discovery ─────────────────────────────────────────────────────────────────
+
+
+@router.get("/types", response_model=ConnectorTypesResponse)
+def list_connector_types() -> ConnectorTypesResponse:
+    """List all registered connector types with their config schemas."""
+    manifests = REGISTRY.list_manifests()
+    items = [_manifest_to_type_info(m) for m in manifests]
+    return ConnectorTypesResponse(items=items, total=len(items))
+
+
+# ── CRUD ──────────────────────────────────────────────────────────────────────
+
+
 @router.get("", response_model=ConnectorListResponse)
 def list_connectors() -> ConnectorListResponse:
     """List all registered connectors."""
@@ -44,7 +103,12 @@ def list_connectors() -> ConnectorListResponse:
 
 @router.post("", response_model=ConnectorResponse, status_code=201)
 def create_connector(body: ConnectorCreateRequest) -> ConnectorResponse:
-    """Register a new connector."""
+    """Register a new connector.
+
+    Rejects unknown ``connector_type`` values (HTTP 422) and config fields
+    that do not match the manifest schema.
+    """
+    _validate_type_and_config(body.connector_type, body.config)
     db = _repo.create(
         connector_id=body.connector_id,
         name=body.name,
@@ -65,7 +129,17 @@ def get_connector(connector_id: str) -> ConnectorResponse:
 
 @router.patch("/{connector_id}", response_model=ConnectorResponse)
 def update_connector(connector_id: str, body: ConnectorUpdateRequest) -> ConnectorResponse:
-    """Update connector name or configuration."""
+    """Update connector name or configuration.
+
+    If a new config is supplied, it is validated against the stored connector
+    type's manifest.
+    """
+    if body.config is not None:
+        existing = _repo.get(connector_id)
+        if existing is None:
+            raise HTTPException(status_code=404, detail=f"Connector '{connector_id}' not found.")
+        _validate_type_and_config(existing.connector_type, body.config)
+
     db = _repo.update(connector_id, name=body.name, config=body.config)
     if db is None:
         raise HTTPException(status_code=404, detail=f"Connector '{connector_id}' not found.")

--- a/swarmmind/cli/client.py
+++ b/swarmmind/cli/client.py
@@ -19,6 +19,7 @@ from swarmmind.models import (
     ConnectorHeartbeatRequest,
     ConnectorListResponse,
     ConnectorResponse,
+    ConnectorTypesResponse,
     ConnectorUpdateRequest,
     Conversation,
     ConversationListResponse,
@@ -516,6 +517,10 @@ class SwarmMindClient:
         """Report connector health to the control plane."""
         body = ConnectorHeartbeatRequest(status=status, mcp_url=mcp_url).model_dump(mode="json", exclude_none=True)
         return self._list(ConnectorResponse, "POST", f"/connectors/{connector_id}/heartbeat", json_body=body)
+
+    def list_connector_types(self) -> ConnectorTypesResponse:
+        """List all registered connector types with their config schemas."""
+        return self._list(ConnectorTypesResponse, "GET", "/connectors/types")
 
     # ---- stream ----
 

--- a/swarmmind/cli/commands/connector.py
+++ b/swarmmind/cli/commands/connector.py
@@ -111,6 +111,12 @@ def connector_status(
     run_client_command(ctx, lambda client: client.get_connector(connector_id))
 
 
+@connector_app.command("types")
+def list_connector_types(ctx: typer.Context) -> None:
+    """List all available connector types and their configuration schemas."""
+    run_client_command(ctx, lambda client: client.list_connector_types())
+
+
 # ── Feishu-specific commands ──────────────────────────────────────────────────
 
 

--- a/swarmmind/connectors/config_validation.py
+++ b/swarmmind/connectors/config_validation.py
@@ -1,0 +1,56 @@
+"""Connector config validation against a ConnectorManifest schema.
+
+Validates that a supplied config dict satisfies the manifest's field rules:
+- Required fields are present and non-empty.
+- No unknown fields are present.
+- Returns field-level errors so the API can surface them as HTTP 422 details.
+
+Usage::
+
+    from swarmmind.connectors.config_validation import validate_config
+    from swarmmind.connectors.registry import REGISTRY
+
+    manifest = REGISTRY.get_manifest("feishu-cli")
+    errors = validate_config(manifest, {"app_id": "x"})
+    # errors is empty → config is valid
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from swarmmind.connectors.base import ConnectorManifest
+
+
+def validate_config(
+    manifest: ConnectorManifest,
+    config: dict[str, Any],
+) -> list[dict[str, str]]:
+    """Validate *config* against *manifest*.config_schema.
+
+    Args:
+        manifest: The ConnectorManifest whose ``config_schema`` defines the rules.
+        config: The user-supplied config dict to validate.
+
+    Returns:
+        A list of ``{"field": ..., "error": ...}`` dicts. Empty means valid.
+    """
+    errors: list[dict[str, str]] = []
+
+    known_fields = {field.name for field in manifest.config_schema}
+    required_fields = {field.name for field in manifest.config_schema if field.required}
+
+    # Check for unknown keys
+    errors = [
+        {"field": key, "error": f"Unknown field '{key}' for connector type '{manifest.name}'."}
+        for key in config
+        if key not in known_fields
+    ]
+
+    # Check for required fields that are missing or empty
+    for field_name in required_fields:
+        value = config.get(field_name)
+        if value is None or (isinstance(value, str) and not value.strip()):
+            errors.append({"field": field_name, "error": f"Required field '{field_name}' is missing or empty."})
+
+    return errors

--- a/swarmmind/connectors/registry.py
+++ b/swarmmind/connectors/registry.py
@@ -7,9 +7,9 @@ Usage::
 
     from swarmmind.connectors.registry import REGISTRY
 
-    manifest = REGISTRY.get_manifest("feishu-cli")   # or None
+    manifest = REGISTRY.get_manifest("feishu-cli")  # or None
     all_types = REGISTRY.list_manifests()
-    REGISTRY.is_registered("feishu-cli")             # bool
+    REGISTRY.is_registered("feishu-cli")  # bool
 """
 
 from __future__ import annotations

--- a/swarmmind/connectors/registry.py
+++ b/swarmmind/connectors/registry.py
@@ -1,0 +1,108 @@
+"""Connector type registry — single source of truth for available connector types.
+
+The registry is code-level (not persisted): connector types ship with the
+codebase, connector *instances* live in ConnectorDB.
+
+Usage::
+
+    from swarmmind.connectors.registry import REGISTRY
+
+    manifest = REGISTRY.get_manifest("feishu-cli")   # or None
+    all_types = REGISTRY.list_manifests()
+    REGISTRY.is_registered("feishu-cli")             # bool
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from swarmmind.connectors.base import BaseConnector, ConnectorManifest
+
+
+@dataclass(frozen=True)
+class ConnectorEntry:
+    """A registered connector type with its class and manifest."""
+
+    connector_class: type[BaseConnector]
+    manifest: ConnectorManifest
+
+
+class ConnectorRegistry:
+    """Immutable registry of connector types available in this installation."""
+
+    def __init__(self) -> None:
+        self._entries: dict[str, ConnectorEntry] = {}
+
+    def register(
+        self,
+        connector_type: str,
+        connector_class: type[BaseConnector],
+        manifest: ConnectorManifest,
+    ) -> None:
+        """Register a connector type.
+
+        Args:
+            connector_type: Stable slug (e.g. ``"feishu-cli"``).
+            connector_class: Concrete ``BaseConnector`` subclass.
+            manifest: Static ``ConnectorManifest`` instance.
+        """
+        self._entries[connector_type] = ConnectorEntry(
+            connector_class=connector_class,
+            manifest=manifest,
+        )
+
+    def get_entry(self, connector_type: str) -> ConnectorEntry | None:
+        """Return the ConnectorEntry for *connector_type*, or None if unknown."""
+        return self._entries.get(connector_type)
+
+    def get_manifest(self, connector_type: str) -> ConnectorManifest | None:
+        """Return the manifest for *connector_type*, or None if unknown."""
+        entry = self._entries.get(connector_type)
+        return entry.manifest if entry else None
+
+    def get_class(self, connector_type: str) -> type[BaseConnector] | None:
+        """Return the connector class for *connector_type*, or None if unknown."""
+        entry = self._entries.get(connector_type)
+        return entry.connector_class if entry else None
+
+    def is_registered(self, connector_type: str) -> bool:
+        """Return True if *connector_type* is registered."""
+        return connector_type in self._entries
+
+    def list_manifests(self) -> list[ConnectorManifest]:
+        """Return all registered manifests, sorted by name."""
+        return sorted(
+            (e.manifest for e in self._entries.values()),
+            key=lambda m: m.name,
+        )
+
+    def list_types(self) -> list[str]:
+        """Return all registered connector type slugs, sorted."""
+        return sorted(self._entries.keys())
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton — the only registry instance in the process.
+# ---------------------------------------------------------------------------
+REGISTRY = ConnectorRegistry()
+
+
+def _bootstrap() -> None:
+    """Register all built-in connector types.
+
+    This is called once at module import. Adding a new connector type only
+    requires adding an entry here and shipping the implementation.
+    """
+    from swarmmind.connectors.feishu.connector import FeishuCLIConnector
+    from swarmmind.connectors.feishu.manifest import FEISHU_CLI_MANIFEST
+
+    REGISTRY.register(
+        connector_type="feishu-cli",
+        connector_class=FeishuCLIConnector,
+        manifest=FEISHU_CLI_MANIFEST,
+    )
+
+
+_bootstrap()

--- a/swarmmind/models.py
+++ b/swarmmind/models.py
@@ -1195,6 +1195,34 @@ class DeleteConnectorResponse(BaseModel):
     deleted: bool
 
 
+class ConnectorConfigFieldInfo(BaseModel):
+    """A single field descriptor from a connector manifest's config schema."""
+
+    name: str
+    description: str
+    required: bool
+    secret: bool
+    default: str | None = None
+
+
+class ConnectorTypeInfo(BaseModel):
+    """Describes a registered connector type and its configuration schema."""
+
+    name: str
+    version: str
+    description: str
+    capabilities: list[str]
+    transport: str
+    config_schema: list[ConnectorConfigFieldInfo]
+
+
+class ConnectorTypesResponse(BaseModel):
+    """Response listing all available connector types."""
+
+    items: list[ConnectorTypeInfo]
+    total: int
+
+
 # ── Auth setup / status models ────────────────────────────────────────────────
 
 

--- a/tests/test_connector_registry.py
+++ b/tests/test_connector_registry.py
@@ -1,0 +1,186 @@
+"""Tests for ConnectorRegistry and config validation."""
+
+from __future__ import annotations
+
+from swarmmind.connectors.base import (
+    ConnectorCapability,
+    ConnectorConfigField,
+    ConnectorManifest,
+    ConnectorTransport,
+)
+from swarmmind.connectors.config_validation import validate_config
+from swarmmind.connectors.registry import REGISTRY, ConnectorRegistry
+
+# ── Registry unit tests ───────────────────────────────────────────────────────
+
+
+def test_registry_has_feishu_cli():
+    assert REGISTRY.is_registered("feishu-cli")
+
+
+def test_registry_get_manifest_returns_manifest():
+    manifest = REGISTRY.get_manifest("feishu-cli")
+    assert manifest is not None
+    assert manifest.name == "feishu-cli"
+
+
+def test_registry_get_manifest_unknown_returns_none():
+    assert REGISTRY.get_manifest("nonexistent-connector") is None
+
+
+def test_registry_is_registered_unknown_returns_false():
+    assert REGISTRY.is_registered("totally-unknown") is False
+
+
+def test_registry_list_manifests_nonempty():
+    manifests = REGISTRY.list_manifests()
+    assert len(manifests) >= 1
+    names = [m.name for m in manifests]
+    assert "feishu-cli" in names
+
+
+def test_registry_list_types_sorted():
+    types = REGISTRY.list_types()
+    assert types == sorted(types)
+    assert "feishu-cli" in types
+
+
+def test_registry_get_class_returns_class():
+    cls = REGISTRY.get_class("feishu-cli")
+    assert cls is not None
+
+
+def test_registry_get_class_unknown_returns_none():
+    assert REGISTRY.get_class("ghost") is None
+
+
+def test_custom_registry_register_and_lookup():
+    """A fresh registry can register and look up entries independently."""
+    from swarmmind.connectors.feishu.connector import FeishuCLIConnector
+    from swarmmind.connectors.feishu.manifest import FEISHU_CLI_MANIFEST
+
+    reg = ConnectorRegistry()
+    assert not reg.is_registered("feishu-cli")
+
+    reg.register("feishu-cli", FeishuCLIConnector, FEISHU_CLI_MANIFEST)
+    assert reg.is_registered("feishu-cli")
+    assert reg.get_manifest("feishu-cli") is FEISHU_CLI_MANIFEST
+
+
+# ── Config validation unit tests ─────────────────────────────────────────────
+
+
+def _make_manifest(fields: list[ConnectorConfigField]) -> ConnectorManifest:
+    return ConnectorManifest(
+        name="test-connector",
+        version="1.0.0",
+        description="Test connector",
+        capabilities=[ConnectorCapability.INGEST],
+        transport=ConnectorTransport.MCP_HTTP,
+        config_schema=fields,
+    )
+
+
+def test_validate_config_empty_schema_empty_config():
+    manifest = _make_manifest([])
+    assert validate_config(manifest, {}) == []
+
+
+def test_validate_config_valid_all_fields():
+    manifest = _make_manifest([
+        ConnectorConfigField(name="api_key", description="Key", required=True, secret=True),
+        ConnectorConfigField(name="base_url", description="URL", required=False),
+    ])
+    errors = validate_config(manifest, {"api_key": "secret", "base_url": "http://x"})
+    assert errors == []
+
+
+def test_validate_config_missing_required_field():
+    manifest = _make_manifest([
+        ConnectorConfigField(name="api_key", description="Key", required=True, secret=True),
+    ])
+    errors = validate_config(manifest, {})
+    assert len(errors) == 1
+    assert errors[0]["field"] == "api_key"
+
+
+def test_validate_config_empty_string_required_field():
+    manifest = _make_manifest([
+        ConnectorConfigField(name="api_key", description="Key", required=True, secret=True),
+    ])
+    errors = validate_config(manifest, {"api_key": "  "})
+    assert len(errors) == 1
+    assert errors[0]["field"] == "api_key"
+
+
+def test_validate_config_unknown_field_rejected():
+    manifest = _make_manifest([
+        ConnectorConfigField(name="base_url", description="URL", required=False),
+    ])
+    errors = validate_config(manifest, {"base_url": "http://x", "secret_sauce": "nope"})
+    assert len(errors) == 1
+    assert errors[0]["field"] == "secret_sauce"
+
+
+def test_validate_config_optional_field_absent_is_ok():
+    manifest = _make_manifest([
+        ConnectorConfigField(name="base_url", description="URL", required=False),
+    ])
+    assert validate_config(manifest, {}) == []
+
+
+def test_validate_config_multiple_errors():
+    manifest = _make_manifest([
+        ConnectorConfigField(name="req1", description="R1", required=True),
+        ConnectorConfigField(name="req2", description="R2", required=True),
+    ])
+    errors = validate_config(manifest, {"unknown_key": "val"})
+    field_names = {e["field"] for e in errors}
+    assert "req1" in field_names
+    assert "req2" in field_names
+    assert "unknown_key" in field_names
+
+
+# ── API integration: /connectors/types ───────────────────────────────────────
+
+
+def test_connector_types_api_shape():
+    """GET /connectors/types returns ConnectorTypesResponse-compatible shape."""
+    from fastapi.testclient import TestClient
+
+    from swarmmind.api.routers.connectors import router
+
+    app_tmp = __import__("fastapi", fromlist=["FastAPI"]).FastAPI()
+    app_tmp.include_router(router)
+    client = TestClient(app_tmp)
+
+    resp = client.get("/connectors/types")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "items" in data
+    assert "total" in data
+    assert data["total"] >= 1
+
+    feishu = next((i for i in data["items"] if i["name"] == "feishu-cli"), None)
+    assert feishu is not None
+    assert "config_schema" in feishu
+    assert "capabilities" in feishu
+    assert "transport" in feishu
+
+
+def test_connector_create_unknown_type_rejected():
+    """POST /connectors with an unknown connector_type returns HTTP 422."""
+    from fastapi.testclient import TestClient
+
+    from swarmmind.api.routers.connectors import router
+
+    app_tmp = __import__("fastapi", fromlist=["FastAPI"]).FastAPI()
+    app_tmp.include_router(router)
+    client = TestClient(app_tmp)
+
+    resp = client.post(
+        "/connectors",
+        json={"name": "test", "connector_type": "ghost-connector", "config": {}},
+    )
+    assert resp.status_code == 422
+    assert "ghost-connector" in resp.text

--- a/tests/test_connector_registry.py
+++ b/tests/test_connector_registry.py
@@ -87,53 +87,65 @@ def test_validate_config_empty_schema_empty_config():
 
 
 def test_validate_config_valid_all_fields():
-    manifest = _make_manifest([
-        ConnectorConfigField(name="api_key", description="Key", required=True, secret=True),
-        ConnectorConfigField(name="base_url", description="URL", required=False),
-    ])
+    manifest = _make_manifest(
+        [
+            ConnectorConfigField(name="api_key", description="Key", required=True, secret=True),
+            ConnectorConfigField(name="base_url", description="URL", required=False),
+        ]
+    )
     errors = validate_config(manifest, {"api_key": "secret", "base_url": "http://x"})
     assert errors == []
 
 
 def test_validate_config_missing_required_field():
-    manifest = _make_manifest([
-        ConnectorConfigField(name="api_key", description="Key", required=True, secret=True),
-    ])
+    manifest = _make_manifest(
+        [
+            ConnectorConfigField(name="api_key", description="Key", required=True, secret=True),
+        ]
+    )
     errors = validate_config(manifest, {})
     assert len(errors) == 1
     assert errors[0]["field"] == "api_key"
 
 
 def test_validate_config_empty_string_required_field():
-    manifest = _make_manifest([
-        ConnectorConfigField(name="api_key", description="Key", required=True, secret=True),
-    ])
+    manifest = _make_manifest(
+        [
+            ConnectorConfigField(name="api_key", description="Key", required=True, secret=True),
+        ]
+    )
     errors = validate_config(manifest, {"api_key": "  "})
     assert len(errors) == 1
     assert errors[0]["field"] == "api_key"
 
 
 def test_validate_config_unknown_field_rejected():
-    manifest = _make_manifest([
-        ConnectorConfigField(name="base_url", description="URL", required=False),
-    ])
+    manifest = _make_manifest(
+        [
+            ConnectorConfigField(name="base_url", description="URL", required=False),
+        ]
+    )
     errors = validate_config(manifest, {"base_url": "http://x", "secret_sauce": "nope"})
     assert len(errors) == 1
     assert errors[0]["field"] == "secret_sauce"
 
 
 def test_validate_config_optional_field_absent_is_ok():
-    manifest = _make_manifest([
-        ConnectorConfigField(name="base_url", description="URL", required=False),
-    ])
+    manifest = _make_manifest(
+        [
+            ConnectorConfigField(name="base_url", description="URL", required=False),
+        ]
+    )
     assert validate_config(manifest, {}) == []
 
 
 def test_validate_config_multiple_errors():
-    manifest = _make_manifest([
-        ConnectorConfigField(name="req1", description="R1", required=True),
-        ConnectorConfigField(name="req2", description="R2", required=True),
-    ])
+    manifest = _make_manifest(
+        [
+            ConnectorConfigField(name="req1", description="R1", required=True),
+            ConnectorConfigField(name="req2", description="R2", required=True),
+        ]
+    )
     errors = validate_config(manifest, {"unknown_key": "val"})
     field_names = {e["field"] for e in errors}
     assert "req1" in field_names


### PR DESCRIPTION
## Summary

Implements **Phase 1** of #81 — Connector Registry & Manifest Discovery.

`connector_type` is now a validated, discoverable control-plane concept.

### What changed

| File | Change |
|---|---|
| `swarmmind/connectors/registry.py` | New: `ConnectorRegistry` singleton `REGISTRY`; bootstraps `feishu-cli` |
| `swarmmind/connectors/config_validation.py` | New: `validate_config(manifest, config)` — field-level error list |
| `swarmmind/api/routers/connectors.py` | `GET /connectors/types`; `create_connector` + `update_connector` now validate type & config (HTTP 422) |
| `swarmmind/models.py` | New: `ConnectorConfigFieldInfo`, `ConnectorTypeInfo`, `ConnectorTypesResponse` |
| `swarmmind/cli/client.py` | `list_connector_types()` |
| `swarmmind/cli/commands/connector.py` | `swarmmind connector types` command |
| `tests/test_connector_registry.py` | 18 tests — registry, config validation, API shape |

### Key properties

- **Code-level registry, DB-level instances**: new connector *types* ship with the codebase; connector *instances* stay in `ConnectorDB`. No migration needed.
- **Tolerant reads**: `list`/`get` existing connectors with unknown types still works — validation only fires on create/update.
- **Additive**: no existing connector API contract broken; `/connectors/types` is a new endpoint.

### Verification

```bash
uv run pytest tests/test_connector_registry.py -v   # 18 passed
swarmmind connector types                            # lists feishu-cli with schema
curl http://localhost:8000/connectors/types          # JSON with items/total
# POST /connectors with connector_type="ghost" → HTTP 422
```

Closes Phase 1 of #81. Phase 2 (heartbeat + RuntimeProfile MCP injection) and Phase 3 (UI + ingress provenance) to follow.

https://github.com/rongxinzy/SwarmMind/issues/81

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fx4qJWRN4Jb3eM7vBKDWq2)_